### PR TITLE
chore(specify): add cursor-agent integration metadata and scripts

### DIFF
--- a/.specify/init-options.json
+++ b/.specify/init-options.json
@@ -1,11 +1,9 @@
 {
   "ai": "cursor-agent",
-  "ai_commands_dir": null,
-  "ai_skills": false,
   "branch_numbering": "sequential",
   "here": true,
-  "offline": false,
+  "integration": "cursor-agent",
   "preset": null,
   "script": "ps",
-  "speckit_version": "0.3.2"
+  "speckit_version": "0.5.1.dev0"
 }

--- a/.specify/integration.json
+++ b/.specify/integration.json
@@ -1,0 +1,7 @@
+{
+  "integration": "cursor-agent",
+  "version": "0.5.1.dev0",
+  "scripts": {
+    "update-context": ".specify/integrations/cursor-agent/scripts/update-context.ps1"
+  }
+}

--- a/.specify/integrations/cursor-agent.manifest.json
+++ b/.specify/integrations/cursor-agent.manifest.json
@@ -1,0 +1,18 @@
+{
+  "integration": "cursor-agent",
+  "version": "0.5.1.dev0",
+  "installed_at": "2026-04-08T16:23:41.281885+00:00",
+  "files": {
+    ".cursor/commands/speckit.analyze.md": "56285817b93f55ae926eade0528673d25ffcf441e8109492323bfbe8941be8f7",
+    ".cursor/commands/speckit.checklist.md": "53ce35462c1df402780e730ea54150a30872e6e0d6d44a8bd38dd8b5d42900a9",
+    ".cursor/commands/speckit.clarify.md": "97b14836d6174f0ef51d8bbda0b731c87ef0b011aa36ccd4171a2fc3d7e3280a",
+    ".cursor/commands/speckit.constitution.md": "58d35eb026f56bb7364d91b8b0382d5dd1249ded6c1449a2b69546693afb85f7",
+    ".cursor/commands/speckit.implement.md": "9dda40376414146a8992d09e6853976c75708ba4cad7d9df9fcd6e7faa8f0a4c",
+    ".cursor/commands/speckit.plan.md": "599eacc1ae40e9cad6693f80a12860e36436570141f2ae9859b492ac3548dcea",
+    ".cursor/commands/speckit.specify.md": "f75a5652f234d49b26df322d52f9d2dd518f66f02a3d55954a6054dd15bd007c",
+    ".cursor/commands/speckit.tasks.md": "d505523168e1f1c758350da9d45c08ff990ed8686d6bc8451db8b89a145768a4",
+    ".cursor/commands/speckit.taskstoissues.md": "12532e50c8f9aeb453a565aec6aa6f53abe53cf92926ca553b3d2c61b6b7b6e3",
+    ".specify/integrations/cursor-agent/scripts/update-context.ps1": "b9926450bd00c225b32617188abaedbe9fb31c1722f68b9d984c87372c65c55a",
+    ".specify/integrations/cursor-agent/scripts/update-context.sh": "808bb864ae28438418e246d5bcca623d34d6a3481ff3bf422c0a5ae5ba76081b"
+  }
+}

--- a/.specify/integrations/cursor-agent/scripts/update-context.ps1
+++ b/.specify/integrations/cursor-agent/scripts/update-context.ps1
@@ -1,0 +1,23 @@
+# update-context.ps1 — Cursor integration: create/update .cursor/rules/specify-rules.mdc
+#
+# Thin wrapper that delegates to the shared update-agent-context script.
+# Activated in Stage 7 when the shared script uses integration.json dispatch.
+#
+# Until then, this delegates to the shared script as a subprocess.
+
+$ErrorActionPreference = 'Stop'
+
+# Derive repo root from script location (walks up to find .specify/)
+$scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Definition
+$repoRoot = try { git rev-parse --show-toplevel 2>$null } catch { $null }
+# If git did not return a repo root, or the git root does not contain .specify,
+# fall back to walking up from the script directory to find the initialized project root.
+if (-not $repoRoot -or -not (Test-Path (Join-Path $repoRoot '.specify'))) {
+    $repoRoot = $scriptDir
+    $fsRoot = [System.IO.Path]::GetPathRoot($repoRoot)
+    while ($repoRoot -and $repoRoot -ne $fsRoot -and -not (Test-Path (Join-Path $repoRoot '.specify'))) {
+        $repoRoot = Split-Path -Parent $repoRoot
+    }
+}
+
+& "$repoRoot/.specify/scripts/powershell/update-agent-context.ps1" -AgentType cursor-agent

--- a/.specify/integrations/cursor-agent/scripts/update-context.sh
+++ b/.specify/integrations/cursor-agent/scripts/update-context.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# update-context.sh — Cursor integration: create/update .cursor/rules/specify-rules.mdc
+#
+# Thin wrapper that delegates to the shared update-agent-context script.
+# Activated in Stage 7 when the shared script uses integration.json dispatch.
+#
+# Until then, this delegates to the shared script as a subprocess.
+
+set -euo pipefail
+
+# Derive repo root from script location (walks up to find .specify/)
+_script_dir="$(cd "$(dirname "$0")" && pwd)"
+_root="$_script_dir"
+while [ "$_root" != "/" ] && [ ! -d "$_root/.specify" ]; do _root="$(dirname "$_root")"; done
+if [ -z "${REPO_ROOT:-}" ]; then
+  if [ -d "$_root/.specify" ]; then
+    REPO_ROOT="$_root"
+  else
+    git_root="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+    if [ -n "$git_root" ] && [ -d "$git_root/.specify" ]; then
+      REPO_ROOT="$git_root"
+    else
+      REPO_ROOT="$_root"
+    fi
+  fi
+fi
+
+exec "$REPO_ROOT/.specify/scripts/bash/update-agent-context.sh" cursor-agent

--- a/.specify/integrations/speckit.manifest.json
+++ b/.specify/integrations/speckit.manifest.json
@@ -1,0 +1,6 @@
+{
+  "integration": "speckit",
+  "version": "0.5.1.dev0",
+  "installed_at": "2026-04-08T16:23:41.286593+00:00",
+  "files": {}
+}


### PR DESCRIPTION
## Context & Objective
This change aligns the repository with the newer SpecKit integration flow for Cursor Agent.
It introduces explicit integration metadata and wrapper scripts so context-update behavior can be dispatched consistently via `.specify/integration.json`.

## Core Changes
- Updated `.specify/init-options.json`:
  - switched to integration-based config (`"integration": "cursor-agent"`)
  - bumped `speckit_version` to `0.5.1.dev0`
  - removed deprecated options no longer used by the new flow
- Added `.specify/integration.json` to define:
  - selected integration (`cursor-agent`)
  - integration version
  - script entry for `update-context`
- Added integration manifests:
  - `.specify/integrations/cursor-agent.manifest.json`
  - `.specify/integrations/speckit.manifest.json`
- Added Cursor integration wrapper scripts:
  - `.specify/integrations/cursor-agent/scripts/update-context.ps1`
  - `.specify/integrations/cursor-agent/scripts/update-context.sh`
- Wrapper scripts resolve repo root robustly and delegate to shared `update-agent-context` scripts, preparing for integration-based dispatch.

## Testing & Notes
- Rebase check: branch has been successfully rebased onto `origin/main` without conflicts.
- Suggested reviewer checks:
  1. Run the PowerShell wrapper on Windows and verify it calls shared update logic correctly.
  2. Run the Bash wrapper on Unix-like shell and verify the same behavior.
  3. Confirm `.specify/integration.json` is correctly consumed by downstream tooling.
- Notes:
  - This is mainly configuration/bootstrap work; no application runtime logic is changed.
  - `installed_at` timestamps and manifest file hashes are expected generated metadata.