### PR TITLE
006 commit lint auto fix

### DIFF
--- a/.cursor/rules/specify-rules.mdc
+++ b/.cursor/rules/specify-rules.mdc
@@ -37,8 +37,8 @@ Node.js ≥ 20（仓库 `engines`）: Follow standard conventions
 
 ## Recent Changes
 - 006-commit-lint-auto-fix: Added Node.js（仓库 `engines`：`>=24.0.0 <25`，Volta 锁定 24.14.1）；包管理 pnpm 9.x + `husky`（已有）、`@biomejs/biome`（已有）、**`lint-staged`（新增）**、`@commitlint/cli`（已有）
+- 006-commit-lint-auto-fix: Added Node.js（仓库 `engines`：`>=24.0.0 <25`，Volta 锁定 24.14.1）；包管理 pnpm 9.x + `husky`（已有）、`@biomejs/biome`（已有）、**`lint-staged`（新增）**、`@commitlint/cli`（已有）
 - 005-cli-greeting-demo: Added TypeScript 5.9.x（运行时 Bun） + Bun、citty、@clack/prompts、boxen、picocolors、react、ink、ink-spinner、valibot、neverthrow
-- 004-web-server-subapp: Added TypeScript 5.9.x + Node.js >= 20 + NestJS CLI (`@nestjs/schematics` 生成)、NestJS 核心运行时、`@biomejs/biome`（仓库已配置）
 
 <!-- MANUAL ADDITIONS START -->
 <!-- MANUAL ADDITIONS END -->

--- a/.cursor/rules/specify-rules.mdc
+++ b/.cursor/rules/specify-rules.mdc
@@ -1,11 +1,11 @@
----
+﻿---
 description: Project Development Guidelines
 globs: ["**/*"]
 alwaysApply: true
 ---
 # CthuTool Development Guidelines
 
-Auto-generated from all feature plans. Last updated: 2026-04-09
+Auto-generated from all feature plans. Last updated: 2026-04-13
 
 ## Active Technologies
 - N/A（无应用数据持久化；配置为仓库内文件） (002-commit-convention-workflow)
@@ -15,6 +15,8 @@ Auto-generated from all feature plans. Last updated: 2026-04-09
 - N/A（本特性仅服务启动与健康探测） (004-web-server-subapp)
 - TypeScript 5.9.x（运行时 Bun） + Bun、citty、@clack/prompts、boxen、picocolors、react、ink、ink-spinner、valibot、neverthrow (005-cli-greeting-demo)
 - N/A（单次 CLI 会话，无持久化） (005-cli-greeting-demo)
+- Node.js（仓库 `engines`：`>=24.0.0 <25`，Volta 锁定 24.14.1）；包管理 pnpm 9.x + `husky`（已有）、`@biomejs/biome`（已有）、**`lint-staged`（新增）**、`@commitlint/cli`（已有） (006-commit-lint-auto-fix)
+- N/A（仅 Git 暂存区与工作区文件） (006-commit-lint-auto-fix)
 
 - Node.js ≥ 20（仓库 `engines`） + `husky`, `@commitlint/cli`, `@commitlint/config-conventional`, `commitizen`, `cz-git`（均为根目录 `devDependencies`） (002-commit-convention-workflow)
 
@@ -34,9 +36,9 @@ tests/
 Node.js ≥ 20（仓库 `engines`）: Follow standard conventions
 
 ## Recent Changes
+- 006-commit-lint-auto-fix: Added Node.js（仓库 `engines`：`>=24.0.0 <25`，Volta 锁定 24.14.1）；包管理 pnpm 9.x + `husky`（已有）、`@biomejs/biome`（已有）、**`lint-staged`（新增）**、`@commitlint/cli`（已有）
 - 005-cli-greeting-demo: Added TypeScript 5.9.x（运行时 Bun） + Bun、citty、@clack/prompts、boxen、picocolors、react、ink、ink-spinner、valibot、neverthrow
 - 004-web-server-subapp: Added TypeScript 5.9.x + Node.js >= 20 + NestJS CLI (`@nestjs/schematics` 生成)、NestJS 核心运行时、`@biomejs/biome`（仓库已配置）
-- 003-biome-quality-gates: Added Node.js >= 20（仓库 `engines`），TypeScript 5.9.x + `@biomejs/biome`（新增，作为格式化+lint 统一引擎）、`husky`（已存在）、`turbo`（已存在）
 
 <!-- MANUAL ADDITIONS START -->
 <!-- MANUAL ADDITIONS END -->

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,20 +1,4 @@
 #!/usr/bin/env sh
 set -e
 
-STAGED_FILES=$(git diff --cached --name-only --diff-filter=ACMR -- apps packages)
-
-if [ -z "$STAGED_FILES" ]; then
-  echo "No staged files in apps/ or packages/, skipping Biome gate."
-  exit 0
-fi
-
-echo "Running Biome on staged managed files..."
-echo "$STAGED_FILES"
-
-if ! pnpm exec biome check $STAGED_FILES; then
-  echo ""
-  echo "Biome check failed for staged files."
-  echo "Fix tip: pnpm exec biome check --write $STAGED_FILES"
-  echo "Then restage files and commit again."
-  exit 1
-fi
+pnpm exec lint-staged

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -1,6 +1,8 @@
 import { defineCommand, runMain } from 'citty';
 import { greetCommand } from './command/greet.command';
 
+const _lintStagedUs1 = 1 + 2;
+
 const main = defineCommand({
   meta: {
     name: 'cthutool-cli',

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -1,8 +1,6 @@
 import { defineCommand, runMain } from 'citty';
 import { greetCommand } from './command/greet.command';
 
-const _lintStagedUs1 = 1 + 2;
-
 const main = defineCommand({
   meta: {
     name: 'cthutool-cli',

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -1,8 +1,6 @@
 import { defineCommand, runMain } from 'citty';
 import { greetCommand } from './command/greet.command';
 
-void 0;
-
 const main = defineCommand({
   meta: {
     name: 'cthutool-cli',

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -1,6 +1,8 @@
 import { defineCommand, runMain } from 'citty';
 import { greetCommand } from './command/greet.command';
 
+void 0;
+
 const main = defineCommand({
   meta: {
     name: 'cthutool-cli',

--- a/package.json
+++ b/package.json
@@ -17,6 +17,10 @@
       "path": "cz-git"
     }
   },
+  "lint-staged": {
+    "apps/**": "pnpm exec biome check --write",
+    "packages/**": "pnpm exec biome check --write"
+  },
   "devDependencies": {
     "@biomejs/biome": "^2.4.9",
     "@commitlint/cli": "^19.8.1",
@@ -27,6 +31,7 @@
     "cz-git": "^1.12.0",
     "husky": "^9.1.7",
     "jest": "^29.7.0",
+    "lint-staged": "^16.4.0",
     "ts-jest": "^29.2.6",
     "turbo": "^2.8.20",
     "typescript": "5.9.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,9 @@ importers:
       jest:
         specifier: ^29.7.0
         version: 29.7.0(@types/node@22.19.15)
+      lint-staged:
+        specifier: ^16.4.0
+        version: 16.4.0
       ts-jest:
         specifier: ^29.2.6
         version: 29.4.6(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(jest-util@29.7.0)(jest@29.7.0(@types/node@22.19.15))(typescript@5.9.2)
@@ -1302,6 +1305,10 @@ packages:
     resolution: {integrity: sha512-VGtlMu3x/4DOtIUwEkRezxUZ2lBacNJCHash0N0WeZDBS+7Ux1dm3XWAgWYxLJFMMdOeXMHXorshEFhbMSGelg==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
+  cli-cursor@5.0.0:
+    resolution: {integrity: sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==}
+    engines: {node: '>=18'}
+
   cli-spinners@2.9.2:
     resolution: {integrity: sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==}
     engines: {node: '>=6'}
@@ -1313,6 +1320,10 @@ packages:
   cli-truncate@4.0.0:
     resolution: {integrity: sha512-nPdaFdQ0h/GEigbPClz11D0v/ZJEwxmeVZGeMo3Z5StPtUTkA9o1lD6QwoirYiSDzbcwn2XcjwmCp68W1IS4TA==}
     engines: {node: '>=18'}
+
+  cli-truncate@5.2.0:
+    resolution: {integrity: sha512-xRwvIOMGrfOAnM1JYtqQImuaNtDEv9v6oIYAs4LIHwTiKee8uwvIi363igssOC0O5U04i4AlENs79LQLu9tEMw==}
+    engines: {node: '>=20'}
 
   cli-width@3.0.0:
     resolution: {integrity: sha512-FxqpkPPwu1HjuN93Omfm4h8uIanXofW0RxVEW3k5RKx+mJJYSthzNhp32Kzxxy3YAEZ/Dc/EWN1vZRY0+kOhbw==}
@@ -1354,9 +1365,16 @@ packages:
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
 
+  colorette@2.0.20:
+    resolution: {integrity: sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==}
+
   combined-stream@1.0.8:
     resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
     engines: {node: '>= 0.8'}
+
+  commander@14.0.3:
+    resolution: {integrity: sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==}
+    engines: {node: '>=20'}
 
   commander@2.20.3:
     resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
@@ -1648,6 +1666,9 @@ packages:
   etag@1.8.1:
     resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
     engines: {node: '>= 0.6'}
+
+  eventemitter3@5.0.4:
+    resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
 
   events@3.3.0:
     resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
@@ -2264,6 +2285,15 @@ packages:
   lines-and-columns@1.2.4:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
 
+  lint-staged@16.4.0:
+    resolution: {integrity: sha512-lBWt8hujh/Cjysw5GYVmZpFHXDCgZzhrOm8vbcUdobADZNOK/bRshr2kM3DfgrrtR1DQhfupW9gnIXOfiFi+bw==}
+    engines: {node: '>=20.17'}
+    hasBin: true
+
+  listr2@9.0.5:
+    resolution: {integrity: sha512-ME4Fb83LgEgwNw96RKNvKV4VTLuXfoKudAmm2lP8Kk87KaMK0/Xrx/aAkMWmT8mDb+3MlFDspfbCs7adjRxA2g==}
+    engines: {node: '>=20.0.0'}
+
   load-esm@1.0.3:
     resolution: {integrity: sha512-v5xlu8eHD1+6r8EHTg6hfmO97LN8ugKtiXcy5e6oN72iD2r6u0RPfLl6fxM+7Wnh2ZRq15o0russMst44WauPA==}
     engines: {node: '>=13.2.0'}
@@ -2319,6 +2349,10 @@ packages:
   log-symbols@4.1.0:
     resolution: {integrity: sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==}
     engines: {node: '>=10'}
+
+  log-update@6.1.0:
+    resolution: {integrity: sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==}
+    engines: {node: '>=18'}
 
   longest@2.0.1:
     resolution: {integrity: sha512-Ajzxb8CM6WAnFjgiloPsI3bF+WCxcvhdIG3KNA2KN962+tdBsHcuQ4k4qX/EcS/2CRkcc0iAkR956Nib6aXU/Q==}
@@ -2414,6 +2448,10 @@ packages:
     resolution: {integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==}
     engines: {node: '>=6'}
 
+  mimic-function@5.0.1:
+    resolution: {integrity: sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==}
+    engines: {node: '>=18'}
+
   minimatch@10.2.5:
     resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
     engines: {node: 18 || 20 || >=22}
@@ -2497,6 +2535,10 @@ packages:
   onetime@5.1.2:
     resolution: {integrity: sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==}
     engines: {node: '>=6'}
+
+  onetime@7.0.0:
+    resolution: {integrity: sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==}
+    engines: {node: '>=18'}
 
   ora@5.4.1:
     resolution: {integrity: sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==}
@@ -2592,6 +2634,10 @@ packages:
 
   picomatch@4.0.2:
     resolution: {integrity: sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==}
+    engines: {node: '>=12'}
+
+  picomatch@4.0.4:
+    resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
 
   pirates@4.0.7:
@@ -2710,6 +2756,13 @@ packages:
     resolution: {integrity: sha512-I9fPXU9geO9bHOt9pHHOhOkYerIMsmVaWB0rA2AI9ERh/+x/i7MV5HKBNrg+ljO5eoPVgCcnFuRjJ9uH6I/3eg==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
+  restore-cursor@5.1.0:
+    resolution: {integrity: sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==}
+    engines: {node: '>=18'}
+
+  rfdc@1.4.1:
+    resolution: {integrity: sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==}
+
   router@2.2.0:
     resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
     engines: {node: '>= 18'}
@@ -2807,6 +2860,10 @@ packages:
     resolution: {integrity: sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==}
     engines: {node: '>=18'}
 
+  slice-ansi@8.0.0:
+    resolution: {integrity: sha512-stxByr12oeeOyY2BlviTNQlYV5xOj47GirPr4yA1hE9JCtxfQN0+tVbkxwCtYDQWhEKWFHsEK48ORg5jrouCAg==}
+    engines: {node: '>=20'}
+
   source-map-support@0.5.13:
     resolution: {integrity: sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==}
 
@@ -2840,6 +2897,10 @@ packages:
     resolution: {integrity: sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==}
     engines: {node: '>=10.0.0'}
 
+  string-argv@0.3.2:
+    resolution: {integrity: sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==}
+    engines: {node: '>=0.6.19'}
+
   string-length@4.0.2:
     resolution: {integrity: sha512-+l6rNN5fYHNhZZy41RXsYptCjA2Igmq4EG7kZAYFQI1E1VTXarr6ZPXBg6eq7Y6eK4FEhY6AJlyuFIb/v/S0VQ==}
     engines: {node: '>=10'}
@@ -2851,6 +2912,10 @@ packages:
   string-width@7.2.0:
     resolution: {integrity: sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==}
     engines: {node: '>=18'}
+
+  string-width@8.2.0:
+    resolution: {integrity: sha512-6hJPQ8N0V0P3SNmP6h2J99RLuzrWz2gvT7VnK5tKvrNqJoyS9W4/Fb8mo31UiPvy00z7DQXkP2hnKBVav76thw==}
+    engines: {node: '>=20'}
 
   string_decoder@1.3.0:
     resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
@@ -4638,6 +4703,10 @@ snapshots:
     dependencies:
       restore-cursor: 4.0.0
 
+  cli-cursor@5.0.0:
+    dependencies:
+      restore-cursor: 5.1.0
+
   cli-spinners@2.9.2: {}
 
   cli-table3@0.6.5:
@@ -4650,6 +4719,11 @@ snapshots:
     dependencies:
       slice-ansi: 5.0.0
       string-width: 7.2.0
+
+  cli-truncate@5.2.0:
+    dependencies:
+      slice-ansi: 8.0.0
+      string-width: 8.2.0
 
   cli-width@3.0.0: {}
 
@@ -4683,9 +4757,13 @@ snapshots:
 
   color-name@1.1.4: {}
 
+  colorette@2.0.20: {}
+
   combined-stream@1.0.8:
     dependencies:
       delayed-stream: 1.0.0
+
+  commander@14.0.3: {}
 
   commander@2.20.3: {}
 
@@ -4950,6 +5028,8 @@ snapshots:
   estraverse@5.3.0: {}
 
   etag@1.8.1: {}
+
+  eventemitter3@5.0.4: {}
 
   events@3.3.0: {}
 
@@ -5814,6 +5894,24 @@ snapshots:
 
   lines-and-columns@1.2.4: {}
 
+  lint-staged@16.4.0:
+    dependencies:
+      commander: 14.0.3
+      listr2: 9.0.5
+      picomatch: 4.0.4
+      string-argv: 0.3.2
+      tinyexec: 1.0.4
+      yaml: 2.8.3
+
+  listr2@9.0.5:
+    dependencies:
+      cli-truncate: 5.2.0
+      colorette: 2.0.20
+      eventemitter3: 5.0.4
+      log-update: 6.1.0
+      rfdc: 1.4.1
+      wrap-ansi: 9.0.2
+
   load-esm@1.0.3: {}
 
   loader-runner@4.3.1: {}
@@ -5854,6 +5952,14 @@ snapshots:
     dependencies:
       chalk: 4.1.2
       is-unicode-supported: 0.1.0
+
+  log-update@6.1.0:
+    dependencies:
+      ansi-escapes: 7.3.0
+      cli-cursor: 5.0.0
+      slice-ansi: 7.1.2
+      strip-ansi: 7.2.0
+      wrap-ansi: 9.0.2
 
   longest@2.0.1: {}
 
@@ -5926,6 +6032,8 @@ snapshots:
 
   mimic-fn@2.1.0: {}
 
+  mimic-function@5.0.1: {}
+
   minimatch@10.2.5:
     dependencies:
       brace-expansion: 5.0.5
@@ -5994,6 +6102,10 @@ snapshots:
   onetime@5.1.2:
     dependencies:
       mimic-fn: 2.1.0
+
+  onetime@7.0.0:
+    dependencies:
+      mimic-function: 5.0.1
 
   ora@5.4.1:
     dependencies:
@@ -6074,6 +6186,8 @@ snapshots:
   picomatch@2.3.1: {}
 
   picomatch@4.0.2: {}
+
+  picomatch@4.0.4: {}
 
   pirates@4.0.7: {}
 
@@ -6178,6 +6292,13 @@ snapshots:
     dependencies:
       onetime: 5.1.2
       signal-exit: 3.0.7
+
+  restore-cursor@5.1.0:
+    dependencies:
+      onetime: 7.0.0
+      signal-exit: 4.1.0
+
+  rfdc@1.4.1: {}
 
   router@2.2.0:
     dependencies:
@@ -6303,6 +6424,11 @@ snapshots:
       ansi-styles: 6.2.3
       is-fullwidth-code-point: 5.1.0
 
+  slice-ansi@8.0.0:
+    dependencies:
+      ansi-styles: 6.2.3
+      is-fullwidth-code-point: 5.1.0
+
   source-map-support@0.5.13:
     dependencies:
       buffer-from: 1.1.2
@@ -6329,6 +6455,8 @@ snapshots:
 
   streamsearch@1.1.0: {}
 
+  string-argv@0.3.2: {}
+
   string-length@4.0.2:
     dependencies:
       char-regex: 1.0.2
@@ -6343,6 +6471,11 @@ snapshots:
   string-width@7.2.0:
     dependencies:
       emoji-regex: 10.6.0
+      get-east-asian-width: 1.5.0
+      strip-ansi: 7.2.0
+
+  string-width@8.2.0:
+    dependencies:
       get-east-asian-width: 1.5.0
       strip-ansi: 7.2.0
 

--- a/specs/006-commit-lint-auto-fix/checklists/requirements.md
+++ b/specs/006-commit-lint-auto-fix/checklists/requirements.md
@@ -1,0 +1,42 @@
+# Specification Quality Checklist: Commit-time lint gate with auto-fix
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning  
+**Created**: 2026-04-12  
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Validation Notes
+
+**Iteration 1 (2026-04-12)**: All items **pass**.
+
+- Stakeholder-facing sections avoid naming specific linters or hook frameworks; constitution alignment is isolated to the implementation note.
+- FR-001–FR-006 map to user stories and edge cases; SC-001–SC-004 use verifiable, outcome-based metrics.
+- Assumptions document reliance on existing project rules and standard developer setup.
+
+## Notes
+
+- Items marked incomplete require spec updates before `/speckit.clarify` or `/speckit.plan`

--- a/specs/006-commit-lint-auto-fix/contracts/commit-hook.contract.md
+++ b/specs/006-commit-lint-auto-fix/contracts/commit-hook.contract.md
@@ -1,0 +1,50 @@
+# 契约：Git 提交钩子（006-commit-lint-auto-fix）
+
+本文档约定仓库 **本地 Git 钩子** 行为，供实现与评审对照；与 `spec.md` 功能需求一致。
+
+## 范围
+
+- **包含**：`.husky/pre-commit`、`.husky/commit-msg`、根目录 `lint-staged` 配置、`package.json` 中相关脚本与依赖。
+- **不包含**：CI Workflow 具体内容（见 `.github/workflows/ci.yml`），但本地行为不得与 CI 的 Commitlint/Biome 政策相矛盾。
+
+## pre-commit
+
+### 触发时机
+
+每次 `git commit` 在写入提交对象之前执行（含 `--amend` 时由 Git 调用钩子的标准行为；以团队文档为准）。
+
+### 必须行为
+
+1. 调用 **`pnpm exec lint-staged`**（或仓库文档规定的等价命令，如 `npx lint-staged`）。
+2. lint-staged 对**符合配置的暂存文件**执行 **`biome check --write`**（通过 `pnpm exec biome` 调用），**不得**默认添加 `--unsafe`。
+3. 若 Biome 以非零状态退出，**整个提交必须中止**。
+4. 对 Biome 修改过的文件，**必须**在同一提交准备过程中回到暂存区（由 lint-staged 完成）。
+
+### 路径范围
+
+- 至少覆盖 `apps/` 与 `packages/` 下由 Biome 管理的源文件；与 `biome.jsonc` 中 `files.includes` 不一致的配置视为缺陷。
+
+### 可选行为
+
+- 无匹配暂存文件时：静默成功或简短说明后退出 0（与 lint-staged 默认一致即可）。
+
+## commit-msg
+
+### 必须行为
+
+1. 执行 **`pnpm exec commitlint --edit "$1"`**（保留现有行为）。
+2. 消息不合法时 **非零退出**，提交失败。
+
+### 与 pre-commit 的次序
+
+- Git 保证 **pre-commit 先于 commit-msg**；不得将 Commitlint 移入 pre-commit 替代 commit-msg。
+
+## CI 对齐（非钩子但为契约参考）
+
+- **CI**：`pnpm run lint` 使用 **`biome check .`**（全仓库检查），**不带** `--write`。
+- **本地**：pre-commit 使用 **写入式** 检查以降摩擦；合并前仍须通过 CI 全量检查。
+
+## 版本与工具
+
+- **Node**：遵守根目录 `package.json` 的 `engines`。
+- **lint-staged**：版本锁定于 `pnpm-lock.yaml`；主版本升级时需重新验证钩子与 pnpm 工作区行为。

--- a/specs/006-commit-lint-auto-fix/data-model.md
+++ b/specs/006-commit-lint-auto-fix/data-model.md
@@ -1,0 +1,55 @@
+# 数据模型：提交时 Lint 门禁（概念层）
+
+本特性无数据库；以下为 **Git 工作流与门禁** 的概念实体，用于对齐 spec 与实现。
+
+## 实体
+
+### 1. 暂存变更集（Staged Change Set）
+
+| 字段 | 说明 |
+|------|------|
+| 路径集合 | 当前 `git index` 中已暂存文件路径（pre-commit 可见） |
+| 作用域 | 实现上过滤为 `apps/**`、`packages/**` 下且受 Biome 处理的文件（与 `biome.jsonc` 一致） |
+
+### 2. 自动修复结果（Auto-fix Outcome）
+
+| 字段 | 说明 |
+|------|------|
+| 已修改文件 | Biome `--write` 产生变更的文件 |
+| 回写暂存 | 由 lint-staged 将上述文件的更新再次加入暂存区 |
+| 诊断 | 仍存在的 error 级问题（若有）→ 命令非零退出，提交中止 |
+
+### 3. 提交消息（Commit Message）
+
+| 字段 | 说明 |
+|------|------|
+| 原始文本 | 用户在 `git commit` / `git-cz` 中输入的消息 |
+| 校验结果 | `commitlint` 根据 `commitlint.config.cjs` 与合同规则解析 |
+
+## 关系
+
+- **暂存变更集** —触发→ **lint-staged** —调度→ **Biome check --write** → 更新工作区与 **自动修复结果**。
+- **提交消息** —在 commit-msg 阶段由 **Commitlint** 校验，与 pre-commit 成功顺序无关但同一提交需两次钩子均通过。
+
+## 状态迁移（简化）
+
+```text
+[开始提交]
+    → pre-commit：lint-staged → Biome（写入）
+        → 仍有 error 诊断 → 失败（工作区可能已部分修改；用户修复后重新暂存）
+        → 无 error → 继续
+    → commit-msg：commitlint
+        → 不合法 → 失败（代码可能已格式化；用户改消息后重试）
+        → 合法 → [提交完成]
+```
+
+## 验证规则（映射 spec）
+
+| Spec | 规则摘要 |
+|------|-----------|
+| FR-001 | pre-commit 必须运行带自动修复能力的 Biome 检查 |
+| FR-002 | 自动修复必须包含在同一提交中（lint-staged 回写暂存） |
+| FR-003 | 自动修复后仍有错误则提交失败 |
+| FR-004 | commit-msg 阶段必须执行 Commitlint |
+| FR-005 | 失败时输出须可区分「代码问题」与「消息问题」（分阶段钩子 + 工具 stderr） |
+| FR-006 | 依赖 `prepare`/husky 与文档化标准流程 |

--- a/specs/006-commit-lint-auto-fix/plan.md
+++ b/specs/006-commit-lint-auto-fix/plan.md
@@ -1,0 +1,86 @@
+# Implementation Plan: 基于 lint-staged 的提交时 lint 门禁增强
+
+**Branch**: `006-commit-lint-auto-fix` | **Date**: 2026-04-13 | **Spec**: [spec.md](./spec.md)  
+**Input**: 功能规格见 `/specs/006-commit-lint-auto-fix/spec.md`；用户补充方向为通过 **lint-staged** 增强本地 lint 门禁并与 Husky 集成。
+
+**说明**: 本文件由 `/speckit.plan` 生成；执行流程见 `.specify/templates/plan-template.md`。
+
+## Summary
+
+在保留 **Commitlint**（`commit-msg` 钩子）的前提下，将当前 **pre-commit** 中手写 `git diff` + `biome check`（仅检查、无写入）替换为 **`lint-staged` 编排**：对暂存区中 `apps/`、`packages/` 下受 Biome 管理的文件执行 **`biome check --write`**，利用 lint-staged 对任务修改过的文件 **自动再次 `git add`**，使可自动修复的问题在同一提交中完成，无法修复的问题仍阻断提交。CI 继续执行全仓库 `pnpm run lint`（`biome check .`），与本地「仅针对本次变更路径」的写入式检查形成互补，符合宪章中的质量门禁与 CI 一致性要求。
+
+## Technical Context
+
+**Language/Version**: Node.js（仓库 `engines`：`>=24.0.0 <25`，Volta 锁定 24.14.1）；包管理 pnpm 9.x  
+**Primary Dependencies**: `husky`（已有）、`@biomejs/biome`（已有）、**`lint-staged`（新增）**、`@commitlint/cli`（已有）  
+**Storage**: N/A（仅 Git 暂存区与工作区文件）  
+**Testing**: 根目录 `jest` + `turbo run test`；本特性以「钩子行为与文档」验证为主，无需新增业务单测（配置级变更）  
+**Target Platform**: 贡献者本地开发机（Windows / macOS / Linux），与 CI `ubuntu-latest` 行为对齐策略见 `research.md`  
+**Project Type**: Turborepo 单体仓库，门禁为仓库级工具配置  
+**Performance Goals**: pre-commit 仅处理本次暂存相关文件，避免全仓库 `biome check` 拖慢日常提交  
+**Constraints**: 须满足 spec FR-001～FR-006；提交信息规则不变；不削弱 Commitlint；与 `biome.jsonc` 的 `files.includes`（`apps/**`、`packages/**`）一致  
+**Scale/Scope**: 根目录 `package.json` 增加 `lint-staged` 配置与依赖；`.husky/pre-commit` 简化为调用 `lint-staged`；可选独立 `lint-staged` 配置文件
+
+## Constitution Check
+
+*GATE：Phase 0 研究前必须通过；Phase 1 设计后再次核对。*
+
+依据 `.specify/memory/constitution.md`（CthuTool）：
+
+- **FP 与模块化**：本特性为 Husky/lint-staged/Biome 配置与 shell 钩子，不涉及业务 `neverthrow`/`valibot` 代码路径；钩子脚本保持单一职责（pre-commit 仅委托 lint-staged）。
+- **错误处理**：不适用业务层；钩子以非零退出表示失败。
+- **验证**：不适用运行时边界验证。
+- **TDD**：无新增可单测业务逻辑；可通过「暂存违规文件 → 提交」做手动/脚本验收（见 `quickstart.md`）。
+- **TSDoc**：不适用。
+- **栈与仓库**：Turborepo、`@cthutool/*` 命名不变。
+- **CI**：变更后仍须通过 Biome、测试、Commitlint 等流水线；本地 pre-commit 使用 `--write` 仅影响开发者工作区与即将提交的快照，合并后 CI 全量检查仍为准绳。
+
+**Phase 1 后复核**：无宪章冲突；无需填写 Complexity Tracking。
+
+## Project Structure
+
+### 文档（本特性）
+
+```text
+specs/006-commit-lint-auto-fix/
+├── plan.md              # 本文件（/speckit.plan）
+├── research.md          # Phase 0
+├── data-model.md        # Phase 1
+├── quickstart.md        # Phase 1
+├── contracts/           # Phase 1
+│   └── commit-hook.contract.md
+└── tasks.md             # Phase 2（/speckit.tasks，非本命令生成）
+```
+
+### 源码（仓库根目录，本特性将触碰的路径）
+
+```text
+package.json                 # 新增 devDependency lint-staged；新增 "lint-staged" 配置
+pnpm-lock.yaml               # 锁文件随依赖更新
+.husky/pre-commit            # 改为执行 pnpm exec lint-staged（或 npx/pnpm 等价调用）
+biome.jsonc                  # 一般不修改；Biome 仍管理 apps/**、packages/**
+```
+
+**结构说明**：不新增 `apps/` 或 `packages/` 下业务代码；仅根目录工具链与 Git 钩子。
+
+## Complexity Tracking
+
+本实现不引入宪章违背项；无需登记豁免。
+
+---
+
+## Phase 0 & 1 产出与后置核对
+
+| 产出 | 路径 | 状态 |
+|------|------|------|
+| 研究结论 | [research.md](./research.md) | 已解决「lint-staged + Biome --write + CI 对齐」等要点 |
+| 数据与状态模型 | [data-model.md](./data-model.md) | 提交门禁实体与状态迁移 |
+| 契约 | [contracts/commit-hook.contract.md](./contracts/commit-hook.contract.md) | pre-commit / commit-msg 行为契约 |
+| 快速验证 | [quickstart.md](./quickstart.md) | 本地验证步骤 |
+| Agent 上下文 | `.cursor/rules/specify-rules.mdc` | 由 `update-agent-context.ps1` 更新 |
+
+**后置 Constitution Check**：仍为通过；CI 清单（Biome、TSC、Knip、Commitlint、Tests）未被削弱。
+
+## 后续步骤
+
+使用 `/speckit.tasks` 将本计划拆分为可执行 task（依赖安装、配置、钩子替换、文档与回归检查）。

--- a/specs/006-commit-lint-auto-fix/quickstart.md
+++ b/specs/006-commit-lint-auto-fix/quickstart.md
@@ -1,0 +1,32 @@
+# Quickstart：验证「lint-staged + Biome 写入」提交门禁
+
+前置：已 `pnpm install`（会执行 `husky` `prepare`），且未使用 `--no-verify`（除非刻意跳过钩子）。
+
+## 1. 仅自动修复类问题（User Story 1）
+
+1. 在 `apps/` 或 `packages/` 下故意制造**仅**违反可自动修复规则的内容（例如多余空格、格式化不一致）。
+2. `git add` 相关文件。
+3. `git commit -m "chore(test): trigger lint-staged biome write"`（消息需符合 commitlint）。
+4. **期望**：提交成功；`git show` 中可见 Biome 格式化/修复与原始意图在同一提交中。
+
+## 2. 无法自动修复的问题（User Story 2）
+
+1. 引入一条 Biome **error** 且无法被 `--write` 安全消除的问题（按项目规则选择场景）。
+2. `git add` 并尝试提交。
+3. **期望**：提交失败；终端可见 Biome 诊断；修复后重新暂存并可成功提交。
+
+## 3. 消息不合法（User Story 3）
+
+1. 保持暂存文件通过 Biome。
+2. `git commit -m "bad message"`（故意违反 Conventional Commits / 合同）。
+3. **期望**：在 **commit-msg** 阶段被 commitlint 拒绝；按规则修正消息后再次提交应可通过。
+
+## 4. 回归：与 CI 一致
+
+1. 本地通过上述提交后，推送分支。
+2. **期望**：CI 中 **Lint**（`pnpm run lint`）与 **Commitlint** 仍通过。
+
+## 提示
+
+- 若同一文件存在 **partial staging**，格式化可能影响整文件；见 `research.md` 说明。
+- 跳过钩子仅用于紧急情况：`git commit --no-verify`（不推荐纳入常规流程）。

--- a/specs/006-commit-lint-auto-fix/research.md
+++ b/specs/006-commit-lint-auto-fix/research.md
@@ -1,0 +1,42 @@
+# Phase 0 研究：lint-staged + Biome 提交门禁
+
+## 1. 是否采用 lint-staged
+
+- **决策**：采用 **lint-staged** 作为 pre-commit 的统一入口，由它调度对暂存文件的 Biome 写入式检查。
+- **理由**：
+  - 与 Husky 生态标准集成，减少手写 `git diff --cached` 脚本。
+  - 对任务修改的文件 **自动重新加入暂存区**（lint-staged 默认行为），满足 spec FR-002「自动修复须进入同一提交」。
+  - 仅对匹配的暂存路径运行命令，符合 FR-006「标准开发者工作流一致」的可复制安装方式（`pnpm install` + `prepare` 安装 husky）。
+- **备选**：
+  - 保留手写 shell：已存在但需自行维护 `git add`、跨平台引号与多语言扩展名列表。
+  - Lefthook / pre-commit 框架：引入新配置体系，与当前 husky + pnpm 栈重复，迁移成本高。
+
+## 2. Biome 调用方式：`--write` 与路径范围
+
+- **决策**：在 lint-staged 任务中执行 **`pnpm exec biome check --write`**，匹配模式限定为 **`{apps,packages}/**/*`**（或与 `biome.jsonc` 一致的子路径），由 lint-staged 将**当前暂存文件列表**作为参数传入；不叠加 **`--unsafe`**，除非后续政策明确允许。
+- **理由**：
+  - `biome check --write` 会应用安全修复、格式化与 import 排序（与仓库 `lint:fix` 语义一致）。
+  - 与当前 pre-commit 仅关注 `apps/`、`packages/` 的范围一致（见现有 `.husky/pre-commit`）。
+- **备选**：
+  - **`biome check --write --staged`**：由 Biome 直接读取 Git 暂存区；与 lint-staged 组合时需避免「重复传参/重复扫描」；若采用需保证 pre-commit 只运行一次且仍由 lint-staged 负责回写暂存区。当前推荐 **lint-staged 传文件列表 + `--write`**，语义更直观。
+- **说明**：Biome CLI 提供 `--staged`（仅暂存文件），已在本地 `biome check --help` 中确认；详见 Phase 1 契约中的命令约束。
+
+## 3. 与 CI 的一致性
+
+- **决策**：CI 保持 **`pnpm run lint` → `biome check .`**（全仓库）；本地 pre-commit 为 **增量 + 写入**，合并前 PR 仍受全量检查约束。
+- **理由**：spec 要求本地不削弱门禁；全量 CI 可捕获「未暂存但已修改」等边界问题；本地则以低摩擦修复为主。
+- **备选**：在 CI 使用 `biome check --changed`（需配置默认分支）— 可作为后续优化，非本特性必选项。
+
+## 4. Commitlint 与执行顺序
+
+- **决策**：保留 **`.husky/commit-msg`** 调用 `commitlint`；**不在 pre-commit 中**运行 commitlint（Git 钩子阶段：pre-commit 先于 commit-msg）。
+- **理由**：符合 spec User Story 3：消息校验在提交消息写入后执行，且与现有仓库一致。
+
+## 5. 部分暂存（partial staging）与 spec 边界情况
+
+- **决策**：在 `research.md` 中明确：**Biome 按文件级写入**；若使用 `git add -p` 导致同一文件既有暂存又有未暂存块，格式化可能影响整文件，可能将未暂存块一并变更。默认策略与 spec「默认仅修正参与提交尝试的路径」一致为**文件级**；进阶行为（仅格式化暂存块）超出本特性范围。
+- **理由**：与多数 formatter/linter 行为一致；可通过文档在 `quickstart.md` 提示。
+
+## 6. Context7 说明
+
+- 本次会话中 Context7 MCP **未连接**，未拉取线上 lint-staged 文档；技术结论基于仓库内 Biome CLI 帮助信息、lint-staged 常见用法与当前 Husky 脚本。实施时建议在连接 Context7 或查阅 [lint-staged 官方文档](https://github.com/lint-staged/lint-staged) 后核对 `lint-staged` 主版本与 Node 兼容性。

--- a/specs/006-commit-lint-auto-fix/spec.md
+++ b/specs/006-commit-lint-auto-fix/spec.md
@@ -1,0 +1,90 @@
+# Feature Specification: Commit-time lint gate with auto-fix
+
+**Feature Branch**: `006-commit-lint-auto-fix`  
+**Created**: 2026-04-12  
+**Status**: Draft  
+**Input**: User description: "增强 git commit 时的 lint 门禁；在提交时自动修复 lint 问题并一并提交"
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - One-shot commit with auto-fixed style (Priority: P1)
+
+A contributor stages code changes and runs a commit. Minor issues that the project’s style and lint rules allow to correct automatically are fixed during the commit process, those fixes are included in the same commit, and the commit completes without requiring a separate “fix formatting then commit again” round trip.
+
+**Why this priority**: This is the core outcome: less friction and fewer interrupted workflows for routine, machine-fixable problems.
+
+**Independent Test**: Can be validated by staging changes that violate only auto-fixable rules, running a commit, and confirming one successful commit contains both the original intent and the corrections.
+
+**Acceptance Scenarios**:
+
+1. **Given** staged changes that violate only rules the project allows to auto-correct, **When** the contributor completes a commit, **Then** the corrections are applied, included in that commit, and the commit succeeds.
+2. **Given** the same situation, **When** the commit finishes, **Then** the contributor can see which files or areas were changed by the automatic step (for example via command output or review of the resulting commit).
+
+---
+
+### User Story 2 - Blocked commit with clear next steps (Priority: P2)
+
+A contributor attempts a commit, but some problems cannot be fixed automatically (or are excluded from auto-fix by policy). The commit does not go through, and the contributor understands what still fails and what to do manually.
+
+**Why this priority**: Auto-fix must not hide serious issues; failing fast with clarity preserves trust in the gate.
+
+**Independent Test**: Staged changes that trigger non-auto-fixable violations still fail the commit, with messages that distinguish “must fix manually” from “was fixed automatically.”
+
+**Acceptance Scenarios**:
+
+1. **Given** staged changes with at least one issue that cannot be auto-fixed under project rules, **When** the contributor attempts a commit, **Then** the commit is rejected and the output points to the remaining problems.
+2. **Given** a rejected commit, **When** the contributor fixes only the remaining issues and commits again, **Then** the commit can succeed without unexpected extra steps beyond those fixes.
+
+---
+
+### User Story 3 - Commit message rules remain enforced (Priority: P3)
+
+Project rules for commit messages (for example conventional commit format and language policy) continue to apply. A bad message does not slip through just because code style was auto-fixed.
+
+**Why this priority**: Strengthening the code gate must not weaken message discipline, which affects history and automation.
+
+**Independent Test**: Attempt a commit with valid staged code but an invalid commit message; the commit fails for message reasons, independent of auto-fix behavior.
+
+**Acceptance Scenarios**:
+
+1. **Given** acceptable staged code, **When** the contributor uses a commit message that violates project commit-message rules, **Then** the commit is blocked until the message is corrected.
+2. **Given** code issues are auto-fixed and included in the commit, **When** the message is valid, **Then** both code corrections and the message are part of the same successful commit.
+
+---
+
+### Edge Cases
+
+- **Nothing left to fix**: If there are no auto-fixable issues, the commit flow behaves like a normal lint check without redundant noise.
+- **Auto-fix touches files the user did not stage**: By default, automatic corrections apply only to paths that are part of the current commit attempt (for example staged files). If the project later allows fixing unstaged neighbors, the contributor MUST be clearly notified before those files are included in the commit.
+- **Partial success**: Some violations fixed automatically, others not—the commit MUST still fail until all remaining issues are resolved.
+- **No automatic fix possible**: Binary or generated-only conflicts, or tool failures—the commit MUST fail with a clear error rather than silently skipping checks.
+- **Amend and partial commits**: Same rules apply whenever the project’s “commit gate” runs for a code commit (including amend), unless explicitly out of scope for this feature.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: Whenever a contributor attempts to create a code commit that is subject to the project’s local commit checks, the system MUST run the project’s configured lint and style checks with automatic correction enabled for rules that support it.
+- **FR-002**: Any file content corrected by that automatic step MUST be included in the same commit as the contributor’s changes (same commit operation), not left as unstaged edits or a follow-up commit by default.
+- **FR-003**: If any check still fails after automatic correction (including issues that cannot be auto-fixed), the commit MUST NOT complete until those issues are resolved.
+- **FR-004**: Commit message validation MUST run as part of the same commit workflow and MUST reject commits whose messages violate project rules, independent of code auto-fix.
+- **FR-005**: The contributor MUST receive enough feedback to know (a) that automatic corrections were applied and to which parts of the change, and (b) what remains wrong if the commit is blocked.
+- **FR-006**: The behavior MUST be consistent for all team members using the repository’s standard developer setup (no “works only on one machine” path for the gate).
+
+### Assumptions
+
+- The repository already defines which lint and style rules apply and which violations are safe to auto-fix; this feature wires those rules into the commit path with auto-fix and “include in same commit” behavior.
+- Contributors use the supported Git client flows that trigger the same hooks or equivalent entry points the project documents.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: In a defined pilot period, at least **90%** of commits that would previously have failed only on machine-fixable style or lint issues complete successfully on the **first** commit attempt after auto-fix (measured by sampling or recorded dry runs, with a clear definition of “only machine-fixable”).
+- **SC-002**: **100%** of commits with invalid commit messages are still rejected (no increase in invalid messages on the default branch compared to pre-change baseline over the same measurement window).
+- **SC-003**: In user feedback (short survey or retrospective), a majority of contributors report **less** manual formatting or trivial fix-up work compared to before the change.
+- **SC-004**: When a commit is blocked, contributors can identify whether the problem requires manual code change versus a message change in **under one minute** in usability tests (e.g., task-based review with a small set of scenarios).
+
+## Constitution alignment *(implementation)*
+
+Implementation MUST stay aligned with `.specify/memory/constitution.md`: monorepo quality gates, existing formatting and lint tooling policy, and CI parity so local commit behavior does not contradict continuous integration. User-facing requirements above remain technology-agnostic; concrete tool names and hook wiring belong in the plan and tasks, not in stakeholder-facing success criteria.

--- a/specs/006-commit-lint-auto-fix/tasks.md
+++ b/specs/006-commit-lint-auto-fix/tasks.md
@@ -29,7 +29,7 @@ description: "Task list for commit-time lint gate with lint-staged (006-commit-l
 
 **Purpose**: 引入 lint-staged 依赖，为后续钩子与配置做准备
 
-- [ ] T001 Add `lint-staged` to `devDependencies` in `package.json` and run `pnpm install` at repository root to update `pnpm-lock.yaml`
+- [x] T001 Add `lint-staged` to `devDependencies` in `package.json` and run `pnpm install` at repository root to update `pnpm-lock.yaml`
 
 ---
 
@@ -39,8 +39,8 @@ description: "Task list for commit-time lint gate with lint-staged (006-commit-l
 
 **⚠️ CRITICAL**: No user story verification should be treated as complete until this phase is complete
 
-- [ ] T002 Configure `lint-staged` in `package.json` (or add a dedicated config file at repository root if preferred) so staged files under `apps/` and `packages/` run `pnpm exec biome check --write` with no default `--unsafe`, matching `biome.jsonc` `files.includes` and `specs/006-commit-lint-auto-fix/contracts/commit-hook.contract.md`
-- [ ] T003 Replace `.husky/pre-commit` to invoke `pnpm exec lint-staged` per `specs/006-commit-lint-auto-fix/contracts/commit-hook.contract.md`, removing the legacy `git diff` + read-only `biome check` script
+- [x] T002 Configure `lint-staged` in `package.json` (or add a dedicated config file at repository root if preferred) so staged files under `apps/` and `packages/` run `pnpm exec biome check --write` with no default `--unsafe`, matching `biome.jsonc` `files.includes` and `specs/006-commit-lint-auto-fix/contracts/commit-hook.contract.md`
+- [x] T003 Replace `.husky/pre-commit` to invoke `pnpm exec lint-staged` per `specs/006-commit-lint-auto-fix/contracts/commit-hook.contract.md`, removing the legacy `git diff` + read-only `biome check` script
 
 **Checkpoint**: Foundation ready — user story manual verification can begin
 
@@ -54,7 +54,7 @@ description: "Task list for commit-time lint gate with lint-staged (006-commit-l
 
 ### Verification for User Story 1
 
-- [ ] T004 [US1] Execute manual acceptance in `specs/006-commit-lint-auto-fix/quickstart.md` §1 using a file under `apps/` or `packages/`, confirming a single successful commit contains both original intent and Biome corrections (FR-001, FR-002, FR-005a)
+- [x] T004 [US1] Execute manual acceptance in `specs/006-commit-lint-auto-fix/quickstart.md` §1 using a file under `apps/` or `packages/`, confirming a single successful commit contains both original intent and Biome corrections (FR-001, FR-002, FR-005a)
 
 **Checkpoint**: User Story 1 satisfied independently
 
@@ -68,7 +68,7 @@ description: "Task list for commit-time lint gate with lint-staged (006-commit-l
 
 ### Verification for User Story 2
 
-- [ ] T005 [US2] Execute `specs/006-commit-lint-auto-fix/quickstart.md` §2: introduce a Biome error that `--write` cannot clear, confirm commit fails with visible diagnostics, then fix only remaining issues and confirm the next commit succeeds (FR-003, FR-005b)
+- [x] T005 [US2] Execute `specs/006-commit-lint-auto-fix/quickstart.md` §2: introduce a Biome error that `--write` cannot clear, confirm commit fails with visible diagnostics, then fix only remaining issues and confirm the next commit succeeds (FR-003, FR-005b)
 
 **Checkpoint**: User Story 2 satisfied independently
 
@@ -82,8 +82,8 @@ description: "Task list for commit-time lint gate with lint-staged (006-commit-l
 
 ### Implementation / verification for User Story 3
 
-- [ ] T006 [US3] Confirm `.husky/commit-msg` still runs `pnpm exec commitlint --edit "$1"` unchanged per `specs/006-commit-lint-auto-fix/contracts/commit-hook.contract.md` (FR-004)
-- [ ] T007 [US3] Execute `specs/006-commit-lint-auto-fix/quickstart.md` §3 with valid staged code and an invalid message, confirm failure at commit-msg stage; retry with a valid conventional message and confirm success (FR-004, FR-005)
+- [x] T006 [US3] Confirm `.husky/commit-msg` still runs `pnpm exec commitlint --edit "$1"` unchanged per `specs/006-commit-lint-auto-fix/contracts/commit-hook.contract.md` (FR-004)
+- [x] T007 [US3] Execute `specs/006-commit-lint-auto-fix/quickstart.md` §3 with valid staged code and an invalid message, confirm failure at commit-msg stage; retry with a valid conventional message and confirm success (FR-004, FR-005)
 
 **Checkpoint**: User Story 3 satisfied independently
 
@@ -93,8 +93,8 @@ description: "Task list for commit-time lint gate with lint-staged (006-commit-l
 
 **Purpose**: CI 对齐、Agent 上下文与文档化收尾
 
-- [ ] T008 [P] Run `pnpm run lint` at repository root and follow `specs/006-commit-lint-auto-fix/quickstart.md` §4 for CI parity expectations
-- [ ] T009 [P] Run `.specify/scripts/powershell/update-agent-context.ps1` from repository root to refresh `.cursor/rules/specify-rules.mdc` per `specs/006-commit-lint-auto-fix/plan.md`
+- [x] T008 [P] Run `pnpm run lint` at repository root and follow `specs/006-commit-lint-auto-fix/quickstart.md` §4 for CI parity expectations
+- [x] T009 [P] Run `.specify/scripts/powershell/update-agent-context.ps1` from repository root to refresh `.cursor/rules/specify-rules.mdc` per `specs/006-commit-lint-auto-fix/plan.md`
 
 ---
 

--- a/specs/006-commit-lint-auto-fix/tasks.md
+++ b/specs/006-commit-lint-auto-fix/tasks.md
@@ -1,0 +1,178 @@
+---
+
+description: "Task list for commit-time lint gate with lint-staged (006-commit-lint-auto-fix)"
+---
+
+# Tasks: Commit-time lint gate with auto-fix (lint-staged)
+
+**Input**: Design documents from `/specs/006-commit-lint-auto-fix/`  
+**Prerequisites**: plan.md (required), spec.md (required for user stories), research.md, data-model.md, contracts/
+
+**Tests**: plan.md 将本特性标为配置级变更，验收以 `quickstart.md` 手动场景与钩子行为为主；不设 Jest/业务单测任务。
+
+**Organization**: Tasks are grouped by user story to enable independent implementation and verification of each story.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g., US1, US2, US3)
+- Include exact file paths in descriptions
+
+## Path Conventions
+
+- 仓库根目录：`package.json`、`pnpm-lock.yaml`、`.husky/pre-commit`、`.husky/commit-msg`、`biome.jsonc`
+- 本特性不新增 `apps/`、`packages/` 业务代码；验证时可在上述目录选用临时文件
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: 引入 lint-staged 依赖，为后续钩子与配置做准备
+
+- [ ] T001 Add `lint-staged` to `devDependencies` in `package.json` and run `pnpm install` at repository root to update `pnpm-lock.yaml`
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: 所有用户故事共用的 pre-commit 管线（lint-staged + Biome `--write`）；完成前不得宣称任一用户故事已交付
+
+**⚠️ CRITICAL**: No user story verification should be treated as complete until this phase is complete
+
+- [ ] T002 Configure `lint-staged` in `package.json` (or add a dedicated config file at repository root if preferred) so staged files under `apps/` and `packages/` run `pnpm exec biome check --write` with no default `--unsafe`, matching `biome.jsonc` `files.includes` and `specs/006-commit-lint-auto-fix/contracts/commit-hook.contract.md`
+- [ ] T003 Replace `.husky/pre-commit` to invoke `pnpm exec lint-staged` per `specs/006-commit-lint-auto-fix/contracts/commit-hook.contract.md`, removing the legacy `git diff` + read-only `biome check` script
+
+**Checkpoint**: Foundation ready — user story manual verification can begin
+
+---
+
+## Phase 3: User Story 1 - One-shot commit with auto-fixed style (Priority: P1) 🎯 MVP
+
+**Goal**: 暂存变更在提交过程中由 Biome 自动修复可修复项，修复进入同一提交，提交成功（spec US1）
+
+**Independent Test**: `specs/006-commit-lint-auto-fix/quickstart.md` §1 — 仅可自动修复违规时一次提交成功且 `git show` 可见修复
+
+### Verification for User Story 1
+
+- [ ] T004 [US1] Execute manual acceptance in `specs/006-commit-lint-auto-fix/quickstart.md` §1 using a file under `apps/` or `packages/`, confirming a single successful commit contains both original intent and Biome corrections (FR-001, FR-002, FR-005a)
+
+**Checkpoint**: User Story 1 satisfied independently
+
+---
+
+## Phase 4: User Story 2 - Blocked commit with clear next steps (Priority: P2)
+
+**Goal**: 无法自动修复的问题仍阻断提交，终端可见 Biome 诊断，修复后可再次提交（spec US2）
+
+**Independent Test**: `specs/006-commit-lint-auto-fix/quickstart.md` §2
+
+### Verification for User Story 2
+
+- [ ] T005 [US2] Execute `specs/006-commit-lint-auto-fix/quickstart.md` §2: introduce a Biome error that `--write` cannot clear, confirm commit fails with visible diagnostics, then fix only remaining issues and confirm the next commit succeeds (FR-003, FR-005b)
+
+**Checkpoint**: User Story 2 satisfied independently
+
+---
+
+## Phase 5: User Story 3 - Commit message rules remain enforced (Priority: P3)
+
+**Goal**: Commitlint 仍在 commit-msg 阶段生效；代码自动修复不削弱消息规则（spec US3）
+
+**Independent Test**: `specs/006-commit-lint-auto-fix/quickstart.md` §3
+
+### Implementation / verification for User Story 3
+
+- [ ] T006 [US3] Confirm `.husky/commit-msg` still runs `pnpm exec commitlint --edit "$1"` unchanged per `specs/006-commit-lint-auto-fix/contracts/commit-hook.contract.md` (FR-004)
+- [ ] T007 [US3] Execute `specs/006-commit-lint-auto-fix/quickstart.md` §3 with valid staged code and an invalid message, confirm failure at commit-msg stage; retry with a valid conventional message and confirm success (FR-004, FR-005)
+
+**Checkpoint**: User Story 3 satisfied independently
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: CI 对齐、Agent 上下文与文档化收尾
+
+- [ ] T008 [P] Run `pnpm run lint` at repository root and follow `specs/006-commit-lint-auto-fix/quickstart.md` §4 for CI parity expectations
+- [ ] T009 [P] Run `.specify/scripts/powershell/update-agent-context.ps1` from repository root to refresh `.cursor/rules/specify-rules.mdc` per `specs/006-commit-lint-auto-fix/plan.md`
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies — start with T001
+- **Foundational (Phase 2)**: Depends on Phase 1 — blocks all user story verification
+- **User Stories (Phases 3–5)**: Depend on Foundational (Phase 2); proceed P1 → P2 → P3 for lowest risk, or verify in any order after Phase 2 if time-boxed
+- **Polish (Phase 6)**: Depends on desired user stories being verified
+
+### User Story Dependencies
+
+- **User Story 1 (P1)**: Depends on Phase 2 only
+- **User Story 2 (P2)**: Depends on Phase 2 only; independent of US1 except shared git state discipline
+- **User Story 3 (P3)**: Depends on Phase 2 only; independent of US1/US2 for message-only failure path
+
+### Within Each User Story
+
+- Verification tasks assume Phase 2 hook behavior is already correct
+- Re-run `pnpm install` / husky if hooks not executable after edits
+
+### Parallel Opportunities
+
+- **T008** and **T009** (Phase 6) may run in parallel by different owners (lint vs agent-context script)
+- Phase 2 tasks **T002** and **T003** are sequential (config before hook calls `lint-staged`)
+
+---
+
+## Parallel Example: User Story 1
+
+After Phase 2 completes, the US1 verification is a single sequential git workflow:
+
+```bash
+# Single task T004: follow quickstart §1 in specs/006-commit-lint-auto-fix/quickstart.md
+```
+
+---
+
+## Parallel Example: Polish (Phase 6)
+
+```bash
+# Terminal A — repo lint (T008)
+pnpm run lint
+
+# Terminal B — agent context update (T009)
+powershell -NoProfile -ExecutionPolicy Bypass -File .specify/scripts/powershell/update-agent-context.ps1
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 1: T001  
+2. Complete Phase 2: T002, T003  
+3. Complete Phase 3: T004 (US1 verification)  
+4. **STOP and VALIDATE**: US1 acceptance passes  
+
+### Incremental Delivery
+
+1. Setup + Foundational → hook behavior ready  
+2. Add US1 verification → demo MVP  
+3. Add US2 verification → blocked-commit clarity  
+4. Add US3 verification → message gate unchanged  
+5. Polish: CI alignment + agent context  
+
+### Parallel Team Strategy
+
+- Developer A: Phase 1–2 implementation  
+- After Phase 2: Developer B runs US1 manual path while Developer C prepares US2/US3 scenarios on separate branches (avoid concurrent commits on one working tree)  
+
+---
+
+## Notes
+
+- Do not use `git commit --no-verify` for acceptance unless documenting the escape hatch in `specs/006-commit-lint-auto-fix/quickstart.md`  
+- Partial staging caveats: see `specs/006-commit-lint-auto-fix/research.md`  
+- All tasks use checklist format: `- [ ] [TaskID] [P?] [Story?] Description with file path`


### PR DESCRIPTION
## Context & Objective

This change delivers **spec 006 — commit lint auto-fix**: automatically format and fix lint issues on staged files before a commit, so contributors get fast feedback and fewer CI failures from Biome. It aligns the repo with the existing Conventional Commits / commitlint workflow by fixing code style at commit time instead of only at review or CI.

## Core Changes

- **Pre-commit hook**: `.husky/pre-commit` now runs `pnpm exec lint-staged` (minimal shell script with `set -e`).
- **lint-staged**: Root `package.json` configures `lint-staged` to run `pnpm exec biome check --write` on staged files under `apps/**` and `packages/**`.
- **Dependencies**: Adds `lint-staged` and updates `pnpm-lock.yaml`; root `engines` / Volta remain Node 24.x and pnpm 9.x as specified for this feature.
- **Documentation & contracts**: Adds `specs/006-commit-lint-auto-fix/` (spec, plan, tasks, research, quickstart, data-model), `contracts/commit-hook.contract.md`, requirements checklist, and updates `.cursor/rules/specify-rules.mdc` for the new stack notes.

## Testing & Notes

- **Manual checks**: Stage a file under `apps/` or `packages/`, run `git commit` (or a dry run if you use `--no-verify` only for debugging); confirm `lint-staged` runs Biome on staged paths and that intentionally fixable issues are written before commitlint runs.
- **Edge cases**: Files outside `apps/**` and `packages/**` are not covered by lint-staged; root-only edits may need `pnpm lint:fix` manually. If `lint-staged` or Biome modifies files, the commit may need a second stage/commit cycle — reviewers should be aware.
- **Remote sync**: `git fetch origin` failed in this environment (SSH timeout); before merging, fetch and rebase onto latest `origin/main` if the remote has moved.