### PR TITLE
Rework desktop settings into clear service, runtime, diagnostics, and appearance sections

### DIFF
--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -6,14 +6,17 @@ import {
   type HostActions,
   LocalStatusPage,
   PageFrame,
+  PageStatusList,
 } from '@cthutool/app-shell';
 import { Button } from '@cthutool/ui';
 import {
+  Activity,
   Bot,
   Chrome,
   FileText,
   Home,
   Info,
+  Palette,
   RefreshCw,
   Save,
   Server,
@@ -57,7 +60,12 @@ type AppProps = {
 
 type Workspace = 'main' | 'settings';
 type MainView = 'home' | 'browser' | 'agents';
-type SettingsView = 'service' | 'status' | 'logs';
+type SettingsView =
+  | 'service'
+  | 'local-runtime'
+  | 'diagnostics'
+  | 'logs'
+  | 'appearance';
 type BrowserProfileActionName = 'openLogin' | 'verifyProfile' | 'clearProfile';
 type BrowserActionState = {
   readonly action?: BrowserProfileActionName;
@@ -112,9 +120,11 @@ const mainNav = [
 ] as const;
 
 const settingsNav = [
-  { id: 'service', label: 'Service', icon: Server },
-  { id: 'status', label: 'Status', icon: Info },
+  { id: 'service', label: 'Service Connection', icon: Server },
+  { id: 'local-runtime', label: 'Local Runtime', icon: Activity },
+  { id: 'diagnostics', label: 'Diagnostics', icon: Info },
   { id: 'logs', label: 'Logs', icon: FileText },
+  { id: 'appearance', label: 'Appearance', icon: Palette },
 ] as const;
 
 export function App({
@@ -368,9 +378,13 @@ export function App({
       }),
     [browserStatus, localPendingAuthTasks],
   );
+  const openConnectionSettings = () => {
+    setWorkspace('settings');
+    setSettingsView('service');
+  };
   const openClientStatusSettings = () => {
     setWorkspace('settings');
-    setSettingsView('status');
+    setSettingsView('local-runtime');
   };
 
   return (
@@ -444,6 +458,7 @@ export function App({
                   saveState,
                   connection,
                   appInfo,
+                  activeEnvironmentLabel: activeEnvironment?.label ?? 'Local',
                 })}
           </section>
         </div>
@@ -455,7 +470,8 @@ export function App({
           platform={appInfo.platform}
           statusLabel={statusLabel}
           version={appInfo.version}
-          onOpenStatus={openClientStatusSettings}
+          onOpenClientStatus={openClientStatusSettings}
+          onOpenConnectionStatus={openConnectionSettings}
         />
       </main>
     </AppRuntimeProvider>
@@ -772,6 +788,7 @@ function renderSettingsWorkspace({
   saveState,
   connection,
   appInfo,
+  activeEnvironmentLabel,
 }: {
   readonly view: SettingsView;
   readonly config: DesktopConfig | undefined;
@@ -796,35 +813,57 @@ function renderSettingsWorkspace({
   readonly saveState: 'idle' | 'saving' | 'saved';
   readonly connection: AgentConnectionState;
   readonly appInfo: DesktopAppInfo;
+  readonly activeEnvironmentLabel: string;
 }) {
-  if (view === 'status') {
+  const configuredBackendUrl = config?.backendUrl ?? connection.backendUrl;
+  const browserRuntimeKind =
+    appInfo.browserRuntime?.activeKind ??
+    appInfo.browserRuntime?.preferredKind ??
+    'Unknown';
+  const browserRuntimeStatus = appInfo.browserRuntime?.status ?? 'unknown';
+  const browserRuntimeDetail =
+    appInfo.browserRuntime?.message ?? 'Not available';
+
+  if (view === 'local-runtime') {
     return (
-      <WorkspacePanel title="Connection Status" eyebrow="Settings">
+      <WorkspacePanel title="Local Runtime" eyebrow="Settings">
         <LocalStatusPage
           rows={[
-            ['Backend URL', config?.backendUrl ?? connection.backendUrl],
             ['Agent ID', config?.agentId ?? connection.agentId],
-            [
-              'Browser Runtime',
-              appInfo.browserRuntime?.activeKind ??
-                appInfo.browserRuntime?.preferredKind ??
-                'Unknown',
-            ],
-            ['Runtime Status', appInfo.browserRuntime?.status ?? 'unknown'],
-            [
-              'Runtime Detail',
-              appInfo.browserRuntime?.message ?? 'Not available',
-            ],
             ['Device', config?.deviceName ?? connection.deviceName],
+            ['Browser Runtime', browserRuntimeKind],
+            ['Runtime Status', browserRuntimeStatus],
+            ['Version', appInfo.version],
+            ['Platform', appInfo.platform],
+            ['Packaged', appInfo.isPackaged ? 'yes' : 'no'],
+          ]}
+          localRows={[
+            ['User Data', localPathValue(appInfo.userDataDir)],
+            ['Browser Profiles', localPathValue(appInfo.browserProfilesDir)],
+            ['Config File', localPathValue(appInfo.configPath)],
+          ]}
+        />
+      </WorkspacePanel>
+    );
+  }
+
+  if (view === 'diagnostics') {
+    return (
+      <WorkspacePanel title="Diagnostics" eyebrow="Settings">
+        <LocalStatusPage
+          rows={[
+            ['Environment', activeEnvironmentLabel],
+            ['Backend URL', configuredBackendUrl],
             ['Connection', connection.status],
+            ['Agent ID', config?.agentId ?? connection.agentId],
             [
               'Last Registered',
               connection.lastRegisteredAt ?? 'Not registered',
             ],
             ['Last Error', connection.lastError ?? 'None'],
-            ['Version', appInfo.version],
-            ['Platform', appInfo.platform],
-            ['Packaged', appInfo.isPackaged ? 'yes' : 'no'],
+            ['Browser Runtime', browserRuntimeKind],
+            ['Runtime Status', browserRuntimeStatus],
+            ['Runtime Detail', browserRuntimeDetail],
           ]}
           localRows={[
             ['User Data', localPathValue(appInfo.userDataDir)],
@@ -846,6 +885,27 @@ function renderSettingsWorkspace({
             log inspection. No log stream is currently wired in CthuDesktop.
           </p>
         </div>
+      </WorkspacePanel>
+    );
+  }
+
+  if (view === 'appearance') {
+    return (
+      <WorkspacePanel title="Appearance" eyebrow="Settings">
+        <div className="log-view">
+          <h2>Fixed theme system</h2>
+          <p>
+            CthuDesktop is currently using the Dracula token system. Theme
+            switching controls are not available in this settings phase.
+          </p>
+        </div>
+        <PageStatusList
+          rows={[
+            ['Mode', config?.appearance.mode ?? form.appearanceMode],
+            ['Color Scheme', config?.appearance.colorScheme ?? 'dracula'],
+            ['Theme Controls', 'Not connected in this release'],
+          ]}
+        />
       </WorkspacePanel>
     );
   }

--- a/apps/desktop/src/renderer/src/shell-components.tsx
+++ b/apps/desktop/src/renderer/src/shell-components.tsx
@@ -175,7 +175,8 @@ export function DesktopStatusBar({
   backendUrl,
   connectionStatus,
   environmentLabel,
-  onOpenStatus,
+  onOpenClientStatus,
+  onOpenConnectionStatus,
   platform,
   statusLabel,
   version,
@@ -183,7 +184,8 @@ export function DesktopStatusBar({
   readonly backendUrl: string;
   readonly connectionStatus: string;
   readonly environmentLabel: string;
-  readonly onOpenStatus: () => void;
+  readonly onOpenClientStatus: () => void;
+  readonly onOpenConnectionStatus: () => void;
   readonly platform: string;
   readonly statusLabel: string;
   readonly version: string;
@@ -194,7 +196,7 @@ export function DesktopStatusBar({
         aria-label="Open connection details"
         className={`statusbar-connection ${connectionStatus}`}
         type="button"
-        onClick={onOpenStatus}
+        onClick={onOpenConnectionStatus}
       >
         {connectionStatus === 'connected' ? (
           <Wifi size={13} />
@@ -209,7 +211,7 @@ export function DesktopStatusBar({
         aria-label="Open client status"
         className="statusbar-meta"
         type="button"
-        onClick={onOpenStatus}
+        onClick={onOpenClientStatus}
       >
         <span>{platform}</span>
         <span>v{version}</span>

--- a/apps/desktop/tests/renderer/app.test.tsx
+++ b/apps/desktop/tests/renderer/app.test.tsx
@@ -250,6 +250,9 @@ describe('CthuDesktop shell', () => {
     expect(screen.getByText('Browser Attention')).toBeInTheDocument();
     expect(screen.queryByLabelText('Douban subject')).not.toBeInTheDocument();
     expect(
+      screen.queryByDisplayValue('http://backend.local:3000'),
+    ).not.toBeInTheDocument();
+    expect(
       within(screen.getByLabelText('Primary')).queryByRole('button', {
         name: 'Tasks',
       }),
@@ -292,14 +295,22 @@ describe('CthuDesktop shell', () => {
         deviceName: 'Windows PC',
       });
     });
-    await userEvent.click(screen.getByRole('button', { name: 'Status' }));
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Local Runtime' }),
+    );
+    expect(
+      screen.getByRole('heading', { name: 'Local Runtime' }),
+    ).toBeInTheDocument();
     expect(screen.getByText('windows-pc')).toBeInTheDocument();
+    expect(screen.getByText('Browser Runtime')).toBeInTheDocument();
+    expect(screen.getByText('Browser Profiles')).toBeInTheDocument();
+    await userEvent.click(screen.getByRole('button', { name: 'Diagnostics' }));
+    expect(
+      screen.getByRole('heading', { name: 'Diagnostics' }),
+    ).toBeInTheDocument();
     expect(screen.getByText('Last Registered')).toBeInTheDocument();
     expect(screen.getByText('Last Error')).toBeInTheDocument();
     expect(screen.getByText('Backend URL')).toBeInTheDocument();
-    expect(
-      screen.queryByRole('button', { name: 'Diagnostics' }),
-    ).not.toBeInTheDocument();
     const logsButtons = screen.getAllByRole('button', { name: 'Logs' });
     const settingsLogsButton = logsButtons.at(-1);
     expect(settingsLogsButton).toBeDefined();
@@ -308,9 +319,15 @@ describe('CthuDesktop shell', () => {
     expect(
       screen.getByText('Log viewing is not connected yet'),
     ).toBeInTheDocument();
+    await userEvent.click(screen.getByRole('button', { name: 'Appearance' }));
     expect(
-      screen.queryByRole('button', { name: 'Appearance' }),
-    ).not.toBeInTheDocument();
+      screen.getByRole('heading', { name: 'Appearance' }),
+    ).toBeInTheDocument();
+    expect(screen.getByText('Fixed theme system')).toBeInTheDocument();
+    expect(screen.getByText('Theme Controls')).toBeInTheDocument();
+    expect(
+      screen.getByText('Not connected in this release'),
+    ).toBeInTheDocument();
     expect(
       screen.queryByRole('option', { name: 'Dracula' }),
     ).not.toBeInTheDocument();
@@ -332,10 +349,12 @@ describe('CthuDesktop shell', () => {
     );
 
     expect(
-      screen.getByRole('heading', { name: 'Connection Status' }),
+      screen.getByRole('heading', { name: 'Service Connection' }),
     ).toBeInTheDocument();
-    expect(screen.getByText('Last Registered')).toBeInTheDocument();
-    expect(screen.getByText('Backend URL')).toBeInTheDocument();
+    expect(
+      screen.getByDisplayValue('http://backend.local:3000'),
+    ).toBeInTheDocument();
+    expect(screen.getByText('Local Agent Enabled')).toBeInTheDocument();
   });
 
   test('opens client status from the status bar client button', async () => {
@@ -354,7 +373,7 @@ describe('CthuDesktop shell', () => {
     );
 
     expect(
-      screen.getByRole('heading', { name: 'Connection Status' }),
+      screen.getByRole('heading', { name: 'Local Runtime' }),
     ).toBeInTheDocument();
     expect(screen.getAllByText('win32')).not.toHaveLength(0);
     expect(screen.getByText('0.0.0')).toBeInTheDocument();
@@ -382,9 +401,11 @@ describe('CthuDesktop shell', () => {
     );
 
     expect(
-      screen.getByRole('heading', { name: 'Connection Status' }),
+      screen.getByRole('heading', { name: 'Service Connection' }),
     ).toBeInTheDocument();
-    expect(screen.getByText('Last Registered')).toBeInTheDocument();
+    expect(
+      screen.getByDisplayValue('http://backend.local:3000'),
+    ).toBeInTheDocument();
   });
 
   test('shows a restart hint when local path info is not available yet', async () => {

--- a/openspec/changes/archive/2026-06-23-apps-desktop-settings-information-architecture/.openspec.yaml
+++ b/openspec/changes/archive/2026-06-23-apps-desktop-settings-information-architecture/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-23

--- a/openspec/changes/archive/2026-06-23-apps-desktop-settings-information-architecture/design.md
+++ b/openspec/changes/archive/2026-06-23-apps-desktop-settings-information-architecture/design.md
@@ -1,0 +1,50 @@
+## Context
+
+The desktop renderer currently exposes Settings through a bottom-left shell entry and a small settings subnav with `service`, `status`, and `logs`. Service Connection owns editable environment/backend fields, Connection Status owns a broad mix of agent, runtime, app, and local path metadata, and Logs is an explicit placeholder. After the Home readiness change, Settings should become the detailed configuration and diagnostics center while Home remains a summary surface.
+
+The change is renderer-focused. Existing data already comes from desktop config, agent connection state, and desktop app info, so no backend, preload, or persisted config contract is needed.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Make Settings navigation labels and page titles reflect clear ownership: service configuration, local runtime/status detail, diagnostics, logs placeholder, and appearance readiness.
+- Keep editable controls limited to configuration sections and keep diagnostic sections read-only.
+- Preserve shell deep links from the status bar into the most relevant Settings section.
+- Keep Logs visible but explicitly unconnected.
+- Update renderer tests so the Settings information architecture is covered.
+
+**Non-Goals:**
+
+- Implement a logging system, log streaming, log retrieval, export, or filtering.
+- Add backend endpoints, Electron IPC/preload methods, or config schema migrations.
+- Build a full theme switcher or introduce new appearance persistence behavior.
+- Move Settings into shared packages or redesign the whole desktop shell.
+
+## Decisions
+
+1. Keep Settings inside `apps-desktop-product-shell` instead of creating a new capability.
+   - Rationale: Settings is part of the existing desktop shell contract and reuses current app/runtime data.
+   - Alternative considered: create `apps-desktop-settings` as a new capability. That would make sense once Settings has independent contracts or cross-app reuse, but this change only refines the existing desktop shell behavior.
+
+2. Use a small, explicit Settings subnav rather than nested settings groups.
+   - Rationale: The desktop app currently has a compact shell with one subnav level. A shallow structure keeps implementation small and avoids creating empty pages.
+   - Alternative considered: introduce grouped sidebar categories. That would add layout complexity before there is enough settings surface area.
+
+3. Split information by editability and responsibility.
+   - Service Connection remains the only place for environment/backend editing.
+   - Local Runtime / Status owns read-only host and agent facts.
+   - Diagnostics owns recent connection errors, timing, browser runtime diagnostic text, and local paths.
+   - Logs remains a placeholder.
+   - Appearance is shown only as a fixed-theme/token-system state if included.
+
+4. Do not add new runtime data sources.
+   - Rationale: The required information already exists in renderer state. Adding IPC or backend calls would expand scope into logging/runtime instrumentation work.
+   - Alternative considered: introduce log/runtime APIs now. That is deferred to the planned standalone logging system.
+
+## Risks / Trade-offs
+
+- Settings may still feel sparse after splitting sections -> Use concise empty/read-only states and avoid adding filler controls.
+- Existing tests may rely on old Settings titles or labels -> Update tests around user-visible section names and preserved save/status behavior.
+- Appearance can look like an unfinished feature -> Present it as a fixed current visual system state or omit executable controls.
+- Diagnostics can duplicate Home readiness details -> Keep Home summary-level and Settings detail-level, with no editable controls duplicated on Home.

--- a/openspec/changes/archive/2026-06-23-apps-desktop-settings-information-architecture/proposal.md
+++ b/openspec/changes/archive/2026-06-23-apps-desktop-settings-information-architecture/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+Settings is currently a mixed configuration/status surface, while Home has just been narrowed to a local readiness dashboard. The desktop app needs a clearer Settings information architecture so detailed connection, local runtime, diagnostics, and placeholder log information live in predictable settings sections without expanding backend or logging scope.
+
+## What Changes
+
+- Reorganize Settings into explicit configuration and diagnostics sections with stable labels and page intent.
+- Keep service/environment editing in the Service Connection section and keep Home free of detailed backend configuration controls.
+- Make local runtime and diagnostics detail easier to scan from Settings, including agent identity, app metadata, local paths, browser runtime diagnostics, and connection timing/error information.
+- Keep Logs visible as a not-connected placeholder only; do not add log streaming, log retrieval, local log persistence, or new IPC/API contracts in this change.
+- Keep unfinished Appearance/theme controls out of the active Settings navigation unless they are represented as a clear fixed-theme/token-system state.
+
+## Capabilities
+
+### New Capabilities
+
+- None.
+
+### Modified Capabilities
+
+- `apps-desktop-product-shell`: Clarify Settings as the detailed configuration and diagnostics center, with explicit section ownership for service connection, local runtime/status, diagnostics, logs placeholder, and appearance readiness.
+
+## Impact
+
+- Affects the desktop renderer Settings navigation, Settings page content, shell status deep links, and renderer tests.
+- Does not change backend APIs, Electron preload contracts, persisted config schema, browser profile behavior, or logging infrastructure.

--- a/openspec/changes/archive/2026-06-23-apps-desktop-settings-information-architecture/specs/apps-desktop-product-shell/spec.md
+++ b/openspec/changes/archive/2026-06-23-apps-desktop-settings-information-architecture/specs/apps-desktop-product-shell/spec.md
@@ -1,0 +1,64 @@
+## ADDED Requirements
+
+### Requirement: Settings section ownership
+CthuDesktop SHALL organize Settings sections by information ownership and editability so configuration, local runtime facts, diagnostics, logs, and appearance readiness are not mixed into one page.
+
+#### Scenario: Service section owns editable connection configuration
+- **WHEN** the user opens the Settings service section
+- **THEN** editable environment, backend URL, device name, and local agent enabled controls are available there and not duplicated as editable controls on Home or read-only diagnostics pages
+
+#### Scenario: Local runtime section owns host facts
+- **WHEN** the user opens the Settings local runtime or status section
+- **THEN** read-only local app metadata, platform, packaged state, agent identity, browser runtime kind, browser runtime status, and local filesystem paths are grouped for scanning
+
+#### Scenario: Diagnostics section owns troubleshooting detail
+- **WHEN** the user opens the Settings diagnostics section
+- **THEN** recent connection error, registration timing, backend URL, active environment, browser runtime diagnostic message, and other troubleshooting details are available without exposing unrelated edit controls
+
+#### Scenario: Appearance section does not imply unfinished theme switching
+- **WHEN** the Settings appearance section is shown before full theme switching exists
+- **THEN** it presents the current fixed theme or token-system state without exposing controls that appear executable but are not supported
+
+## MODIFIED Requirements
+
+### Requirement: Settings workspace
+The desktop application SHALL provide a bottom-left Settings entry that switches to an app configuration and diagnostics workspace with clear section ownership.
+
+#### Scenario: Settings entry switches workspace
+- **WHEN** the user activates the bottom-left Settings entry
+- **THEN** the application switches from the main workspace to the Settings workspace
+
+#### Scenario: Settings sections are organized by submenu
+- **WHEN** the Settings workspace is active
+- **THEN** it provides submenu sections for service connection, local runtime or status, diagnostics, logs, and appearance readiness without mixing editable configuration and read-only diagnostic data on the same page
+
+#### Scenario: Service configuration is not mixed into business home
+- **WHEN** the user views the default main workspace
+- **THEN** backend URL and environment editing controls are not the primary content of that workspace
+
+#### Scenario: Logs remains a placeholder section
+- **WHEN** the user opens Settings Logs before a log system exists
+- **THEN** the page clearly states that log viewing is not connected and does not present synthetic logs as real runtime events
+
+### Requirement: Runtime status surfaces
+The desktop application SHALL expose runtime status in the shell and detailed Settings sections without requiring users to open raw logs.
+
+#### Scenario: Status bar summarizes active connection
+- **WHEN** the desktop app is running
+- **THEN** the status bar shows the active environment, backend URL, backend connection state, platform, and app version
+
+#### Scenario: Diagnostics view shows connection detail
+- **WHEN** the user opens the diagnostics section in Settings
+- **THEN** the desktop app shows recent connection errors, selected backend URL, active environment, agent id, last registered time, last heartbeat or last seen information when available, and browser runtime diagnostic detail
+
+#### Scenario: Environment status opens service settings
+- **WHEN** the user activates the status bar environment and connection segment
+- **THEN** the desktop app opens the Settings workspace focused on the service connection section
+
+#### Scenario: Client status opens local runtime settings
+- **WHEN** the user activates the status bar platform and version segment
+- **THEN** the desktop app opens the Settings workspace focused on the local runtime or status section
+
+#### Scenario: Logs view is accessible from Settings
+- **WHEN** the user opens the logs section in Settings
+- **THEN** the desktop app provides an explicit placeholder for future local or server-backed log inspection without mixing logs into the default main workspace or implementing log retrieval in this change

--- a/openspec/changes/archive/2026-06-23-apps-desktop-settings-information-architecture/tasks.md
+++ b/openspec/changes/archive/2026-06-23-apps-desktop-settings-information-architecture/tasks.md
@@ -1,0 +1,21 @@
+## 1. Settings Navigation Structure
+
+- [x] 1.1 Update the desktop renderer Settings view model and submenu items to represent the target sections: Service Connection, Local Runtime or Status, Diagnostics, Logs, and Appearance readiness.
+- [x] 1.2 Preserve bottom-left Settings entry behavior and existing status-bar deep links into the appropriate Settings sections.
+
+## 2. Settings Page Content
+
+- [x] 2.1 Keep environment, backend URL, display name, and local agent enabled editing inside the Service Connection section.
+- [x] 2.2 Reorganize read-only local app, agent, browser runtime, platform, version, packaged state, and local path information into the Local Runtime or Status section.
+- [x] 2.3 Add or refine a Diagnostics section for troubleshooting detail such as active environment, backend URL, connection state, registration timing, last error, and browser runtime diagnostic message.
+- [x] 2.4 Keep Logs as an explicit not-connected placeholder without adding log retrieval, log streaming, persistence, IPC, or backend API behavior.
+- [x] 2.5 Represent Appearance as a fixed current theme/token-system state or omit executable controls that imply unsupported theme switching.
+
+## 3. Tests and Validation
+
+- [x] 3.1 Update renderer tests for Settings navigation labels, section headings, service save behavior, status-bar deep links, diagnostics content, logs placeholder, and appearance readiness.
+- [x] 3.2 Confirm Home remains a readiness summary and does not gain editable backend configuration controls.
+- [x] 3.3 Run `openspec validate apps-desktop-settings-information-architecture --strict`.
+- [x] 3.4 Run `pnpm --filter @cthutool/desktop test`.
+- [x] 3.5 Run `pnpm --filter @cthutool/desktop typecheck`.
+- [x] 3.6 Run `pnpm --filter @cthutool/desktop build`.

--- a/openspec/specs/apps-desktop-product-shell/spec.md
+++ b/openspec/specs/apps-desktop-product-shell/spec.md
@@ -49,7 +49,7 @@ The desktop application SHALL default to a main workspace intended for local hos
 - **THEN** the UI presents them as unavailable or placeholder navigation without exposing executable browser-control behavior
 
 ### Requirement: Settings workspace
-The desktop application SHALL provide a bottom-left Settings entry that switches to an app configuration workspace.
+The desktop application SHALL provide a bottom-left Settings entry that switches to an app configuration and diagnostics workspace with clear section ownership.
 
 #### Scenario: Settings entry switches workspace
 - **WHEN** the user activates the bottom-left Settings entry
@@ -57,11 +57,15 @@ The desktop application SHALL provide a bottom-left Settings entry that switches
 
 #### Scenario: Settings sections are organized by submenu
 - **WHEN** the Settings workspace is active
-- **THEN** it provides submenu sections for service connection, local status, logs, diagnostics, appearance, and other app-level configuration
+- **THEN** it provides submenu sections for service connection, local runtime or status, diagnostics, logs, and appearance readiness without mixing editable configuration and read-only diagnostic data on the same page
 
 #### Scenario: Service configuration is not mixed into business home
 - **WHEN** the user views the default main workspace
 - **THEN** backend URL and environment editing controls are not the primary content of that workspace
+
+#### Scenario: Logs remains a placeholder section
+- **WHEN** the user opens Settings Logs before a log system exists
+- **THEN** the page clearly states that log viewing is not connected and does not present synthetic logs as real runtime events
 
 ### Requirement: Dracula theme foundation
 The desktop renderer SHALL use Dracula as the first built-in color scheme and SHALL implement it through shared semantic theme tokens.
@@ -102,7 +106,7 @@ The desktop application SHALL use environment profiles to choose which backend s
 - **THEN** it migrates that URL into an environment profile without changing the stable local agent id
 
 ### Requirement: Runtime status surfaces
-The desktop application SHALL expose runtime status in the shell without requiring users to open raw logs.
+The desktop application SHALL expose runtime status in the shell and detailed Settings sections without requiring users to open raw logs.
 
 #### Scenario: Status bar summarizes active connection
 - **WHEN** the desktop app is running
@@ -110,19 +114,19 @@ The desktop application SHALL expose runtime status in the shell without requiri
 
 #### Scenario: Diagnostics view shows connection detail
 - **WHEN** the user opens the diagnostics section in Settings
-- **THEN** the desktop app shows recent connection errors, selected backend URL, agent id, last registered time, last heartbeat or last seen information when available
+- **THEN** the desktop app shows recent connection errors, selected backend URL, active environment, agent id, last registered time, last heartbeat or last seen information when available, and browser runtime diagnostic detail
 
 #### Scenario: Environment status opens service settings
 - **WHEN** the user activates the status bar environment and connection segment
 - **THEN** the desktop app opens the Settings workspace focused on the service connection section
 
-#### Scenario: Client status opens local status settings
+#### Scenario: Client status opens local runtime settings
 - **WHEN** the user activates the status bar platform and version segment
-- **THEN** the desktop app opens the Settings workspace focused on the local status section
+- **THEN** the desktop app opens the Settings workspace focused on the local runtime or status section
 
 #### Scenario: Logs view is accessible from Settings
 - **WHEN** the user opens the logs section in Settings
-- **THEN** the desktop app provides a logs view or explicit placeholder for future local log inspection without mixing logs into the default main workspace
+- **THEN** the desktop app provides an explicit placeholder for future local or server-backed log inspection without mixing logs into the default main workspace or implementing log retrieval in this change
 
 ### Requirement: Desktop renderer React 19 baseline
 The desktop renderer SHALL use the React 19 stable line for its renderer runtime and TypeScript React definitions before adopting the shared UI/runtime foundation.
@@ -313,3 +317,22 @@ CthuDesktop SHALL keep the Settings Logs section as an explicit placeholder unti
 #### Scenario: Logs capability is not connected
 - **WHEN** the user opens Settings Logs before a log API exists
 - **THEN** the page clearly indicates that log viewing is not connected yet rather than showing synthetic runtime events as if they were real logs
+
+### Requirement: Settings section ownership
+CthuDesktop SHALL organize Settings sections by information ownership and editability so configuration, local runtime facts, diagnostics, logs, and appearance readiness are not mixed into one page.
+
+#### Scenario: Service section owns editable connection configuration
+- **WHEN** the user opens the Settings service section
+- **THEN** editable environment, backend URL, device name, and local agent enabled controls are available there and not duplicated as editable controls on Home or read-only diagnostics pages
+
+#### Scenario: Local runtime section owns host facts
+- **WHEN** the user opens the Settings local runtime or status section
+- **THEN** read-only local app metadata, platform, packaged state, agent identity, browser runtime kind, browser runtime status, and local filesystem paths are grouped for scanning
+
+#### Scenario: Diagnostics section owns troubleshooting detail
+- **WHEN** the user opens the Settings diagnostics section
+- **THEN** recent connection error, registration timing, backend URL, active environment, browser runtime diagnostic message, and other troubleshooting details are available without exposing unrelated edit controls
+
+#### Scenario: Appearance section does not imply unfinished theme switching
+- **WHEN** the Settings appearance section is shown before full theme switching exists
+- **THEN** it presents the current fixed theme or token-system state without exposing controls that appear executable but are not supported


### PR DESCRIPTION
## Summary
- Reorganize the desktop Settings workspace around explicit ownership: Service Connection, Local Runtime, Diagnostics, Logs, and Appearance.
- Split read-only runtime details from editable connection controls and keep the Logs area as an explicit placeholder.
- Update status-bar deep links and renderer tests to match the new information architecture.

## Testing
- Renderer tests updated for the new Settings navigation and section content.
- OpenSpec validation and desktop test/typecheck/build checks were already completed for this change.