### PR TITLE
Add GitOps observability stack for Grafana, Loki, Prometheus, and Alloy

### DIFF
--- a/gitops/README.md
+++ b/gitops/README.md
@@ -10,6 +10,7 @@ gitops/
 ├── apps/                # ArgoCD Application CRs (one subdirectory per app)
 │   └── <app-name>/
 │       └── application.yaml
+├── observability/       # Observability stack docs and extension points
 ├── bootstrap/           # ArgoCD self-install manifests (future)
 └── README.md
 ```
@@ -21,6 +22,7 @@ gitops/
 - **Auto-sync**: Applications are configured with automated sync (`prune: true`, `selfHeal: true`). ArgoCD polls git every **3 minutes** by default and reconciles any drift.
 - **Retry**: A `syncPolicy.retry` block with exponential backoff (up to 3 minutes) handles transient failures — once the app repo's manifests are valid, the Application self-recovers without manual intervention.
 - **Drift correction**: If a resource is manually edited on the cluster via `kubectl edit`, ArgoCD reverts it within minutes. Edit manifests in git, not the live cluster.
+- **Observability**: Prometheus, Grafana, Loki, and Alloy are managed through upstream chart Applications. See `gitops/observability/README.md` for the metrics, logs, dashboard, and future telemetry ingestion boundaries.
 
 ## Setup
 
@@ -66,3 +68,4 @@ Once applied, ArgoCD discovers the Application CRs from the cluster side and beg
 |-----|-----------|-------------|
 | CthuTool | `cthutool` | [mickmetalholic/CthuTool](https://github.com/mickmetalholic/CthuTool) (self-hosted) |
 | PixelPlayground | `pixel-playground` | [mickmetalholic/PixelPlayground](https://github.com/mickmetalholic/PixelPlayground) |
+| Observability | `observability` | Upstream Helm charts managed by Applications in this repo |

--- a/gitops/apps/observability-alloy/application.yaml
+++ b/gitops/apps/observability-alloy/application.yaml
@@ -1,0 +1,83 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: observability-alloy
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://grafana.github.io/helm-charts
+    chart: alloy
+    targetRevision: 1.10.0
+    helm:
+      releaseName: alloy
+      values: |
+        controller:
+          type: daemonset
+
+        alloy:
+          configMap:
+            create: true
+            content: |-
+              discovery.kubernetes "pods" {
+                role = "pod"
+              }
+
+              discovery.relabel "cthutool_pods" {
+                targets = discovery.kubernetes.pods.targets
+
+                rule {
+                  source_labels = ["__meta_kubernetes_namespace"]
+                  regex = "cthutool"
+                  action = "keep"
+                }
+
+                rule {
+                  source_labels = ["__meta_kubernetes_namespace"]
+                  target_label = "namespace"
+                }
+
+                rule {
+                  source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_part_of"]
+                  target_label = "app"
+                }
+
+                rule {
+                  source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_component"]
+                  target_label = "component"
+                }
+
+                rule {
+                  source_labels = ["__meta_kubernetes_pod_name"]
+                  target_label = "pod"
+                }
+
+                rule {
+                  source_labels = ["__meta_kubernetes_pod_container_name"]
+                  target_label = "container"
+                }
+              }
+
+              loki.source.kubernetes "cthutool_pods" {
+                targets = discovery.relabel.cthutool_pods.output
+                forward_to = [loki.write.default.receiver]
+              }
+
+              loki.write "default" {
+                endpoint {
+                  url = "http://loki-gateway.observability.svc.cluster.local/loki/api/v1/push"
+                }
+              }
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: observability
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    retry:
+      limit: 5
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 3m

--- a/gitops/apps/observability-kube-prometheus-stack/application.yaml
+++ b/gitops/apps/observability-kube-prometheus-stack/application.yaml
@@ -1,0 +1,298 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: observability-kube-prometheus-stack
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://prometheus-community.github.io/helm-charts
+    chart: kube-prometheus-stack
+    targetRevision: 87.2.1
+    helm:
+      releaseName: kube-prometheus-stack
+      values: |
+        fullnameOverride: kube-prometheus-stack
+
+        alertmanager:
+          enabled: true
+          service:
+            type: ClusterIP
+
+        grafana:
+          enabled: true
+          service:
+            type: ClusterIP
+          sidecar:
+            dashboards:
+              enabled: true
+              label: grafana_dashboard
+            datasources:
+              enabled: true
+              defaultDatasourceEnabled: true
+              uid: prometheus
+          additionalDataSources:
+            - name: Loki
+              uid: loki
+              type: loki
+              access: proxy
+              url: http://loki-gateway.observability.svc.cluster.local
+              isDefault: false
+          dashboards:
+            default:
+              cthutool-workloads:
+                json: |
+                  {
+                    "annotations": {
+                      "list": []
+                    },
+                    "editable": true,
+                    "fiscalYearStartMonth": 0,
+                    "graphTooltip": 0,
+                    "id": null,
+                    "links": [
+                      {
+                        "targetBlank": false,
+                        "title": "CthuTool backend logs",
+                        "type": "link",
+                        "url": "/explore?left={\"datasource\":\"loki\",\"queries\":[{\"expr\":\"{namespace=\\\"cthutool\\\",app=\\\"cthutool\\\",component=\\\"backend\\\"}\"}],\"range\":{\"from\":\"now-1h\",\"to\":\"now\"}}"
+                      }
+                    ],
+                    "panels": [
+                      {
+                        "datasource": {
+                          "type": "prometheus",
+                          "uid": "prometheus"
+                        },
+                        "fieldConfig": {
+                          "defaults": {
+                            "color": {
+                              "mode": "thresholds"
+                            },
+                            "thresholds": {
+                              "mode": "absolute",
+                              "steps": [
+                                {
+                                  "color": "red",
+                                  "value": null
+                                },
+                                {
+                                  "color": "green",
+                                  "value": 1
+                                }
+                              ]
+                            }
+                          },
+                          "overrides": []
+                        },
+                        "gridPos": {
+                          "h": 8,
+                          "w": 8,
+                          "x": 0,
+                          "y": 0
+                        },
+                        "id": 1,
+                        "options": {
+                          "colorMode": "value",
+                          "graphMode": "area",
+                          "justifyMode": "auto",
+                          "orientation": "auto",
+                          "reduceOptions": {
+                            "calcs": [
+                              "lastNotNull"
+                            ],
+                            "fields": "",
+                            "values": false
+                          },
+                          "showPercentChange": false,
+                          "textMode": "auto",
+                          "wideLayout": true
+                        },
+                        "pluginVersion": "12.2.1",
+                        "targets": [
+                          {
+                            "datasource": {
+                              "type": "prometheus",
+                              "uid": "prometheus"
+                            },
+                            "editorMode": "code",
+                            "expr": "sum(up{namespace=\"cthutool\",service=\"cthutool-backend\"})",
+                            "instant": true,
+                            "legendFormat": "backend targets up",
+                            "range": false,
+                            "refId": "A"
+                          }
+                        ],
+                        "title": "Backend scrape targets up",
+                        "type": "stat"
+                      },
+                      {
+                        "datasource": {
+                          "type": "prometheus",
+                          "uid": "prometheus"
+                        },
+                        "fieldConfig": {
+                          "defaults": {},
+                          "overrides": []
+                        },
+                        "gridPos": {
+                          "h": 8,
+                          "w": 16,
+                          "x": 8,
+                          "y": 0
+                        },
+                        "id": 2,
+                        "options": {
+                          "legend": {
+                            "displayMode": "list",
+                            "placement": "bottom",
+                            "showLegend": true
+                          },
+                          "tooltip": {
+                            "mode": "single",
+                            "sort": "none"
+                          }
+                        },
+                        "targets": [
+                          {
+                            "datasource": {
+                              "type": "prometheus",
+                              "uid": "prometheus"
+                            },
+                            "editorMode": "code",
+                            "expr": "kube_pod_container_status_ready{namespace=\"cthutool\",container=\"backend\"}",
+                            "legendFormat": "{{pod}} ready",
+                            "range": true,
+                            "refId": "A"
+                          }
+                        ],
+                        "title": "Backend pod readiness",
+                        "type": "timeseries"
+                      },
+                      {
+                        "datasource": {
+                          "type": "loki",
+                          "uid": "loki"
+                        },
+                        "gridPos": {
+                          "h": 10,
+                          "w": 24,
+                          "x": 0,
+                          "y": 8
+                        },
+                        "id": 3,
+                        "options": {
+                          "dedupStrategy": "none",
+                          "enableLogDetails": true,
+                          "prettifyLogMessage": true,
+                          "showCommonLabels": false,
+                          "showLabels": false,
+                          "showTime": true,
+                          "sortOrder": "Descending",
+                          "wrapLogMessage": true
+                        },
+                        "targets": [
+                          {
+                            "datasource": {
+                              "type": "loki",
+                              "uid": "loki"
+                            },
+                            "expr": "{namespace=\"cthutool\",app=\"cthutool\",component=\"backend\"}",
+                            "refId": "A"
+                          }
+                        ],
+                        "title": "Backend structured logs",
+                        "type": "logs"
+                      }
+                    ],
+                    "refresh": "30s",
+                    "schemaVersion": 42,
+                    "tags": [
+                      "cthutool",
+                      "kubernetes",
+                      "observability"
+                    ],
+                    "templating": {
+                      "list": []
+                    },
+                    "time": {
+                      "from": "now-1h",
+                      "to": "now"
+                    },
+                    "timezone": "browser",
+                    "title": "CthuTool Kubernetes Workloads",
+                    "uid": "cthutool-k8s-workloads",
+                    "version": 1
+                  }
+
+        prometheus:
+          service:
+            type: ClusterIP
+          prometheusSpec:
+            retention: 7d
+            enableAdminAPI: false
+            ruleSelector:
+              matchLabels:
+                observability.cthutool.io/rule-scope: platform
+            additionalScrapeConfigs:
+              - job_name: cthutool-backend
+                kubernetes_sd_configs:
+                  - role: endpoints
+                    namespaces:
+                      names:
+                        - cthutool
+                relabel_configs:
+                  - source_labels:
+                      - __meta_kubernetes_service_annotation_prometheus_io_scrape
+                    action: keep
+                    regex: "true"
+                  - source_labels:
+                      - __meta_kubernetes_service_annotation_prometheus_io_path
+                    target_label: __metrics_path__
+                    regex: "(.+)"
+                  - source_labels:
+                      - __address__
+                      - __meta_kubernetes_service_annotation_prometheus_io_port
+                    action: replace
+                    regex: "([^:]+)(?::\\d+)?;(\\d+)"
+                    replacement: "$1:$2"
+                    target_label: __address__
+                  - source_labels:
+                      - __meta_kubernetes_namespace
+                    target_label: namespace
+                  - source_labels:
+                      - __meta_kubernetes_service_label_app_kubernetes_io_part_of
+                    target_label: app
+                  - source_labels:
+                      - __meta_kubernetes_service_label_app_kubernetes_io_component
+                    target_label: component
+                  - source_labels:
+                      - __meta_kubernetes_service_name
+                    target_label: service
+                  - source_labels:
+                      - __meta_kubernetes_pod_name
+                    target_label: instance
+
+        prometheusOperator:
+          admissionWebhooks:
+            enabled: true
+
+        kube-state-metrics:
+          metricLabelsAllowlist:
+            - pods=[app.kubernetes.io/name,app.kubernetes.io/part-of,app.kubernetes.io/component]
+            - services=[app.kubernetes.io/name,app.kubernetes.io/part-of,app.kubernetes.io/component]
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: observability
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - ServerSideApply=true
+    retry:
+      limit: 5
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 3m

--- a/gitops/apps/observability-loki/application.yaml
+++ b/gitops/apps/observability-loki/application.yaml
@@ -1,0 +1,72 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: observability-loki
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://grafana.github.io/helm-charts
+    chart: loki
+    targetRevision: 7.0.0
+    helm:
+      releaseName: loki
+      values: |
+        deploymentMode: SingleBinary
+
+        loki:
+          auth_enabled: false
+          commonConfig:
+            replication_factor: 1
+          limits_config:
+            retention_period: 168h
+          schemaConfig:
+            configs:
+              - from: "2026-01-01"
+                store: tsdb
+                object_store: filesystem
+                schema: v13
+                index:
+                  prefix: loki_index_
+                  period: 24h
+          storage:
+            type: filesystem
+
+        singleBinary:
+          replicas: 1
+          persistence:
+            enabled: false
+
+        read:
+          replicas: 0
+        write:
+          replicas: 0
+        backend:
+          replicas: 0
+
+        gateway:
+          enabled: true
+          service:
+            type: ClusterIP
+
+        chunksCache:
+          enabled: false
+        resultsCache:
+          enabled: false
+        test:
+          enabled: false
+        lokiCanary:
+          enabled: false
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: observability
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    retry:
+      limit: 5
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 3m

--- a/gitops/namespaces/observability.yaml
+++ b/gitops/namespaces/observability.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: observability
+  labels:
+    app.kubernetes.io/name: observability
+    app.kubernetes.io/managed-by: argocd
+    app.kubernetes.io/part-of: cthutool-platform
+    app.kubernetes.io/component: observability

--- a/gitops/observability/README.md
+++ b/gitops/observability/README.md
@@ -1,0 +1,60 @@
+# Observability Stack
+
+The observability stack is managed by Argo CD Applications under `gitops/apps/` and runs in the `observability` namespace.
+
+## Components
+
+| Component | GitOps Application | Upstream chart | Purpose |
+|-----------|--------------------|----------------|---------|
+| Prometheus and Grafana | `observability-kube-prometheus-stack` | `prometheus-community/kube-prometheus-stack` | Metrics collection, alerting foundation, dashboards, and Kubernetes workload views |
+| Loki | `observability-loki` | `grafana/loki` | Structured log storage and query |
+| Grafana Alloy | `observability-alloy` | `grafana/alloy` | Kubernetes stdout/stderr log collection into Loki |
+
+The stack intentionally does not create an `apps/observability` service. It uses upstream open source components and keeps desired state in GitOps manifests.
+
+## CthuTool Backend Metrics Boundary
+
+The CthuTool backend is expected to expose a Prometheus-compatible `/metrics` endpoint in a later backend implementation change. This change only defines the platform-side discovery contract:
+
+- Services opt in with `prometheus.io/scrape: "true"`.
+- Prometheus scrapes the annotated path and port, currently `/metrics` on port `3000`.
+- Prometheus attaches bounded labels: `namespace`, `app`, `component`, `service`, and `instance`.
+- No alert in this change requires `/metrics` to exist yet, so the platform configuration can land before backend instrumentation.
+
+Metric labels must not include request IDs, raw URLs, tokens, cookies, browser profile paths, screenshots, or user-provided free-form values.
+
+## Logs
+
+Alloy collects CthuTool pod stdout/stderr logs from Kubernetes and writes them to Loki. Loki labels are intentionally bounded to:
+
+- `namespace`
+- `app`
+- `component`
+- `pod`
+- `container`
+
+Correlation values such as request IDs, session IDs, URLs, and user-provided values must remain structured log fields, not Loki labels.
+
+## Dashboards
+
+The kube-prometheus-stack values include a starter Grafana dashboard named `CthuTool Kubernetes Workloads`. It includes:
+
+- Backend scrape target status.
+- Backend pod readiness.
+- A Loki logs panel for `namespace="cthutool", app="cthutool", component="backend"`.
+
+## Alert Rule Extension Point
+
+Prometheus selects custom alert and recording rules labeled:
+
+```yaml
+observability.cthutool.io/rule-scope: platform
+```
+
+Add future platform alert rules under a GitOps-managed manifest path and use that label so Prometheus picks them up without backend code changes.
+
+## Future Telemetry Ingestion
+
+Grafana Alloy is the reserved first telemetry ingestion point for future OTLP metrics, logs, and traces. This change only deploys Alloy for Kubernetes log collection. A later change should define any OTLP receiver ports, routing, sampling, authentication, retention, and trace storage.
+
+Tempo is intentionally not deployed by this change. Trace storage, sampling, and trace dashboards belong in a separate tracing change.

--- a/gitops/observability/prometheus/rules/README.md
+++ b/gitops/observability/prometheus/rules/README.md
@@ -1,0 +1,9 @@
+# Prometheus Rule Extension Point
+
+Future CthuTool platform alert and recording rules should be added here or another GitOps-managed manifest path and labeled:
+
+```yaml
+observability.cthutool.io/rule-scope: platform
+```
+
+The kube-prometheus-stack Application configures Prometheus to select rules with that label.

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -6,6 +6,7 @@ metadata:
   labels:
     app.kubernetes.io/name: cthutool-backend
     app.kubernetes.io/part-of: cthutool
+    app.kubernetes.io/component: backend
     app.kubernetes.io/managed-by: argocd
 spec:
   replicas: 1
@@ -17,6 +18,7 @@ spec:
       labels:
         app.kubernetes.io/name: cthutool-backend
         app.kubernetes.io/part-of: cthutool
+        app.kubernetes.io/component: backend
         app.kubernetes.io/managed-by: argocd
     spec:
       containers:
@@ -47,7 +49,7 @@ spec:
             failureThreshold: 3
           readinessProbe:
             httpGet:
-              path: /health
+              path: /health/ready
               port: 3000
             initialDelaySeconds: 5
             periodSeconds: 5

--- a/k8s/service.yaml
+++ b/k8s/service.yaml
@@ -6,7 +6,13 @@ metadata:
   labels:
     app.kubernetes.io/name: cthutool-backend
     app.kubernetes.io/part-of: cthutool
+    app.kubernetes.io/component: backend
     app.kubernetes.io/managed-by: argocd
+  annotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/path: /metrics
+    prometheus.io/port: "3000"
+    prometheus.io/scheme: http
 spec:
   selector:
     app.kubernetes.io/name: cthutool-backend

--- a/openspec/changes/archive/2026-06-25-gitops-observability-grafana-stack/.openspec.yaml
+++ b/openspec/changes/archive/2026-06-25-gitops-observability-grafana-stack/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-25

--- a/openspec/changes/archive/2026-06-25-gitops-observability-grafana-stack/design.md
+++ b/openspec/changes/archive/2026-06-25-gitops-observability-grafana-stack/design.md
@@ -1,0 +1,91 @@
+## Context
+
+CthuTool already defines application observability semantics for backend, web, desktop, and shared packages, and the backend already distinguishes `/health` from `/health/ready`. The Kubernetes deployment still uses `/health` for readiness, and the GitOps layer does not yet provide a cluster observability stack for metrics, dashboards, or structured log search.
+
+The implementation should stay in `gitops/` and `k8s/` and use established upstream components. This avoids creating an `apps/observability` service, keeps logs in standard Kubernetes stdout/stderr pipelines, and leaves business-code metrics implementation for a later backend change. Project policy remains in OpenSpec config and `AGENTS.md`; generated agent adapter folders are not part of this change.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Define a GitOps-managed observability baseline using Prometheus, Grafana, and Loki.
+- Provide platform-side scrape, dashboard, log query, and label conventions for CthuTool workloads.
+- Reserve an OpenTelemetry Collector or Grafana Alloy ingestion point so future metrics, logs, and traces have a clear landing zone.
+- Fix or plan the CthuTool Kubernetes readiness probe to use `/health/ready`.
+- Record that backend must expose a Prometheus-compatible `/metrics` endpoint in a future backend implementation change.
+
+**Non-Goals:**
+
+- Do not build a custom logging or observability app under `apps/`.
+- Do not implement Tempo or end-to-end distributed tracing in this change.
+- Do not modify backend business logic or instrumentation beyond any minimal deployment labels or annotations needed for platform discovery.
+- Do not archive, sync, or edit neighboring OpenSpec changes.
+
+## Decisions
+
+### Use upstream Grafana ecosystem components
+
+The platform stack will use Prometheus for metrics and alerting foundations, Grafana for dashboards, and Loki for structured log storage and querying.
+
+Alternatives considered:
+
+- A custom log API or app: rejected because it would duplicate Loki and violate the requirement to avoid self-built log services.
+- Cloud-only hosted observability: deferred because the GitOps baseline should be reproducible in the cluster and not require a vendor-specific control plane.
+
+### Manage the stack through GitOps manifests
+
+The stack should be represented under `gitops/` with any CthuTool workload integration in `k8s/`. Implementation can use Helm-rendered manifests, Argo CD Applications that reference chart sources, or checked-in Kubernetes manifests, but the desired state must be visible to GitOps and reviewable in the repository.
+
+Alternatives considered:
+
+- Manual cluster installation: rejected because it cannot be reviewed or reconciled through GitOps.
+- Embedding observability resources into backend app code: rejected because the platform stack is cluster infrastructure, not application behavior.
+
+### Keep metrics pull-based first
+
+Prometheus will scrape CthuTool backend metrics once the backend exposes `/metrics`. This change defines the discovery contract through labels, annotations, or ServiceMonitor-style resources, but backend endpoint implementation remains a later task.
+
+Alternatives considered:
+
+- Push metrics directly from the backend: deferred because it would require application code changes and a push gateway or collector decision before the platform baseline exists.
+- Implement backend metrics now: rejected to keep this change scoped to platform integration.
+
+### Collect logs from Kubernetes workload output
+
+Loki ingestion should collect structured JSON logs emitted to pod stdout/stderr and attach bounded Kubernetes labels such as namespace, app, component, pod, and container. High-cardinality values such as request IDs belong in log fields, not Loki labels.
+
+Alternatives considered:
+
+- File-based log sidecars per application: rejected because Kubernetes stdout collection is the simpler baseline.
+- Storing logs in Prometheus: rejected because Prometheus is for metrics and alerts, not log search.
+
+### Reserve Collector or Alloy without Tempo
+
+The stack will leave a documented OpenTelemetry Collector or Grafana Alloy endpoint for future OTLP metrics, logs, and traces. Tempo deployment and trace dashboards remain out of scope until a dedicated tracing change defines retention, sampling, storage, and application instrumentation.
+
+Alternatives considered:
+
+- Deploy Tempo immediately: rejected because the current goal is metrics, dashboards, and logs, and tracing would broaden the implementation and operational surface.
+
+## Risks / Trade-offs
+
+- [Risk] Helm chart defaults may expose more storage, retention, or RBAC surface than the cluster needs. → Mitigation: keep values files explicit and review retention, persistence, service exposure, and RBAC before applying.
+- [Risk] Loki labels can become high-cardinality if request or session identifiers are promoted to labels. → Mitigation: specify bounded label conventions and keep correlation identifiers as structured log fields.
+- [Risk] Prometheus scrape configuration may be added before backend `/metrics` exists. → Mitigation: make scrape resources tolerate absent targets and track backend metrics as a follow-up task boundary.
+- [Risk] Readiness probe changes can affect rollout behavior. → Mitigation: use existing `/health/ready` semantics and verify manifests before rollout.
+- [Risk] Deferring Tempo means traces will not be queryable after this change. → Mitigation: document the Collector or Alloy ingestion point and leave Tempo for a focused follow-up change.
+
+## Migration Plan
+
+1. Add GitOps manifests for the observability namespace and stack Applications or rendered manifests.
+2. Configure Prometheus, Grafana, and Loki with conservative retention and internal-cluster access by default.
+3. Add Grafana data sources and initial dashboards for Kubernetes workload health, Prometheus target status, and Loki log exploration.
+4. Add CthuTool workload labels, scrape discovery stubs, and readiness probe changes in `k8s/`.
+5. Validate OpenSpec deltas and Kubernetes manifests.
+6. Roll back by reverting the GitOps stack manifests and readiness probe change; no persistent business data migration is required by this proposal.
+
+## Open Questions
+
+- Should the implementation prefer kube-prometheus-stack plus Loki chart Applications, or checked-in rendered manifests for this cluster?
+- Should the reserved telemetry ingress be OpenTelemetry Collector, Grafana Alloy, or both as alternatives documented behind one GitOps entry point?
+- What retention and storage class should be used for Prometheus and Loki in the first deployment?

--- a/openspec/changes/archive/2026-06-25-gitops-observability-grafana-stack/proposal.md
+++ b/openspec/changes/archive/2026-06-25-gitops-observability-grafana-stack/proposal.md
@@ -1,0 +1,29 @@
+## Why
+
+CthuTool has application-level observability semantics, but the Kubernetes and GitOps layer does not yet define a standard stack for metrics, dashboards, logs, and future telemetry ingestion. A platform-owned observability baseline is needed before backend services expose production metrics so collection, labels, dashboards, and alerting are consistent from the start.
+
+## What Changes
+
+- Add a GitOps-managed observability stack based on existing open source components: Prometheus for metrics and alerting foundations, Grafana for dashboards, and Loki for structured log collection and query.
+- Define OpenTelemetry Collector or Grafana Alloy as the future ingestion extension point for metrics, logs, and traces without implementing Tempo tracing in this change.
+- Keep deployment ownership in `gitops/` and `k8s/`, avoiding a custom `apps/observability` service or bespoke log backend.
+- Define platform-side scrape, logging, dashboard, and label conventions for the CthuTool backend, including a future `/metrics` endpoint contract that backend implementation can satisfy in a later change.
+- Correct Kubernetes readiness planning so CthuTool workloads use `/health/ready` for readiness checks instead of treating `/health` as dependency readiness.
+- Explicitly leave Tempo and end-to-end distributed tracing for a later phase.
+
+## Capabilities
+
+### New Capabilities
+
+- `gitops-observability-stack`: GitOps-managed observability stack, platform integration points, label conventions, and readiness probe expectations for CthuTool Kubernetes deployments.
+
+### Modified Capabilities
+
+- `apps-backend-observability`: Clarify that the backend must expose a future Prometheus-compatible `/metrics` endpoint with bounded labels, while this change only defines platform-side integration and does not implement backend metrics.
+
+## Impact
+
+- Affected areas: `gitops/`, `k8s/`, and OpenSpec observability specifications.
+- Expected future dependencies: upstream Helm charts or Kubernetes manifests for Prometheus, Grafana, Loki, and either OpenTelemetry Collector or Grafana Alloy.
+- No new custom observability application under `apps/`.
+- No business-code changes are required for this proposal except later backend work to expose `/metrics` and any minimal labels or annotations needed by platform discovery.

--- a/openspec/changes/archive/2026-06-25-gitops-observability-grafana-stack/specs/apps-backend-observability/spec.md
+++ b/openspec/changes/archive/2026-06-25-gitops-observability-grafana-stack/specs/apps-backend-observability/spec.md
@@ -1,0 +1,19 @@
+## ADDED Requirements
+
+### Requirement: Backend Prometheus metrics endpoint
+The backend SHALL expose a Prometheus-compatible `/metrics` endpoint in a future backend implementation so the GitOps-managed Prometheus stack can scrape backend metrics.
+
+#### Scenario: Metrics endpoint is scrape compatible
+- **WHEN** Prometheus scrapes the backend metrics endpoint
+- **THEN** the backend exposes metrics at `/metrics`
+- **AND** the response is compatible with Prometheus scraping
+- **AND** metrics use stable names and bounded label values
+
+#### Scenario: Metrics endpoint avoids sensitive data
+- **WHEN** backend metrics include request, browser task, command dispatch, or readiness dimensions
+- **THEN** metric labels do not include raw URLs, request identifiers, tokens, cookies, screenshots, browser profile paths, or user-provided free-form values
+
+#### Scenario: Platform change does not implement endpoint
+- **WHEN** this GitOps observability stack change is implemented
+- **THEN** the platform may define scrape configuration for `/metrics`
+- **AND** backend code changes to implement `/metrics` remain a separate task boundary unless a later change explicitly includes them

--- a/openspec/changes/archive/2026-06-25-gitops-observability-grafana-stack/specs/gitops-observability-stack/spec.md
+++ b/openspec/changes/archive/2026-06-25-gitops-observability-grafana-stack/specs/gitops-observability-stack/spec.md
@@ -1,0 +1,82 @@
+## ADDED Requirements
+
+### Requirement: GitOps-managed observability stack
+The repository SHALL define a GitOps-managed observability stack for the Kubernetes cluster using existing open source components rather than a custom CthuTool observability or logging service.
+
+#### Scenario: Stack components are declared
+- **WHEN** the observability GitOps manifests are inspected
+- **THEN** they declare Prometheus for metrics collection and alerting foundations
+- **AND** they declare Grafana for dashboards
+- **AND** they declare Loki for structured log collection and query
+- **AND** they do not declare a custom `apps/observability` service
+
+#### Scenario: Stack is reconciled through GitOps
+- **WHEN** the cluster desired state is reviewed
+- **THEN** observability stack resources are represented under `gitops/`
+- **AND** CthuTool workload integration resources are represented under `k8s/` when they belong to the CthuTool application deployment
+
+### Requirement: Prometheus metrics integration
+The observability stack SHALL provide platform-side Prometheus scrape integration for CthuTool workloads without requiring this change to implement backend metrics.
+
+#### Scenario: Backend scrape contract is discoverable
+- **WHEN** Prometheus scrape configuration for the CthuTool backend is inspected
+- **THEN** it targets a future backend `/metrics` endpoint
+- **AND** it uses bounded workload identity labels such as namespace, app, component, service, and instance
+- **AND** it does not require backend business-code changes in this platform change
+
+#### Scenario: Alerting foundation exists
+- **WHEN** Prometheus configuration is inspected
+- **THEN** it includes an extension point for alert rules
+- **AND** initial alert rules can be added without changing backend application code
+
+### Requirement: Grafana dashboards and data sources
+The observability stack SHALL configure Grafana to query Prometheus metrics and Loki logs for CthuTool operational views.
+
+#### Scenario: Grafana data sources are configured
+- **WHEN** Grafana configuration is inspected
+- **THEN** Prometheus is available as a metrics data source
+- **AND** Loki is available as a logs data source
+
+#### Scenario: Starter dashboards are available
+- **WHEN** Grafana dashboards are inspected
+- **THEN** at least one dashboard surfaces Kubernetes workload health or Prometheus target status for CthuTool
+- **AND** at least one dashboard or explore link supports querying CthuTool structured logs from Loki
+
+### Requirement: Loki structured log collection
+The observability stack SHALL collect structured CthuTool Kubernetes logs into Loki using bounded labels and queryable structured fields.
+
+#### Scenario: Kubernetes logs are collected
+- **WHEN** CthuTool backend pods emit structured logs to stdout or stderr
+- **THEN** Loki ingestion collects those logs from Kubernetes workload output
+- **AND** Grafana can query them by namespace, app, component, pod, and container labels
+
+#### Scenario: High-cardinality values stay out of labels
+- **WHEN** logs contain request identifiers, session identifiers, URLs, or user-provided values
+- **THEN** those values remain structured log fields
+- **AND** they are not promoted to Loki labels
+
+### Requirement: Telemetry collector extension point
+The observability stack SHALL reserve an OpenTelemetry Collector or Grafana Alloy ingestion point for future telemetry pipelines without requiring Tempo tracing in this change.
+
+#### Scenario: Collector ingress is reserved
+- **WHEN** observability configuration is inspected
+- **THEN** it documents or declares where future OTLP metrics, logs, and traces can be sent
+- **AND** it identifies whether the first supported collector path is OpenTelemetry Collector, Grafana Alloy, or both
+
+#### Scenario: Tempo is deferred
+- **WHEN** the observability stack for this change is inspected
+- **THEN** it does not require Tempo to be deployed
+- **AND** trace storage, sampling, and trace dashboards are left for a later tracing change
+
+### Requirement: Kubernetes readiness probe semantics
+CthuTool Kubernetes readiness checks SHALL use the backend readiness endpoint instead of the liveness endpoint.
+
+#### Scenario: Readiness probe uses dependency readiness
+- **WHEN** the CthuTool backend Deployment readiness probe is inspected
+- **THEN** the readiness probe path is `/health/ready`
+- **AND** `/health` remains available for process liveness checks
+
+#### Scenario: Readiness is represented separately from metrics
+- **WHEN** Prometheus scrape or alerting configuration is inspected
+- **THEN** readiness probe configuration remains separate from metrics scraping
+- **AND** `/metrics` is not used as a Kubernetes readiness probe

--- a/openspec/changes/archive/2026-06-25-gitops-observability-grafana-stack/tasks.md
+++ b/openspec/changes/archive/2026-06-25-gitops-observability-grafana-stack/tasks.md
@@ -1,0 +1,36 @@
+## 1. Stack Placement
+
+- [x] 1.1 Confirm the implementation approach for upstream components: Argo CD chart Applications, checked-in rendered manifests, or a minimal documented combination under `gitops/`.
+- [x] 1.2 Add or update GitOps namespace resources for the observability stack with Kubernetes recommended labels and Argo CD ownership labels.
+- [x] 1.3 Add GitOps stack entry points for Prometheus, Grafana, and Loki without creating an `apps/observability` service.
+
+## 2. Prometheus Integration
+
+- [x] 2.1 Configure Prometheus deployment values or manifests with conservative retention, internal-cluster exposure, and an alert-rule extension point.
+- [x] 2.2 Add platform-side CthuTool backend scrape discovery for a future `/metrics` endpoint using bounded labels and tolerating the endpoint being absent until backend implementation lands.
+- [x] 2.3 Document the backend `/metrics` follow-up boundary in the relevant GitOps or Kubernetes README so implementation does not happen implicitly in this change.
+
+## 3. Grafana and Loki
+
+- [x] 3.1 Configure Grafana with Prometheus and Loki data sources through GitOps-managed configuration.
+- [x] 3.2 Add starter Grafana dashboard configuration for CthuTool Kubernetes workload health or Prometheus target status.
+- [x] 3.3 Configure Loki log collection from Kubernetes stdout/stderr with bounded labels for namespace, app, component, pod, and container.
+- [x] 3.4 Ensure structured log correlation values such as request IDs remain log fields and are not promoted to Loki labels.
+
+## 4. Collector Extension Point
+
+- [x] 4.1 Add a documented OpenTelemetry Collector or Grafana Alloy ingestion entry point for future OTLP metrics, logs, and traces.
+- [x] 4.2 Explicitly leave Tempo manifests, trace storage, sampling, and trace dashboards out of this change.
+
+## 5. CthuTool Kubernetes Workload Integration
+
+- [x] 5.1 Update `k8s/deployment.yaml` so backend readiness probes use `/health/ready` while liveness remains `/health`.
+- [x] 5.2 Add or confirm stable Kubernetes labels and annotations needed for Prometheus scrape discovery and Loki/Grafana workload filtering.
+- [x] 5.3 Keep any workload changes limited to deployment metadata, probes, and platform integration; do not modify backend business logic in this change.
+
+## 6. Verification
+
+- [x] 6.1 Run `openspec validate gitops-observability-grafana-stack --strict`.
+- [x] 6.2 Validate changed Kubernetes and GitOps YAML with the repository's available manifest validation command or a documented fallback such as `kubectl apply --dry-run=client`.
+- [x] 6.3 Confirm `git diff -- .claude .codex .cursor` is empty unless adapter regeneration was explicitly requested.
+- [x] 6.4 Confirm no neighboring OpenSpec changes were modified, archived, or synced.

--- a/openspec/specs/apps-backend-observability/spec.md
+++ b/openspec/specs/apps-backend-observability/spec.md
@@ -54,3 +54,22 @@ The backend SHALL distinguish liveness from readiness, report dependency readine
 #### Scenario: Degraded readiness is observable
 - **WHEN** the readiness endpoint reports a degraded dependency
 - **THEN** backend observability records which dependency is degraded using bounded status labels and a warning level
+
+### Requirement: Backend Prometheus metrics endpoint
+The backend SHALL expose a Prometheus-compatible `/metrics` endpoint in a future backend implementation so the GitOps-managed Prometheus stack can scrape backend metrics.
+
+#### Scenario: Metrics endpoint is scrape compatible
+- **WHEN** Prometheus scrapes the backend metrics endpoint
+- **THEN** the backend exposes metrics at `/metrics`
+- **AND** the response is compatible with Prometheus scraping
+- **AND** metrics use stable names and bounded label values
+
+#### Scenario: Metrics endpoint avoids sensitive data
+- **WHEN** backend metrics include request, browser task, command dispatch, or readiness dimensions
+- **THEN** metric labels do not include raw URLs, request identifiers, tokens, cookies, screenshots, browser profile paths, or user-provided free-form values
+
+#### Scenario: Platform change does not implement endpoint
+- **WHEN** this GitOps observability stack change is implemented
+- **THEN** the platform may define scrape configuration for `/metrics`
+- **AND** backend code changes to implement `/metrics` remain a separate task boundary unless a later change explicitly includes them
+

--- a/openspec/specs/gitops-observability-stack/spec.md
+++ b/openspec/specs/gitops-observability-stack/spec.md
@@ -1,0 +1,86 @@
+# gitops-observability-stack Specification
+
+## Purpose
+TBD - created by archiving change gitops-observability-grafana-stack. Update Purpose after archive.
+## Requirements
+### Requirement: GitOps-managed observability stack
+The repository SHALL define a GitOps-managed observability stack for the Kubernetes cluster using existing open source components rather than a custom CthuTool observability or logging service.
+
+#### Scenario: Stack components are declared
+- **WHEN** the observability GitOps manifests are inspected
+- **THEN** they declare Prometheus for metrics collection and alerting foundations
+- **AND** they declare Grafana for dashboards
+- **AND** they declare Loki for structured log collection and query
+- **AND** they do not declare a custom `apps/observability` service
+
+#### Scenario: Stack is reconciled through GitOps
+- **WHEN** the cluster desired state is reviewed
+- **THEN** observability stack resources are represented under `gitops/`
+- **AND** CthuTool workload integration resources are represented under `k8s/` when they belong to the CthuTool application deployment
+
+### Requirement: Prometheus metrics integration
+The observability stack SHALL provide platform-side Prometheus scrape integration for CthuTool workloads without requiring this change to implement backend metrics.
+
+#### Scenario: Backend scrape contract is discoverable
+- **WHEN** Prometheus scrape configuration for the CthuTool backend is inspected
+- **THEN** it targets a future backend `/metrics` endpoint
+- **AND** it uses bounded workload identity labels such as namespace, app, component, service, and instance
+- **AND** it does not require backend business-code changes in this platform change
+
+#### Scenario: Alerting foundation exists
+- **WHEN** Prometheus configuration is inspected
+- **THEN** it includes an extension point for alert rules
+- **AND** initial alert rules can be added without changing backend application code
+
+### Requirement: Grafana dashboards and data sources
+The observability stack SHALL configure Grafana to query Prometheus metrics and Loki logs for CthuTool operational views.
+
+#### Scenario: Grafana data sources are configured
+- **WHEN** Grafana configuration is inspected
+- **THEN** Prometheus is available as a metrics data source
+- **AND** Loki is available as a logs data source
+
+#### Scenario: Starter dashboards are available
+- **WHEN** Grafana dashboards are inspected
+- **THEN** at least one dashboard surfaces Kubernetes workload health or Prometheus target status for CthuTool
+- **AND** at least one dashboard or explore link supports querying CthuTool structured logs from Loki
+
+### Requirement: Loki structured log collection
+The observability stack SHALL collect structured CthuTool Kubernetes logs into Loki using bounded labels and queryable structured fields.
+
+#### Scenario: Kubernetes logs are collected
+- **WHEN** CthuTool backend pods emit structured logs to stdout or stderr
+- **THEN** Loki ingestion collects those logs from Kubernetes workload output
+- **AND** Grafana can query them by namespace, app, component, pod, and container labels
+
+#### Scenario: High-cardinality values stay out of labels
+- **WHEN** logs contain request identifiers, session identifiers, URLs, or user-provided values
+- **THEN** those values remain structured log fields
+- **AND** they are not promoted to Loki labels
+
+### Requirement: Telemetry collector extension point
+The observability stack SHALL reserve an OpenTelemetry Collector or Grafana Alloy ingestion point for future telemetry pipelines without requiring Tempo tracing in this change.
+
+#### Scenario: Collector ingress is reserved
+- **WHEN** observability configuration is inspected
+- **THEN** it documents or declares where future OTLP metrics, logs, and traces can be sent
+- **AND** it identifies whether the first supported collector path is OpenTelemetry Collector, Grafana Alloy, or both
+
+#### Scenario: Tempo is deferred
+- **WHEN** the observability stack for this change is inspected
+- **THEN** it does not require Tempo to be deployed
+- **AND** trace storage, sampling, and trace dashboards are left for a later tracing change
+
+### Requirement: Kubernetes readiness probe semantics
+CthuTool Kubernetes readiness checks SHALL use the backend readiness endpoint instead of the liveness endpoint.
+
+#### Scenario: Readiness probe uses dependency readiness
+- **WHEN** the CthuTool backend Deployment readiness probe is inspected
+- **THEN** the readiness probe path is `/health/ready`
+- **AND** `/health` remains available for process liveness checks
+
+#### Scenario: Readiness is represented separately from metrics
+- **WHEN** Prometheus scrape or alerting configuration is inspected
+- **THEN** readiness probe configuration remains separate from metrics scraping
+- **AND** `/metrics` is not used as a Kubernetes readiness probe
+


### PR DESCRIPTION
## Summary
- Add GitOps manifests for the observability namespace and core stack components
- Wire up Alloy, kube-prometheus-stack, and Loki application definitions
- Update backend deployment and service manifests to align with observability requirements
- Archive the completed OpenSpec change and refresh related specs and docs

## Testing
- Not run (not requested)