### PR TITLE
Restore default observability stack selectors

### DIFF
--- a/gitops/apps/observability-kube-prometheus-stack/application.yaml
+++ b/gitops/apps/observability-kube-prometheus-stack/application.yaml
@@ -14,6 +14,8 @@ spec:
       values: |
         fullnameOverride: kube-prometheus-stack
 
+        additionalPrometheusRulesMap: {}
+
         alertmanager:
           enabled: true
           service:
@@ -231,9 +233,6 @@ spec:
           prometheusSpec:
             retention: 7d
             enableAdminAPI: false
-            ruleSelector:
-              matchLabels:
-                observability.cthutool.io/rule-scope: platform
             additionalScrapeConfigs:
               - job_name: cthutool-backend
                 kubernetes_sd_configs:

--- a/gitops/apps/observability-loki/application.yaml
+++ b/gitops/apps/observability-loki/application.yaml
@@ -35,7 +35,8 @@ spec:
         singleBinary:
           replicas: 1
           persistence:
-            enabled: false
+            enabled: true
+            size: 10Gi
 
         read:
           replicas: 0

--- a/gitops/observability/README.md
+++ b/gitops/observability/README.md
@@ -45,13 +45,20 @@ The kube-prometheus-stack values include a starter Grafana dashboard named `Cthu
 
 ## Alert Rule Extension Point
 
-Prometheus selects custom alert and recording rules labeled:
+Custom alert and recording rules should be added through the
+`kube-prometheus-stack` chart's `additionalPrometheusRulesMap` values or a
+future GitOps-managed `PrometheusRule` manifest that matches the chart-managed
+Prometheus rule selector. Do not override the stack's default `ruleSelector`;
+doing so can exclude kube-prometheus-stack's built-in rules.
+
+Rules kept outside the chart values should use the project ownership label:
 
 ```yaml
 observability.cthutool.io/rule-scope: platform
 ```
 
-Add future platform alert rules under a GitOps-managed manifest path and use that label so Prometheus picks them up without backend code changes.
+This label is for ownership and review; the Prometheus selector compatibility
+must still be verified when the rule manifest is introduced.
 
 ## Future Telemetry Ingestion
 

--- a/gitops/observability/prometheus/rules/README.md
+++ b/gitops/observability/prometheus/rules/README.md
@@ -1,9 +1,16 @@
 # Prometheus Rule Extension Point
 
-Future CthuTool platform alert and recording rules should be added here or another GitOps-managed manifest path and labeled:
+Future CthuTool platform alert and recording rules should preferably be added
+through the `kube-prometheus-stack` chart's `additionalPrometheusRulesMap`
+values. If rules are later managed as standalone `PrometheusRule` manifests,
+verify they match the chart-managed Prometheus rule selector so built-in stack
+rules remain active.
+
+Use this project ownership label on CthuTool-specific rules:
 
 ```yaml
 observability.cthutool.io/rule-scope: platform
 ```
 
-The kube-prometheus-stack Application configures Prometheus to select rules with that label.
+Do not replace the default kube-prometheus-stack `ruleSelector` only with this
+label; that can exclude the chart's built-in alerting and recording rules.

--- a/openspec/specs/apps-backend-observability/spec.md
+++ b/openspec/specs/apps-backend-observability/spec.md
@@ -1,7 +1,7 @@
 # apps-backend-observability Specification
 
 ## Purpose
-TBD - created by archiving change apps-backend-observability-semantics. Update Purpose after archive.
+Define backend request context, structured event, readiness, metrics, and trace semantics so CthuTool backend operations can be safely correlated and monitored.
 ## Requirements
 ### Requirement: Backend request context
 The backend SHALL assign or preserve a request context for HTTP entry points that includes a request identifier, start time, method, route or path, response status, duration, and optional upstream correlation metadata.
@@ -72,4 +72,3 @@ The backend SHALL expose a Prometheus-compatible `/metrics` endpoint in a future
 - **WHEN** this GitOps observability stack change is implemented
 - **THEN** the platform may define scrape configuration for `/metrics`
 - **AND** backend code changes to implement `/metrics` remain a separate task boundary unless a later change explicitly includes them
-

--- a/openspec/specs/gitops-observability-stack/spec.md
+++ b/openspec/specs/gitops-observability-stack/spec.md
@@ -1,7 +1,7 @@
 # gitops-observability-stack Specification
 
 ## Purpose
-TBD - created by archiving change gitops-observability-grafana-stack. Update Purpose after archive.
+Define the GitOps-managed Kubernetes observability stack for CthuTool, including metrics, dashboards, log collection, platform integration boundaries, and future telemetry ingestion extension points.
 ## Requirements
 ### Requirement: GitOps-managed observability stack
 The repository SHALL define a GitOps-managed observability stack for the Kubernetes cluster using existing open source components rather than a custom CthuTool observability or logging service.
@@ -83,4 +83,3 @@ CthuTool Kubernetes readiness checks SHALL use the backend readiness endpoint in
 - **WHEN** Prometheus scrape or alerting configuration is inspected
 - **THEN** readiness probe configuration remains separate from metrics scraping
 - **AND** `/metrics` is not used as a Kubernetes readiness probe
-


### PR DESCRIPTION
## Summary
- Add `additionalPrometheusRulesMap` as the extension point for kube-prometheus-stack rules
- Remove the custom Prometheus `ruleSelector` override so built-in stack rules stay active
- Enable Loki single-binary persistence with a 10Gi volume
- Update observability docs and OpenSpec purposes to match the revised stack boundaries

## Testing
- Not run (not requested)