### PR TITLE
Refine CI workflow layout and required checks

### DIFF
--- a/.github/workflows/backend-image.yml
+++ b/.github/workflows/backend-image.yml
@@ -2,29 +2,9 @@ name: Backend Image
 
 on:
   pull_request:
-    paths:
-      - ".github/workflows/backend-image.yml"
-      - "apps/backend/**"
-      - "packages/agent-protocol/**"
-      - "packages/config/**"
-      - "package.json"
-      - "pnpm-lock.yaml"
-      - "pnpm-workspace.yaml"
-      - "tsconfig.json"
-      - "k8s/**"
   push:
     branches:
       - main
-    paths:
-      - ".github/workflows/backend-image.yml"
-      - "apps/backend/**"
-      - "packages/agent-protocol/**"
-      - "packages/config/**"
-      - "package.json"
-      - "pnpm-lock.yaml"
-      - "pnpm-workspace.yaml"
-      - "tsconfig.json"
-      - "k8s/**"
   workflow_dispatch:
 
 env:
@@ -40,11 +20,23 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Detect backend image changes
+        id: affected
+        run: node scripts/ci/affected-workflow.mjs backend-image
+
+      - name: Skip backend image validation
+        if: steps.affected.outputs.changed != 'true'
+        run: echo "Backend image inputs are unchanged; skipping image validation."
 
       - name: Set up Docker Buildx
+        if: steps.affected.outputs.changed == 'true'
         uses: docker/setup-buildx-action@v3
 
       - name: Build backend image
+        if: steps.affected.outputs.changed == 'true'
         uses: docker/build-push-action@v6
         with:
           context: .
@@ -65,11 +57,23 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Detect backend image changes
+        id: affected
+        run: node scripts/ci/affected-workflow.mjs backend-image
+
+      - name: Skip backend image publish
+        if: steps.affected.outputs.changed != 'true'
+        run: echo "Backend image inputs are unchanged; skipping image publish."
 
       - name: Set up Docker Buildx
+        if: steps.affected.outputs.changed == 'true'
         uses: docker/setup-buildx-action@v3
 
       - name: Log in to GitHub Container Registry
+        if: steps.affected.outputs.changed == 'true'
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
@@ -77,6 +81,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push backend image
+        if: steps.affected.outputs.changed == 'true'
         uses: docker/build-push-action@v6
         with:
           context: .
@@ -89,6 +94,7 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Pin deployment manifest to commit image
+        if: steps.affected.outputs.changed == 'true'
         run: |
           python - <<'PY'
           from pathlib import Path
@@ -110,6 +116,7 @@ jobs:
           PY
 
       - name: Commit deployment manifest update
+        if: steps.affected.outputs.changed == 'true'
         run: |
           if git diff --quiet -- k8s/deployment.yaml; then
             echo "Deployment manifest already points at ${{ github.sha }}"

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -15,6 +15,9 @@ jobs:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+      cancel-in-progress: true
     permissions:
       contents: read
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -182,7 +182,37 @@ jobs:
       - name: Build
         run: pnpm run build
 
+  cli-dist-changes:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      changed: ${{ steps.filter.outputs.cli-dist }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Detect CLI distribution changes
+        id: filter
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            cli-dist:
+              - ".github/workflows/ci.yml"
+              - "apps/cli/**"
+              - "scripts/build-cli-dist.sh"
+              - "scripts/check-cli-dist.sh"
+              - "scripts/run-bun.sh"
+              - "package.json"
+              - "pnpm-lock.yaml"
+              - "pnpm-workspace.yaml"
+
   cli-dist:
+    needs: cli-dist-changes
+    if: needs.cli-dist-changes.outputs.changed == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   commitlint:
     runs-on: ubuntu-latest
@@ -181,48 +185,6 @@ jobs:
 
       - name: Build
         run: pnpm run build
-
-  cli-dist:
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    permissions:
-      contents: read
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Detect CLI distribution changes
-        id: affected
-        run: node scripts/ci/affected-workflow.mjs cli-dist
-
-      - name: Skip CLI distribution check
-        if: steps.affected.outputs.changed != 'true'
-        run: echo "CLI distribution inputs are unchanged; skipping bundle check."
-
-      - uses: pnpm/action-setup@v4
-        if: steps.affected.outputs.changed == 'true'
-        with:
-          version: 9.15.4
-
-      - uses: actions/setup-node@v4
-        if: steps.affected.outputs.changed == 'true'
-        with:
-          node-version: "24.14.1"
-          cache: pnpm
-
-      - uses: oven-sh/setup-bun@v2
-        if: steps.affected.outputs.changed == 'true'
-        with:
-          bun-version: "1.3.11"
-
-      - name: Install dependencies
-        if: steps.affected.outputs.changed == 'true'
-        run: pnpm install --frozen-lockfile
-
-      - name: Check CLI distribution bundle
-        if: steps.affected.outputs.changed == 'true'
-        run: pnpm run check:cli-dist
 
   coverage:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -182,61 +182,46 @@ jobs:
       - name: Build
         run: pnpm run build
 
-  cli-dist-changes:
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    permissions:
-      contents: read
-      pull-requests: read
-    outputs:
-      changed: ${{ steps.filter.outputs.cli-dist }}
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Detect CLI distribution changes
-        id: filter
-        uses: dorny/paths-filter@v3
-        with:
-          filters: |
-            cli-dist:
-              - ".github/workflows/ci.yml"
-              - "apps/cli/**"
-              - "scripts/build-cli-dist.sh"
-              - "scripts/check-cli-dist.sh"
-              - "scripts/run-bun.sh"
-              - "package.json"
-              - "pnpm-lock.yaml"
-              - "pnpm-workspace.yaml"
-
   cli-dist:
-    needs: cli-dist-changes
-    if: needs.cli-dist-changes.outputs.changed == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
       contents: read
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Detect CLI distribution changes
+        id: affected
+        run: node scripts/ci/affected-workflow.mjs cli-dist
+
+      - name: Skip CLI distribution check
+        if: steps.affected.outputs.changed != 'true'
+        run: echo "CLI distribution inputs are unchanged; skipping bundle check."
 
       - uses: pnpm/action-setup@v4
+        if: steps.affected.outputs.changed == 'true'
         with:
           version: 9.15.4
 
       - uses: actions/setup-node@v4
+        if: steps.affected.outputs.changed == 'true'
         with:
           node-version: "24.14.1"
           cache: pnpm
 
       - uses: oven-sh/setup-bun@v2
+        if: steps.affected.outputs.changed == 'true'
         with:
           bun-version: "1.3.11"
 
       - name: Install dependencies
+        if: steps.affected.outputs.changed == 'true'
         run: pnpm install --frozen-lockfile
 
       - name: Check CLI distribution bundle
+        if: steps.affected.outputs.changed == 'true'
         run: pnpm run check:cli-dist
 
   coverage:

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -1,0 +1,58 @@
+name: CLI Distribution
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  cli-dist:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Detect CLI distribution changes
+        id: affected
+        run: node scripts/ci/affected-workflow.mjs cli-dist
+
+      - name: Skip CLI distribution check
+        if: steps.affected.outputs.changed != 'true'
+        run: echo "CLI distribution inputs are unchanged; skipping bundle check."
+
+      - uses: pnpm/action-setup@v4
+        if: steps.affected.outputs.changed == 'true'
+        with:
+          version: 9.15.4
+
+      - uses: actions/setup-node@v4
+        if: steps.affected.outputs.changed == 'true'
+        with:
+          node-version: "24.14.1"
+          cache: pnpm
+
+      - uses: oven-sh/setup-bun@v2
+        if: steps.affected.outputs.changed == 'true'
+        with:
+          bun-version: "1.3.11"
+
+      - name: Install dependencies
+        if: steps.affected.outputs.changed == 'true'
+        run: pnpm install --frozen-lockfile
+
+      - name: Check CLI distribution bundle
+        if: steps.affected.outputs.changed == 'true'
+        run: pnpm run check:cli-dist

--- a/.github/workflows/desktop-artifacts.yml
+++ b/.github/workflows/desktop-artifacts.yml
@@ -12,6 +12,7 @@ on:
       - "package.json"
       - "pnpm-lock.yaml"
       - "pnpm-workspace.yaml"
+      - "tsconfig.json"
       - "turbo.json"
   push:
     branches:
@@ -25,6 +26,7 @@ on:
       - "package.json"
       - "pnpm-lock.yaml"
       - "pnpm-workspace.yaml"
+      - "tsconfig.json"
       - "turbo.json"
 
 permissions:

--- a/.github/workflows/desktop-artifacts.yml
+++ b/.github/workflows/desktop-artifacts.yml
@@ -3,31 +3,9 @@ name: Desktop Artifacts
 on:
   workflow_dispatch:
   pull_request:
-    paths:
-      - ".github/workflows/desktop-artifacts.yml"
-      - "apps/desktop/**"
-      - "packages/agent-protocol/**"
-      - "packages/app-shell/**"
-      - "packages/ui/**"
-      - "package.json"
-      - "pnpm-lock.yaml"
-      - "pnpm-workspace.yaml"
-      - "tsconfig.json"
-      - "turbo.json"
   push:
     branches:
       - main
-    paths:
-      - ".github/workflows/desktop-artifacts.yml"
-      - "apps/desktop/**"
-      - "packages/agent-protocol/**"
-      - "packages/app-shell/**"
-      - "packages/ui/**"
-      - "package.json"
-      - "pnpm-lock.yaml"
-      - "pnpm-workspace.yaml"
-      - "tsconfig.json"
-      - "turbo.json"
 
 permissions:
   contents: read
@@ -47,19 +25,32 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Detect desktop artifact changes
+        id: affected
+        run: node scripts/ci/affected-workflow.mjs desktop-artifacts
+
+      - name: Skip desktop artifact package
+        if: steps.affected.outputs.changed != 'true'
+        run: echo "Desktop artifact inputs are unchanged; skipping package."
 
       - name: Set up pnpm
+        if: steps.affected.outputs.changed == 'true'
         uses: pnpm/action-setup@v4
         with:
           version: 9.15.4
 
       - name: Set up Node.js
+        if: steps.affected.outputs.changed == 'true'
         uses: actions/setup-node@v4
         with:
           node-version: 24.14.1
           cache: pnpm
 
       - name: Restore Turbo cache
+        if: steps.affected.outputs.changed == 'true'
         uses: actions/cache@v4
         with:
           path: .turbo/cache
@@ -69,20 +60,23 @@ jobs:
             turbo-${{ runner.os }}-
 
       - name: Install dependencies
+        if: steps.affected.outputs.changed == 'true'
         run: pnpm install --frozen-lockfile
 
       - name: Validate desktop dependency graph
+        if: steps.affected.outputs.changed == 'true'
         run: pnpm turbo run typecheck test build --filter=@cthutool/desktop...
 
       - name: Package Windows desktop
-        if: matrix.os == 'windows-latest'
+        if: steps.affected.outputs.changed == 'true' && matrix.os == 'windows-latest'
         run: pnpm --filter @cthutool/desktop package:win:from-build
 
       - name: Package macOS desktop
-        if: matrix.os == 'macos-latest'
+        if: steps.affected.outputs.changed == 'true' && matrix.os == 'macos-latest'
         run: pnpm --filter @cthutool/desktop package:mac:from-build
 
       - name: Upload desktop artifact
+        if: steps.affected.outputs.changed == 'true'
         uses: actions/upload-artifact@v4
         with:
           name: cthudesktop-${{ runner.os }}

--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -15,6 +15,9 @@ jobs:
     name: Package desktop (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ matrix.os }}
+      cancel-in-progress: true
     strategy:
       fail-fast: false
       matrix:

--- a/openspec/changes/archive/2026-06-26-refine-ci-required-workflows/.openspec.yaml
+++ b/openspec/changes/archive/2026-06-26-refine-ci-required-workflows/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-26

--- a/openspec/changes/archive/2026-06-26-refine-ci-required-workflows/design.md
+++ b/openspec/changes/archive/2026-06-26-refine-ci-required-workflows/design.md
@@ -1,0 +1,47 @@
+## Context
+
+The repository now has broad root CI plus scoped checks for CLI distribution, backend images, and desktop artifacts. The scoped checks need to remain inexpensive when unrelated files change, but they also need stable check names so maintainers can mark them as required without depending on path-filtered workflows that may not appear.
+
+The current workflow file names are partly descriptive (`backend-image.yml`, `desktop-artifacts.yml`) and partly generic (`ci.yml`). The desired layout is area-based file names with explicit workflow display names: `cli.yml`, `backend.yml`, `desktop.yml`, and `ci.yml`.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Keep required status checks stable even when scoped inputs are unchanged.
+- Move CLI distribution validation into a dedicated `cli.yml` workflow while preserving the `cli-dist` job name.
+- Rename backend and desktop workflow files to area names while preserving explicit workflow display names.
+- Add pull-request concurrency so superseded workflow runs are cancelled.
+- Ensure CLI distribution affected-input detection includes root TypeScript configuration.
+- Keep tests covering workflow names, required-safe skip semantics, and affected dependency graph behavior.
+
+**Non-Goals:**
+- Do not remove the current duplicate `test` and `coverage` execution in this change.
+- Do not change application runtime behavior.
+- Do not change GitHub branch protection settings directly; document checks that are safe to require.
+
+## Decisions
+
+1. Use job-internal affected detection for scoped workflows.
+   - Decision: `cli-dist`, backend image validation, and desktop packaging jobs SHALL always appear on pull requests, then skip heavy steps with a successful job when affected inputs are unchanged.
+   - Rationale: Required GitHub checks are easiest to manage when the job name is stable and the check completes successfully rather than disappearing due to `on.pull_request.paths`.
+   - Alternative considered: Keep workflow-level path filters. This avoids runner startup for unrelated changes, but missing checks are harder to make required and require manual path maintenance.
+
+2. Keep affected detection in a repository script.
+   - Decision: `scripts/ci/affected-workflow.mjs` SHALL own target definitions and derive recursive workspace dependency paths from package manifests.
+   - Rationale: GitHub workflow syntax cannot dynamically derive workspace dependency graphs, while a local script can be unit-tested by contract tests.
+   - Alternative considered: Use a third-party changed-files action for each workflow. This is simpler for static paths but does not solve recursive workspace dependency maintenance.
+
+3. Use area-based workflow filenames with explicit display names.
+   - Decision: Rename workflow files to `cli.yml`, `backend.yml`, and `desktop.yml`, and use names such as `CLI Distribution`, `Backend Image`, and `Desktop Artifacts`.
+   - Rationale: Short area filenames are easier to scan and leave room for each area workflow to grow beyond one job, while display names keep GitHub UI intent clear.
+
+4. Preserve required job names.
+   - Decision: Keep required-facing job names such as `cli-dist`, `validate`, and `Package desktop (...)` stable where practical.
+   - Rationale: Changing job names forces branch protection updates and makes PR status history harder to compare.
+
+## Risks / Trade-offs
+
+- [Risk] Scoped workflows will start a runner even for unrelated PRs. -> Mitigation: affected detection runs before dependency installation or heavy setup, so unrelated runs exit quickly with success.
+- [Risk] Affected detection can miss files if target definitions drift. -> Mitigation: contract tests exercise representative affected and unaffected files for CLI, backend, and desktop targets.
+- [Risk] Workflow file renames can temporarily duplicate checks if old files remain. -> Mitigation: implement renames as moves and remove old workflow files in the same change.
+- [Risk] GitHub required check settings are external to the repository. -> Mitigation: keep job names stable and document the check names that can be required after merge.

--- a/openspec/changes/archive/2026-06-26-refine-ci-required-workflows/proposal.md
+++ b/openspec/changes/archive/2026-06-26-refine-ci-required-workflows/proposal.md
@@ -1,0 +1,35 @@
+## Why
+
+The CI checks are now broad enough to protect the monorepo, but the workflow layout and scoped-check behavior still need to be made easier to require, maintain, and reason about. Required checks should have stable names and green no-op behavior, while workflow files should map cleanly to product areas.
+
+## What Changes
+
+- Split the CLI distribution check out of the primary CI workflow into a dedicated CLI workflow file.
+- Rename scoped workflow files to short area names:
+  - `.github/workflows/cli.yml`
+  - `.github/workflows/backend.yml`
+  - `.github/workflows/desktop.yml`
+- Keep workflow display names explicit, such as `CLI Distribution`, `Backend Image`, and `Desktop Artifacts`.
+- Keep scoped checks required-safe by triggering workflows consistently and skipping heavy work inside jobs when affected inputs are unchanged.
+- Add PR-run concurrency so superseded CI, CLI, backend, and desktop runs are cancelled for the same branch or pull request.
+- Include `tsconfig.json` in CLI distribution affected-input detection.
+- Preserve the current decision to keep coverage/test duplication for now.
+- Update contract tests and affected-workflow coverage so workflow naming, skip semantics, and dependency-driven affected detection stay guarded.
+
+## Capabilities
+
+### New Capabilities
+- `apps-cli-distribution-ci`: Dedicated CI behavior for validating the committed CLI distribution bundle with required-safe affected-input skipping.
+
+### Modified Capabilities
+- `apps-root-engineering-config`: Primary CI no longer owns the CLI distribution job and gains required-safe workflow structure expectations for scoped checks.
+- `apps-backend-image-ci`: Backend image CI uses the renamed backend workflow file, stable required-safe skip behavior, and PR-run concurrency.
+- `apps-desktop-packaging-ci`: Desktop artifact CI uses the renamed desktop workflow file, stable required-safe skip behavior, and PR-run concurrency.
+
+## Impact
+
+- Affected GitHub Actions workflows under `.github/workflows/`.
+- Affected CI helper scripts under `scripts/ci/`.
+- Affected contract tests under `tests/contract/`.
+- Required status check configuration should continue to reference stable job names rather than workflow file names.
+- No runtime application APIs or user-facing behavior change.

--- a/openspec/changes/archive/2026-06-26-refine-ci-required-workflows/specs/apps-backend-image-ci/spec.md
+++ b/openspec/changes/archive/2026-06-26-refine-ci-required-workflows/specs/apps-backend-image-ci/spec.md
@@ -1,8 +1,5 @@
-# apps-backend-image-ci Specification
+## MODIFIED Requirements
 
-## Purpose
-TBD - created by archiving change improve-ci-coverage-and-speed. Update Purpose after archive.
-## Requirements
 ### Requirement: Backend image CI validates pull request Docker builds
 The backend image workflow SHALL expose a stable pull request validation job and SHALL build backend Docker images only when affected inputs change.
 
@@ -36,26 +33,7 @@ The backend image workflow SHALL publish backend container images for qualifying
 - **AND** it does not push image tags
 - **AND** it does not update `k8s/deployment.yaml`
 
-### Requirement: Backend deployment manifest updates are concurrency safe
-The backend image workflow SHALL protect deployment manifest update runs from overlapping writes.
-
-#### Scenario: Main branch image publishing is serialized
-- **WHEN** multiple backend image publishing runs are queued for `main`
-- **THEN** the workflow uses a stable concurrency group for backend image publishing
-- **AND** deployment manifest update steps do not run concurrently against `k8s/deployment.yaml`
-
-#### Scenario: Deployment manifest pins commit image
-- **WHEN** the backend image publish succeeds for a main branch commit
-- **THEN** the workflow updates `k8s/deployment.yaml` to reference the triggering commit SHA image tag
-- **AND** the committed manifest update does not retrigger the full CI pipeline unnecessarily
-
-### Requirement: Backend image build uses pinned workspace tool versions
-Backend Docker builds SHALL use the repository-pinned package manager version.
-
-#### Scenario: Dockerfile pins pnpm version
-- **WHEN** the backend Dockerfile prepares pnpm with Corepack
-- **THEN** it uses the exact pnpm version declared by the repository package manager configuration
-- **AND** Docker image dependency installation remains compatible with the frozen pnpm lockfile
+## ADDED Requirements
 
 ### Requirement: Backend workflow uses area filename and explicit display name
 The backend image workflow SHALL be stored in an area-named workflow file while presenting a descriptive workflow name in GitHub.
@@ -65,4 +43,3 @@ The backend image workflow SHALL be stored in an area-named workflow file while 
 - **THEN** backend image behavior is defined in `.github/workflows/backend.yml`
 - **AND** the workflow display name identifies backend image behavior
 - **AND** the old `.github/workflows/backend-image.yml` file is not retained as a duplicate workflow
-

--- a/openspec/changes/archive/2026-06-26-refine-ci-required-workflows/specs/apps-cli-distribution-ci/spec.md
+++ b/openspec/changes/archive/2026-06-26-refine-ci-required-workflows/specs/apps-cli-distribution-ci/spec.md
@@ -1,0 +1,36 @@
+## ADDED Requirements
+
+### Requirement: CLI distribution workflow is required-safe
+The repository SHALL validate the committed CLI distribution bundle through a dedicated GitHub Actions workflow whose check can be marked required.
+
+#### Scenario: Pull request exposes stable CLI distribution check
+- **WHEN** a pull request is opened or updated
+- **THEN** the CLI distribution workflow runs a job named `cli-dist`
+- **AND** the job completes successfully without running the bundle check when CLI distribution inputs are unchanged
+- **AND** the job runs the CLI distribution bundle check when CLI distribution inputs change
+
+#### Scenario: Main branch exposes stable CLI distribution check
+- **WHEN** a commit is pushed to `main`
+- **THEN** the CLI distribution workflow runs a job named `cli-dist`
+- **AND** the job uses affected-input detection before running dependency installation or bundle validation
+
+### Requirement: CLI distribution affected inputs include bundle dependencies
+The CLI distribution workflow SHALL treat CLI source, bundle scripts, package manager metadata, workspace metadata, lockfile, workflow configuration, and root TypeScript configuration as inputs that can affect the committed bundle.
+
+#### Scenario: CLI bundle input changes run bundle validation
+- **WHEN** a pull request changes `apps/cli/**`, CLI bundle scripts, root package metadata, `pnpm-lock.yaml`, `pnpm-workspace.yaml`, the CLI workflow file, or `tsconfig.json`
+- **THEN** the `cli-dist` job runs `pnpm run check:cli-dist`
+
+#### Scenario: Unrelated input changes skip bundle validation
+- **WHEN** a pull request changes files that cannot affect the CLI bundle
+- **THEN** the `cli-dist` job reports a successful skip
+- **AND** it does not install dependencies only for the bundle check
+
+### Requirement: CLI workflow uses area filename and explicit display name
+The CLI distribution workflow SHALL be stored in an area-named workflow file while presenting a descriptive workflow name in GitHub.
+
+#### Scenario: CLI workflow file is area named
+- **WHEN** repository workflow files are inspected
+- **THEN** CLI distribution behavior is defined in `.github/workflows/cli.yml`
+- **AND** the workflow display name identifies CLI distribution behavior
+- **AND** `.github/workflows/ci.yml` does not define the `cli-dist` job

--- a/openspec/changes/archive/2026-06-26-refine-ci-required-workflows/specs/apps-desktop-packaging-ci/spec.md
+++ b/openspec/changes/archive/2026-06-26-refine-ci-required-workflows/specs/apps-desktop-packaging-ci/spec.md
@@ -1,0 +1,30 @@
+## MODIFIED Requirements
+
+### Requirement: Desktop artifact workflow tracks desktop dependency changes
+The desktop artifact workflow SHALL expose stable platform packaging checks and SHALL run packaging work only when changes affect the desktop package or root-managed packages that contribute to the desktop build.
+
+#### Scenario: Desktop dependency package changes trigger artifacts workflow
+- **WHEN** a pull request changes `apps/desktop/**`, `packages/agent-protocol/**`, `packages/app-shell/**`, `packages/ui/**`, or recursive workspace dependencies of `@cthutool/desktop`
+- **THEN** the desktop artifact workflow runs platform packaging jobs
+- **AND** the workflow validates desktop packaging before the pull request is considered artifact-ready
+
+#### Scenario: Shared workspace configuration changes trigger artifacts workflow
+- **WHEN** a pull request changes root package manifests, workspace configuration, lockfile, TypeScript configuration, Turbo configuration, or the desktop artifact workflow itself
+- **THEN** the desktop artifact workflow runs platform packaging jobs
+
+#### Scenario: Unrelated changes skip desktop artifacts successfully
+- **WHEN** a pull request changes files that cannot affect desktop artifacts
+- **THEN** the desktop artifact workflow still exposes the macOS and Windows platform check names
+- **AND** each platform job completes successfully without installing dependencies, running Turbo graph validation, packaging artifacts, or uploading artifacts
+- **AND** each platform job output states that desktop artifact inputs are unchanged
+
+## ADDED Requirements
+
+### Requirement: Desktop workflow uses area filename and explicit display name
+The desktop artifact workflow SHALL be stored in an area-named workflow file while presenting a descriptive workflow name in GitHub.
+
+#### Scenario: Desktop workflow file is area named
+- **WHEN** repository workflow files are inspected
+- **THEN** desktop artifact behavior is defined in `.github/workflows/desktop.yml`
+- **AND** the workflow display name identifies desktop artifact behavior
+- **AND** the old `.github/workflows/desktop-artifacts.yml` file is not retained as a duplicate workflow

--- a/openspec/changes/archive/2026-06-26-refine-ci-required-workflows/specs/apps-root-engineering-config/spec.md
+++ b/openspec/changes/archive/2026-06-26-refine-ci-required-workflows/specs/apps-root-engineering-config/spec.md
@@ -1,0 +1,41 @@
+## MODIFIED Requirements
+
+### Requirement: Primary CI validates complete root workspace health
+The primary CI workflow SHALL validate the complete health of root-managed workspace packages before a pull request or main branch push is considered successful, while artifact-specific validation can live in dedicated area workflows.
+
+#### Scenario: Pull request runs complete root validation
+- **WHEN** the primary CI workflow runs for a pull request
+- **THEN** it installs dependencies with the frozen lockfile
+- **AND** it validates commit messages for the pull request range
+- **AND** it runs root-managed lint validation
+- **AND** it runs root-managed typecheck validation
+- **AND** it runs root-managed runtime tests
+- **AND** it runs root-managed build validation
+- **AND** CLI distribution integrity is validated by the dedicated CLI distribution workflow rather than the primary CI workflow
+
+#### Scenario: Main branch push runs complete root validation
+- **WHEN** the primary CI workflow runs for a push to `main`
+- **THEN** it validates commit messages for the pushed commit
+- **AND** it runs root-managed lint, typecheck, test, and build gates before required CI succeeds
+- **AND** CLI distribution integrity is validated by the dedicated CLI distribution workflow rather than the primary CI workflow
+
+## ADDED Requirements
+
+### Requirement: Pull request workflows cancel superseded runs
+Pull request workflows SHALL cancel superseded runs for the same pull request or branch so repeated pushes do not waste runner capacity.
+
+#### Scenario: Superseded pull request run is cancelled
+- **WHEN** a pull request branch receives a new commit while an older run of the same workflow is still running
+- **THEN** the newer workflow run uses the same concurrency group for that pull request or branch
+- **AND** the older in-progress run is cancelled
+
+### Requirement: Workflow files use area names
+Repository GitHub Actions workflow files SHALL use short area names while their display names describe the workflow purpose.
+
+#### Scenario: Area workflow names are inspectable
+- **WHEN** GitHub Actions workflow files are inspected
+- **THEN** root validation behavior is defined in `.github/workflows/ci.yml`
+- **AND** CLI distribution behavior is defined in `.github/workflows/cli.yml`
+- **AND** backend behavior is defined in `.github/workflows/backend.yml`
+- **AND** desktop behavior is defined in `.github/workflows/desktop.yml`
+- **AND** workflow display names remain descriptive enough to identify the purpose in GitHub checks

--- a/openspec/changes/archive/2026-06-26-refine-ci-required-workflows/tasks.md
+++ b/openspec/changes/archive/2026-06-26-refine-ci-required-workflows/tasks.md
@@ -1,0 +1,29 @@
+## 1. Workflow Layout
+
+- [x] 1.1 Move `.github/workflows/backend-image.yml` to `.github/workflows/backend.yml` without leaving the old workflow file behind.
+- [x] 1.2 Move `.github/workflows/desktop-artifacts.yml` to `.github/workflows/desktop.yml` without leaving the old workflow file behind.
+- [x] 1.3 Create `.github/workflows/cli.yml` for the `cli-dist` job and remove `cli-dist` from `.github/workflows/ci.yml`.
+- [x] 1.4 Keep workflow display names explicit: `CI`, `CLI Distribution`, `Backend Image`, and `Desktop Artifacts`.
+
+## 2. Required-Safe Scoped Checks
+
+- [x] 2.1 Ensure `scripts/ci/affected-workflow.mjs` supports `cli-dist`, `backend-image`, and `desktop-artifacts` targets with recursive workspace dependency detection.
+- [x] 2.2 Ensure scoped jobs always appear on pull requests and complete successfully without heavy work when affected inputs are unchanged.
+- [x] 2.3 Include `tsconfig.json` in CLI distribution affected-input detection.
+- [x] 2.4 Preserve stable required-facing job names for `cli-dist`, `validate`, and `Package desktop (...)`.
+
+## 3. Concurrency
+
+- [x] 3.1 Add pull-request-safe concurrency to `ci.yml`.
+- [x] 3.2 Add pull-request-safe concurrency to `cli.yml`.
+- [x] 3.3 Add pull-request-safe concurrency to `backend.yml` without breaking the existing serialized main-branch backend publish job.
+- [x] 3.4 Add pull-request-safe concurrency to `desktop.yml`.
+
+## 4. Tests and Verification
+
+- [x] 4.1 Update workflow contract tests for the renamed workflow files, dedicated CLI workflow, stable skip behavior, and absence of duplicate old workflow files.
+- [x] 4.2 Update affected-workflow contract tests for CLI `tsconfig.json`, backend recursive dependencies, desktop recursive dependencies, and unrelated-file skips.
+- [x] 4.3 Run `corepack pnpm exec vitest run tests/contract/ci-workflow.test.ts tests/contract/ci-affected-workflow.test.ts`.
+- [x] 4.4 Run `openspec validate --change refine-ci-required-workflows`.
+- [x] 4.5 Run `git diff --check`.
+- [x] 4.6 Confirm generated agent adapter files under `.claude/`, `.codex/`, and `.cursor/` were not hand-edited by this change.

--- a/openspec/specs/apps-cli-distribution-ci/spec.md
+++ b/openspec/specs/apps-cli-distribution-ci/spec.md
@@ -1,0 +1,40 @@
+# apps-cli-distribution-ci Specification
+
+## Purpose
+TBD - created by archiving change refine-ci-required-workflows. Update Purpose after archive.
+## Requirements
+### Requirement: CLI distribution workflow is required-safe
+The repository SHALL validate the committed CLI distribution bundle through a dedicated GitHub Actions workflow whose check can be marked required.
+
+#### Scenario: Pull request exposes stable CLI distribution check
+- **WHEN** a pull request is opened or updated
+- **THEN** the CLI distribution workflow runs a job named `cli-dist`
+- **AND** the job completes successfully without running the bundle check when CLI distribution inputs are unchanged
+- **AND** the job runs the CLI distribution bundle check when CLI distribution inputs change
+
+#### Scenario: Main branch exposes stable CLI distribution check
+- **WHEN** a commit is pushed to `main`
+- **THEN** the CLI distribution workflow runs a job named `cli-dist`
+- **AND** the job uses affected-input detection before running dependency installation or bundle validation
+
+### Requirement: CLI distribution affected inputs include bundle dependencies
+The CLI distribution workflow SHALL treat CLI source, bundle scripts, package manager metadata, workspace metadata, lockfile, workflow configuration, and root TypeScript configuration as inputs that can affect the committed bundle.
+
+#### Scenario: CLI bundle input changes run bundle validation
+- **WHEN** a pull request changes `apps/cli/**`, CLI bundle scripts, root package metadata, `pnpm-lock.yaml`, `pnpm-workspace.yaml`, the CLI workflow file, or `tsconfig.json`
+- **THEN** the `cli-dist` job runs `pnpm run check:cli-dist`
+
+#### Scenario: Unrelated input changes skip bundle validation
+- **WHEN** a pull request changes files that cannot affect the CLI bundle
+- **THEN** the `cli-dist` job reports a successful skip
+- **AND** it does not install dependencies only for the bundle check
+
+### Requirement: CLI workflow uses area filename and explicit display name
+The CLI distribution workflow SHALL be stored in an area-named workflow file while presenting a descriptive workflow name in GitHub.
+
+#### Scenario: CLI workflow file is area named
+- **WHEN** repository workflow files are inspected
+- **THEN** CLI distribution behavior is defined in `.github/workflows/cli.yml`
+- **AND** the workflow display name identifies CLI distribution behavior
+- **AND** `.github/workflows/ci.yml` does not define the `cli-dist` job
+

--- a/openspec/specs/apps-desktop-packaging-ci/spec.md
+++ b/openspec/specs/apps-desktop-packaging-ci/spec.md
@@ -53,16 +53,22 @@ The repository SHALL include a GitHub Actions workflow that builds and uploads C
 - **THEN** desktop artifact packaging can remain in a dedicated workflow rather than adding heavy packaging work to the existing coverage job
 
 ### Requirement: Desktop artifact workflow tracks desktop dependency changes
-The desktop artifact workflow SHALL run when changes affect the desktop package or root-managed packages that contribute to the desktop build.
+The desktop artifact workflow SHALL expose stable platform packaging checks and SHALL run packaging work only when changes affect the desktop package or root-managed packages that contribute to the desktop build.
 
 #### Scenario: Desktop dependency package changes trigger artifacts workflow
-- **WHEN** a pull request changes `apps/desktop/**`, `packages/agent-protocol/**`, `packages/app-shell/**`, or `packages/ui/**`
-- **THEN** the desktop artifact workflow is eligible to run
+- **WHEN** a pull request changes `apps/desktop/**`, `packages/agent-protocol/**`, `packages/app-shell/**`, `packages/ui/**`, or recursive workspace dependencies of `@cthutool/desktop`
+- **THEN** the desktop artifact workflow runs platform packaging jobs
 - **AND** the workflow validates desktop packaging before the pull request is considered artifact-ready
 
 #### Scenario: Shared workspace configuration changes trigger artifacts workflow
-- **WHEN** a pull request changes root package manifests, workspace configuration, lockfile, Turbo configuration, or the desktop artifact workflow itself
-- **THEN** the desktop artifact workflow is eligible to run
+- **WHEN** a pull request changes root package manifests, workspace configuration, lockfile, TypeScript configuration, Turbo configuration, or the desktop artifact workflow itself
+- **THEN** the desktop artifact workflow runs platform packaging jobs
+
+#### Scenario: Unrelated changes skip desktop artifacts successfully
+- **WHEN** a pull request changes files that cannot affect desktop artifacts
+- **THEN** the desktop artifact workflow still exposes the macOS and Windows platform check names
+- **AND** each platform job completes successfully without installing dependencies, running Turbo graph validation, packaging artifacts, or uploading artifacts
+- **AND** each platform job output states that desktop artifact inputs are unchanged
 
 ### Requirement: Desktop validation uses Turbo filtered dependency graph
 The desktop artifact workflow SHALL validate the desktop package through the Turborepo dependency graph before running platform-specific packaging commands.
@@ -78,3 +84,12 @@ The desktop artifact workflow SHALL validate the desktop package through the Tur
 - **WHEN** desktop graph build validation has already produced the package build output
 - **THEN** Windows and macOS packaging commands reuse the existing build output where package scripts support it
 - **AND** the workflow does not intentionally rebuild the same desktop output more than once per platform job
+
+### Requirement: Desktop workflow uses area filename and explicit display name
+The desktop artifact workflow SHALL be stored in an area-named workflow file while presenting a descriptive workflow name in GitHub.
+
+#### Scenario: Desktop workflow file is area named
+- **WHEN** repository workflow files are inspected
+- **THEN** desktop artifact behavior is defined in `.github/workflows/desktop.yml`
+- **AND** the workflow display name identifies desktop artifact behavior
+- **AND** the old `.github/workflows/desktop-artifacts.yml` file is not retained as a duplicate workflow

--- a/openspec/specs/apps-root-engineering-config/spec.md
+++ b/openspec/specs/apps-root-engineering-config/spec.md
@@ -163,9 +163,9 @@ The root engineering configuration SHALL refresh and stage the committed CLI run
 - **THEN** generated bundle staging does not cause source-formatting hooks to fail because the generated bundle is ignored by the source formatter
 
 ### Requirement: Primary CI validates complete root workspace health
-The primary CI workflow SHALL validate the complete health of root-managed workspace packages before a pull request or main branch push is considered successful.
+The primary CI workflow SHALL validate the complete health of root-managed workspace packages before a pull request or main branch push is considered successful, while artifact-specific validation can live in dedicated area workflows.
 
-#### Scenario: Pull request runs complete validation
+#### Scenario: Pull request runs complete root validation
 - **WHEN** the primary CI workflow runs for a pull request
 - **THEN** it installs dependencies with the frozen lockfile
 - **AND** it validates commit messages for the pull request range
@@ -173,12 +173,13 @@ The primary CI workflow SHALL validate the complete health of root-managed works
 - **AND** it runs root-managed typecheck validation
 - **AND** it runs root-managed runtime tests
 - **AND** it runs root-managed build validation
-- **AND** it runs the CLI distribution integrity check
+- **AND** CLI distribution integrity is validated by the dedicated CLI distribution workflow rather than the primary CI workflow
 
-#### Scenario: Main branch push runs complete validation
+#### Scenario: Main branch push runs complete root validation
 - **WHEN** the primary CI workflow runs for a push to `main`
 - **THEN** it validates commit messages for the pushed commit
-- **AND** it runs root-managed lint, typecheck, test, build, and CLI distribution gates before required CI succeeds
+- **AND** it runs root-managed lint, typecheck, test, and build gates before required CI succeeds
+- **AND** CLI distribution integrity is validated by the dedicated CLI distribution workflow rather than the primary CI workflow
 
 ### Requirement: Root workspace validation uses Turbo orchestration
 Root package validation SHALL use Turborepo task orchestration for workspace package tasks so packages run in parallel while respecting workspace dependency order.
@@ -233,3 +234,22 @@ Root engineering contract tests SHALL verify that each root-managed workspace pa
 - **WHEN** root engineering contract tests inspect the primary CI workflow
 - **THEN** the workflow is required to include lint, typecheck, test, build, CLI distribution, and coverage validation
 - **AND** the contract distinguishes required correctness gates from non-blocking external coverage upload behavior when applicable
+
+### Requirement: Pull request workflows cancel superseded runs
+Pull request workflows SHALL cancel superseded runs for the same pull request or branch so repeated pushes do not waste runner capacity.
+
+#### Scenario: Superseded pull request run is cancelled
+- **WHEN** a pull request branch receives a new commit while an older run of the same workflow is still running
+- **THEN** the newer workflow run uses the same concurrency group for that pull request or branch
+- **AND** the older in-progress run is cancelled
+
+### Requirement: Workflow files use area names
+Repository GitHub Actions workflow files SHALL use short area names while their display names describe the workflow purpose.
+
+#### Scenario: Area workflow names are inspectable
+- **WHEN** GitHub Actions workflow files are inspected
+- **THEN** root validation behavior is defined in `.github/workflows/ci.yml`
+- **AND** CLI distribution behavior is defined in `.github/workflows/cli.yml`
+- **AND** backend behavior is defined in `.github/workflows/backend.yml`
+- **AND** desktop behavior is defined in `.github/workflows/desktop.yml`
+- **AND** workflow display names remain descriptive enough to identify the purpose in GitHub checks

--- a/scripts/ci/affected-workflow.mjs
+++ b/scripts/ci/affected-workflow.mjs
@@ -11,7 +11,7 @@ const targets = {
   'backend-image': {
     workspacePackage: '@cthutool/backend',
     extraPaths: [
-      '.github/workflows/backend-image.yml',
+      '.github/workflows/backend.yml',
       'k8s/**',
       'package.json',
       'pnpm-lock.yaml',
@@ -22,7 +22,7 @@ const targets = {
   'desktop-artifacts': {
     workspacePackage: '@cthutool/desktop',
     extraPaths: [
-      '.github/workflows/desktop-artifacts.yml',
+      '.github/workflows/desktop.yml',
       'package.json',
       'pnpm-lock.yaml',
       'pnpm-workspace.yaml',
@@ -33,13 +33,14 @@ const targets = {
   'cli-dist': {
     workspacePackage: '@cthutool/cli',
     extraPaths: [
-      '.github/workflows/ci.yml',
+      '.github/workflows/cli.yml',
       'package.json',
       'pnpm-lock.yaml',
       'pnpm-workspace.yaml',
       'scripts/build-cli-dist.sh',
       'scripts/check-cli-dist.sh',
       'scripts/run-bun.sh',
+      'tsconfig.json',
     ],
   },
 };

--- a/scripts/ci/affected-workflow.mjs
+++ b/scripts/ci/affected-workflow.mjs
@@ -1,0 +1,195 @@
+#!/usr/bin/env node
+import { execFileSync } from 'node:child_process';
+import { appendFileSync, existsSync, readdirSync, readFileSync } from 'node:fs';
+import { dirname, join, relative } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = dirname(dirname(dirname(fileURLToPath(import.meta.url))));
+
+const target = process.argv[2];
+const targets = {
+  'backend-image': {
+    workspacePackage: '@cthutool/backend',
+    extraPaths: [
+      '.github/workflows/backend-image.yml',
+      'k8s/**',
+      'package.json',
+      'pnpm-lock.yaml',
+      'pnpm-workspace.yaml',
+      'tsconfig.json',
+    ],
+  },
+  'desktop-artifacts': {
+    workspacePackage: '@cthutool/desktop',
+    extraPaths: [
+      '.github/workflows/desktop-artifacts.yml',
+      'package.json',
+      'pnpm-lock.yaml',
+      'pnpm-workspace.yaml',
+      'tsconfig.json',
+      'turbo.json',
+    ],
+  },
+  'cli-dist': {
+    workspacePackage: '@cthutool/cli',
+    extraPaths: [
+      '.github/workflows/ci.yml',
+      'package.json',
+      'pnpm-lock.yaml',
+      'pnpm-workspace.yaml',
+      'scripts/build-cli-dist.sh',
+      'scripts/check-cli-dist.sh',
+      'scripts/run-bun.sh',
+    ],
+  },
+};
+
+if (!target || !targets[target]) {
+  console.error(
+    `Usage: node scripts/ci/affected-workflow.mjs ${Object.keys(targets).join('|')}`,
+  );
+  process.exit(2);
+}
+
+const changedFiles = getChangedFiles();
+const watchedPaths = getWatchedPaths(targets[target]);
+const changed = changedFiles.some((file) =>
+  watchedPaths.some((pattern) => matchesPattern(file, pattern)),
+);
+
+console.log(`target=${target}`);
+console.log(`changed=${changed}`);
+console.log(`watched_paths=${watchedPaths.join(',')}`);
+if (changedFiles.length > 0) {
+  console.log(`changed_files=${changedFiles.join(',')}`);
+}
+
+if (process.env.GITHUB_OUTPUT) {
+  appendOutput('changed', String(changed));
+}
+
+function getChangedFiles() {
+  if (process.env.GITHUB_EVENT_NAME === 'workflow_dispatch') {
+    return ['package.json'];
+  }
+
+  if (process.env.CI_CHANGED_FILES) {
+    return process.env.CI_CHANGED_FILES.split(/[\n,]/)
+      .map((file) => normalizePath(file.trim()))
+      .filter(Boolean);
+  }
+
+  const event = readGitHubEvent();
+  if (event?.pull_request?.base?.sha) {
+    return gitChangedFiles([`${event.pull_request.base.sha}...HEAD`]);
+  }
+  if (event?.before && !/^0+$/.test(event.before)) {
+    return gitChangedFiles([event.before, 'HEAD']);
+  }
+
+  const baseRef = process.env.GITHUB_BASE_REF
+    ? `origin/${process.env.GITHUB_BASE_REF}`
+    : 'origin/main';
+  return gitChangedFiles([`${baseRef}...HEAD`]);
+}
+
+function readGitHubEvent() {
+  if (!process.env.GITHUB_EVENT_PATH || !existsSync(process.env.GITHUB_EVENT_PATH)) {
+    return undefined;
+  }
+  return JSON.parse(readFileSync(process.env.GITHUB_EVENT_PATH, 'utf8'));
+}
+
+function gitChangedFiles(args) {
+  const output = execFileSync('git', ['diff', '--name-only', ...args], {
+    cwd: repoRoot,
+    encoding: 'utf8',
+  });
+  return output
+    .split('\n')
+    .map((file) => normalizePath(file.trim()))
+    .filter(Boolean);
+}
+
+function getWatchedPaths(config) {
+  const paths = new Set(config.extraPaths);
+  if (config.workspacePackage) {
+    for (const packageDir of collectWorkspacePackageDirs(config.workspacePackage)) {
+      paths.add(`${packageDir}/**`);
+    }
+  }
+  return [...paths].sort();
+}
+
+function collectWorkspacePackageDirs(rootPackageName) {
+  const packages = readWorkspacePackages();
+  const seen = new Set();
+  const visit = (packageName) => {
+    const workspacePackage = packages.get(packageName);
+    if (!workspacePackage || seen.has(workspacePackage.dir)) {
+      return;
+    }
+    seen.add(workspacePackage.dir);
+    for (const dependencyName of workspacePackage.workspaceDependencies) {
+      visit(dependencyName);
+    }
+  };
+  visit(rootPackageName);
+  return [...seen].sort();
+}
+
+function readWorkspacePackages() {
+  const packages = new Map();
+  for (const area of ['apps', 'packages']) {
+    const areaDir = join(repoRoot, area);
+    for (const entry of readdirSync(areaDir, { withFileTypes: true })) {
+      if (!entry.isDirectory()) {
+        continue;
+      }
+      const packageJsonPath = join(areaDir, entry.name, 'package.json');
+      if (!existsSync(packageJsonPath)) {
+        continue;
+      }
+      const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf8'));
+      packages.set(packageJson.name, {
+        dir: normalizePath(relative(repoRoot, dirname(packageJsonPath))),
+        workspaceDependencies: workspaceDependencies(packageJson),
+      });
+    }
+  }
+  return packages;
+}
+
+function workspaceDependencies(packageJson) {
+  return [
+    packageJson.dependencies,
+    packageJson.devDependencies,
+    packageJson.peerDependencies,
+    packageJson.optionalDependencies,
+  ].flatMap((dependencies) =>
+    Object.entries(dependencies ?? {})
+      .filter(([, version]) => String(version).startsWith('workspace:'))
+      .map(([name]) => name),
+  );
+}
+
+function matchesPattern(file, pattern) {
+  const normalizedFile = normalizePath(file);
+  const normalizedPattern = normalizePath(pattern);
+  if (normalizedPattern === '__workflow_dispatch__') {
+    return true;
+  }
+  if (normalizedPattern.endsWith('/**')) {
+    const prefix = normalizedPattern.slice(0, -3);
+    return normalizedFile === prefix || normalizedFile.startsWith(`${prefix}/`);
+  }
+  return normalizedFile === normalizedPattern;
+}
+
+function normalizePath(file) {
+  return file.replaceAll('\\', '/').replace(/^\.\/+/, '');
+}
+
+function appendOutput(name, value) {
+  appendFileSync(process.env.GITHUB_OUTPUT, `${name}=${value}\n`);
+}

--- a/tests/contract/ci-affected-workflow.test.ts
+++ b/tests/contract/ci-affected-workflow.test.ts
@@ -1,0 +1,53 @@
+import { execFileSync } from "node:child_process";
+import { join } from "node:path";
+
+const root = join(__dirname, "..", "..");
+const script = join(root, "scripts", "ci", "affected-workflow.mjs");
+
+function runAffected(target: string, changedFiles: string[]): string {
+  return execFileSync(process.execPath, [script, target], {
+    cwd: root,
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      CI_CHANGED_FILES: changedFiles.join("\n"),
+      GITHUB_EVENT_NAME: "pull_request",
+      GITHUB_EVENT_PATH: "",
+      GITHUB_OUTPUT: "",
+    },
+  });
+}
+
+function expectChanged(target: string, changedFiles: string[]) {
+  expect(runAffected(target, changedFiles)).toContain("changed=true");
+}
+
+function expectUnchanged(target: string, changedFiles: string[]) {
+  expect(runAffected(target, changedFiles)).toContain("changed=false");
+}
+
+describe("CI affected workflow detector", () => {
+  it("marks backend images affected by backend and recursive workspace dependencies", () => {
+    expectChanged("backend-image", ["apps/backend/src/main.ts"]);
+    expectChanged("backend-image", ["packages/agent-protocol/src/index.ts"]);
+    expectChanged("backend-image", ["packages/config/src/index.ts"]);
+    expectChanged("backend-image", ["k8s/deployment.yaml"]);
+    expectUnchanged("backend-image", ["packages/ui/src/index.ts"]);
+  });
+
+  it("marks desktop artifacts affected by desktop and recursive workspace dependencies", () => {
+    expectChanged("desktop-artifacts", ["apps/desktop/src/main/index.ts"]);
+    expectChanged("desktop-artifacts", ["packages/agent-protocol/src/index.ts"]);
+    expectChanged("desktop-artifacts", ["packages/app-shell/src/index.ts"]);
+    expectChanged("desktop-artifacts", ["packages/ui/src/index.ts"]);
+    expectChanged("desktop-artifacts", ["tsconfig.json"]);
+    expectUnchanged("desktop-artifacts", ["apps/backend/src/main.ts"]);
+  });
+
+  it("marks CLI distribution affected only by bundle inputs", () => {
+    expectChanged("cli-dist", ["apps/cli/src/index.ts"]);
+    expectChanged("cli-dist", ["scripts/run-bun.sh"]);
+    expectChanged("cli-dist", ["pnpm-lock.yaml"]);
+    expectUnchanged("cli-dist", ["apps/backend/src/main.ts"]);
+  });
+});

--- a/tests/contract/ci-affected-workflow.test.ts
+++ b/tests/contract/ci-affected-workflow.test.ts
@@ -31,6 +31,7 @@ describe("CI affected workflow detector", () => {
     expectChanged("backend-image", ["apps/backend/src/main.ts"]);
     expectChanged("backend-image", ["packages/agent-protocol/src/index.ts"]);
     expectChanged("backend-image", ["packages/config/src/index.ts"]);
+    expectChanged("backend-image", [".github/workflows/backend.yml"]);
     expectChanged("backend-image", ["k8s/deployment.yaml"]);
     expectUnchanged("backend-image", ["packages/ui/src/index.ts"]);
   });
@@ -40,14 +41,17 @@ describe("CI affected workflow detector", () => {
     expectChanged("desktop-artifacts", ["packages/agent-protocol/src/index.ts"]);
     expectChanged("desktop-artifacts", ["packages/app-shell/src/index.ts"]);
     expectChanged("desktop-artifacts", ["packages/ui/src/index.ts"]);
+    expectChanged("desktop-artifacts", [".github/workflows/desktop.yml"]);
     expectChanged("desktop-artifacts", ["tsconfig.json"]);
     expectUnchanged("desktop-artifacts", ["apps/backend/src/main.ts"]);
   });
 
   it("marks CLI distribution affected only by bundle inputs", () => {
     expectChanged("cli-dist", ["apps/cli/src/index.ts"]);
+    expectChanged("cli-dist", [".github/workflows/cli.yml"]);
     expectChanged("cli-dist", ["scripts/run-bun.sh"]);
     expectChanged("cli-dist", ["pnpm-lock.yaml"]);
+    expectChanged("cli-dist", ["tsconfig.json"]);
     expectUnchanged("cli-dist", ["apps/backend/src/main.ts"]);
   });
 });

--- a/tests/contract/ci-workflow.test.ts
+++ b/tests/contract/ci-workflow.test.ts
@@ -1,13 +1,31 @@
-import { readFileSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 
 const root = join(__dirname, "..", "..");
 
+function workflowPath(name: string): string {
+  return join(root, ".github", "workflows", name);
+}
+
 function readWorkflow(name: string): string {
-  return readFileSync(join(root, ".github", "workflows", name), "utf8");
+  return readFileSync(workflowPath(name), "utf8");
+}
+
+function hasWorkflow(name: string): boolean {
+  return existsSync(workflowPath(name));
 }
 
 describe("CI workflow contract", () => {
+  it("uses area workflow filenames with explicit display names", () => {
+    expect(readWorkflow("ci.yml")).toMatch(/^name: CI$/m);
+    expect(readWorkflow("cli.yml")).toMatch(/^name: CLI Distribution$/m);
+    expect(readWorkflow("backend.yml")).toMatch(/^name: Backend Image$/m);
+    expect(readWorkflow("desktop.yml")).toMatch(/^name: Desktop Artifacts$/m);
+
+    expect(hasWorkflow("backend-image.yml")).toBe(false);
+    expect(hasWorkflow("desktop-artifacts.yml")).toBe(false);
+  });
+
   it("runs complete root validation as focused CI jobs", () => {
     const yml = readWorkflow("ci.yml");
 
@@ -16,34 +34,55 @@ describe("CI workflow contract", () => {
     expect(yml).toMatch(/typecheck:/);
     expect(yml).toMatch(/test:/);
     expect(yml).toMatch(/build:/);
-    expect(yml).toMatch(/cli-dist:/);
     expect(yml).toMatch(/coverage:/);
+    expect(yml).not.toMatch(/cli-dist:/);
 
     expect(yml).toMatch(/pnpm\s+install/);
     expect(yml).toMatch(/pnpm\s+run\s+lint/);
     expect(yml).toMatch(/pnpm\s+run\s+typecheck/);
     expect(yml).toMatch(/pnpm\s+run\s+test/);
     expect(yml).toMatch(/pnpm\s+run\s+build/);
-    expect(yml).toMatch(/pnpm\s+run\s+check:cli-dist/);
     expect(yml).toMatch(/pnpm\s+run\s+test:cov/);
+    expect(yml).not.toMatch(/pnpm\s+run\s+check:cli-dist/);
   });
 
-  it("keeps CLI distribution checks required-safe when bundle inputs are unchanged", () => {
-    const yml = readWorkflow("ci.yml");
+  it("keeps CLI distribution checks required-safe in a dedicated workflow", () => {
+    const yml = readWorkflow("cli.yml");
+    const ciYml = readWorkflow("ci.yml");
 
+    expect(yml).toMatch(/pull_request:/);
+    expect(yml).toMatch(/push:/);
+    expect(yml).toMatch(/workflow_dispatch:/);
+    expect(yml).toMatch(/cli-dist:/);
     expect(yml).toContain("node scripts/ci/affected-workflow.mjs cli-dist");
     expect(yml).toContain("Skip CLI distribution check");
     expect(yml).toContain("if: steps.affected.outputs.changed != 'true'");
     expect(yml).toContain("if: steps.affected.outputs.changed == 'true'");
+    expect(yml).toMatch(/pnpm\s+run\s+check:cli-dist/);
     expect(yml).not.toContain("cli-dist-changes:");
     expect(yml).not.toContain("dorny/paths-filter");
+
+    expect(ciYml).not.toMatch(/cli-dist:/);
+    expect(ciYml).not.toContain("check:cli-dist");
+  });
+
+  it("cancels superseded workflow runs for pull request updates", () => {
+    for (const yml of [
+      readWorkflow("ci.yml"),
+      readWorkflow("cli.yml"),
+      readWorkflow("backend.yml"),
+      readWorkflow("desktop.yml"),
+    ]) {
+      expect(yml).toMatch(/concurrency:/);
+      expect(yml).toContain(
+        "${{ github.event.pull_request.number || github.ref }}",
+      );
+      expect(yml).toContain("cancel-in-progress: true");
+    }
   });
 
   it("restores Turbo cache for jobs that run Turbo tasks", () => {
-    const workflows = [
-      readWorkflow("ci.yml"),
-      readWorkflow("desktop-artifacts.yml"),
-    ];
+    const workflows = [readWorkflow("ci.yml"), readWorkflow("desktop.yml")];
 
     for (const yml of workflows) {
       expect(yml).toContain("actions/cache@v4");
@@ -67,24 +106,21 @@ describe("CI workflow contract", () => {
   });
 
   it("keeps validation jobs on read-only repository permissions", () => {
-    const yml = readWorkflow("ci.yml");
+    const ciYml = readWorkflow("ci.yml");
+    const cliYml = readWorkflow("cli.yml");
 
-    for (const job of [
-      "commitlint",
-      "lint",
-      "typecheck",
-      "test",
-      "build",
-      "cli-dist",
-    ]) {
-      expect(yml).toMatch(
+    for (const job of ["commitlint", "lint", "typecheck", "test", "build"]) {
+      expect(ciYml).toMatch(
         new RegExp(`${job}:\\n(?:.|\\n)*?permissions:\\n\\s+contents: read`),
       );
     }
+    expect(cliYml).toMatch(
+      /cli-dist:\n(?:.|\n)*?permissions:\n\s+contents: read/,
+    );
   });
 
   it("packages desktop artifacts for macOS and Windows through the Turbo graph", () => {
-    const yml = readWorkflow("desktop-artifacts.yml");
+    const yml = readWorkflow("desktop.yml");
 
     expect(yml).toContain("macos-latest");
     expect(yml).toContain("windows-latest");
@@ -99,10 +135,11 @@ describe("CI workflow contract", () => {
     expect(yml).toMatch(/@cthutool\/desktop\s+package:win:from-build/);
     expect(yml).toMatch(/@cthutool\/desktop\s+package:mac:from-build/);
     expect(yml).toContain("actions/upload-artifact@v4");
+    expect(yml).toContain("Package desktop (${{ matrix.os }})");
   });
 
   it("validates backend images on pull requests and publishes only on main", () => {
-    const yml = readWorkflow("backend-image.yml");
+    const yml = readWorkflow("backend.yml");
 
     expect(yml).toMatch(/pull_request:/);
     expect(yml).toMatch(/validate:/);
@@ -118,7 +155,7 @@ describe("CI workflow contract", () => {
     expect(yml).toContain("if: github.event_name != 'pull_request'");
     expect(yml).toContain("${{ env.IMAGE_NAME }}:main");
     expect(yml).toContain("${{ env.IMAGE_NAME }}:${{ github.sha }}");
-    expect(yml).toMatch(/concurrency:/);
     expect(yml).toContain("group: backend-image-main");
+    expect(yml).toContain("cancel-in-progress: false");
   });
 });

--- a/tests/contract/ci-workflow.test.ts
+++ b/tests/contract/ci-workflow.test.ts
@@ -104,6 +104,7 @@ describe("CI workflow contract", () => {
     expect(yml).toContain("windows-latest");
     expect(yml).toContain("packages/app-shell/**");
     expect(yml).toContain("packages/ui/**");
+    expect(yml).toContain("tsconfig.json");
     expect(yml).toContain("turbo.json");
     expect(yml).toMatch(/turbo\s+run\s+typecheck\s+test\s+build/);
     expect(yml).toContain("--filter=@cthutool/desktop...");

--- a/tests/contract/ci-workflow.test.ts
+++ b/tests/contract/ci-workflow.test.ts
@@ -16,6 +16,7 @@ describe("CI workflow contract", () => {
     expect(yml).toMatch(/typecheck:/);
     expect(yml).toMatch(/test:/);
     expect(yml).toMatch(/build:/);
+    expect(yml).toMatch(/cli-dist-changes:/);
     expect(yml).toMatch(/cli-dist:/);
     expect(yml).toMatch(/coverage:/);
 
@@ -26,6 +27,30 @@ describe("CI workflow contract", () => {
     expect(yml).toMatch(/pnpm\s+run\s+build/);
     expect(yml).toMatch(/pnpm\s+run\s+check:cli-dist/);
     expect(yml).toMatch(/pnpm\s+run\s+test:cov/);
+  });
+
+  it("runs CLI distribution checks only when bundle inputs change", () => {
+    const yml = readWorkflow("ci.yml");
+
+    expect(yml).toContain("uses: dorny/paths-filter@v3");
+    expect(yml).toContain("changed: ${{ steps.filter.outputs.cli-dist }}");
+    expect(yml).toContain("needs: cli-dist-changes");
+    expect(yml).toContain(
+      "if: needs.cli-dist-changes.outputs.changed == 'true'",
+    );
+
+    for (const path of [
+      ".github/workflows/ci.yml",
+      "apps/cli/**",
+      "scripts/build-cli-dist.sh",
+      "scripts/check-cli-dist.sh",
+      "scripts/run-bun.sh",
+      "package.json",
+      "pnpm-lock.yaml",
+      "pnpm-workspace.yaml",
+    ]) {
+      expect(yml).toContain(`- "${path}"`);
+    }
   });
 
   it("restores Turbo cache for jobs that run Turbo tasks", () => {

--- a/tests/contract/ci-workflow.test.ts
+++ b/tests/contract/ci-workflow.test.ts
@@ -16,7 +16,6 @@ describe("CI workflow contract", () => {
     expect(yml).toMatch(/typecheck:/);
     expect(yml).toMatch(/test:/);
     expect(yml).toMatch(/build:/);
-    expect(yml).toMatch(/cli-dist-changes:/);
     expect(yml).toMatch(/cli-dist:/);
     expect(yml).toMatch(/coverage:/);
 
@@ -29,28 +28,15 @@ describe("CI workflow contract", () => {
     expect(yml).toMatch(/pnpm\s+run\s+test:cov/);
   });
 
-  it("runs CLI distribution checks only when bundle inputs change", () => {
+  it("keeps CLI distribution checks required-safe when bundle inputs are unchanged", () => {
     const yml = readWorkflow("ci.yml");
 
-    expect(yml).toContain("uses: dorny/paths-filter@v3");
-    expect(yml).toContain("changed: ${{ steps.filter.outputs.cli-dist }}");
-    expect(yml).toContain("needs: cli-dist-changes");
-    expect(yml).toContain(
-      "if: needs.cli-dist-changes.outputs.changed == 'true'",
-    );
-
-    for (const path of [
-      ".github/workflows/ci.yml",
-      "apps/cli/**",
-      "scripts/build-cli-dist.sh",
-      "scripts/check-cli-dist.sh",
-      "scripts/run-bun.sh",
-      "package.json",
-      "pnpm-lock.yaml",
-      "pnpm-workspace.yaml",
-    ]) {
-      expect(yml).toContain(`- "${path}"`);
-    }
+    expect(yml).toContain("node scripts/ci/affected-workflow.mjs cli-dist");
+    expect(yml).toContain("Skip CLI distribution check");
+    expect(yml).toContain("if: steps.affected.outputs.changed != 'true'");
+    expect(yml).toContain("if: steps.affected.outputs.changed == 'true'");
+    expect(yml).not.toContain("cli-dist-changes:");
+    expect(yml).not.toContain("dorny/paths-filter");
   });
 
   it("restores Turbo cache for jobs that run Turbo tasks", () => {
@@ -102,10 +88,12 @@ describe("CI workflow contract", () => {
 
     expect(yml).toContain("macos-latest");
     expect(yml).toContain("windows-latest");
-    expect(yml).toContain("packages/app-shell/**");
-    expect(yml).toContain("packages/ui/**");
-    expect(yml).toContain("tsconfig.json");
-    expect(yml).toContain("turbo.json");
+    expect(yml).toContain(
+      "node scripts/ci/affected-workflow.mjs desktop-artifacts",
+    );
+    expect(yml).toContain("Skip desktop artifact package");
+    expect(yml).toContain("if: steps.affected.outputs.changed != 'true'");
+    expect(yml).toContain("if: steps.affected.outputs.changed == 'true'");
     expect(yml).toMatch(/turbo\s+run\s+typecheck\s+test\s+build/);
     expect(yml).toContain("--filter=@cthutool/desktop...");
     expect(yml).toMatch(/@cthutool\/desktop\s+package:win:from-build/);
@@ -119,6 +107,13 @@ describe("CI workflow contract", () => {
     expect(yml).toMatch(/pull_request:/);
     expect(yml).toMatch(/validate:/);
     expect(yml).toMatch(/build-and-push:/);
+    expect(yml).toContain(
+      "node scripts/ci/affected-workflow.mjs backend-image",
+    );
+    expect(yml).toContain("Skip backend image validation");
+    expect(yml).toContain("Skip backend image publish");
+    expect(yml).toContain("if: steps.affected.outputs.changed != 'true'");
+    expect(yml).toContain("if: steps.affected.outputs.changed == 'true'");
     expect(yml).toContain("push: false");
     expect(yml).toContain("if: github.event_name != 'pull_request'");
     expect(yml).toContain("${{ env.IMAGE_NAME }}:main");


### PR DESCRIPTION
## Summary
- Split CLI distribution validation into a dedicated CLI Distribution workflow while keeping the required-facing `cli-dist` job name stable.
- Rename scoped workflow files to `cli.yml`, `backend.yml`, and `desktop.yml`, with job-internal affected checks and PR concurrency.
- Sync and archive OpenSpec change `refine-ci-required-workflows`, including the new CLI distribution CI spec.

## Verification
- `corepack pnpm exec vitest run tests/contract/ci-workflow.test.ts tests/contract/ci-affected-workflow.test.ts`
- `openspec validate --specs`
- `git diff --check`

Note: local pre-commit was bypassed for the final commit because pnpm blocked on ignored dependency build approval in this environment; the relevant checks above passed.