### PR TITLE
Update OpenSpec purposes for backend and CLI capabilities

### DIFF
--- a/openspec/changes/organize-openspec-spec-docs/.openspec.yaml
+++ b/openspec/changes/organize-openspec-spec-docs/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-22

--- a/openspec/changes/organize-openspec-spec-docs/design.md
+++ b/openspec/changes/organize-openspec-spec-docs/design.md
@@ -1,0 +1,59 @@
+## Context
+
+The current main OpenSpec set contains 56 first-level capabilities and validates successfully. The main maintenance problem is not parser correctness; it is discoverability and stale wording left by archived changes. The current set includes newer backend browser boundaries such as `apps-backend-browser-service`, `apps-backend-browser-public-api`, `packages-browser-runtime-protocol`, and `packages-browser-client-sdk`, plus several observability capabilities that did not exist when this cleanup was first proposed.
+
+OpenSpec 1.3.1 discovers specs as `openspec/specs/<capability>/spec.md` and active change deltas as `openspec/changes/<change>/specs/<capability>/spec.md`. Nested area directories under `openspec/specs/` would not be first-class capabilities for listing, validation, archive, or apply flows. Project policy also prefers ownership-visible area prefixes rather than generic names.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Make the current 56-capability spec set easier to browse through a non-normative `openspec/specs/README.md` capability map.
+- Preserve OpenSpec-compatible first-level capability directories and ownership-visible prefixes.
+- Replace placeholder Purpose text and normalize missing top-level titles in main specs.
+- Clean up backend browser wording so business-facing browser workflows consistently point at `BrowserService`, while `DesktopBrowserRuntimeModule` remains the lower-level runtime client.
+- Record possible future consolidation candidates without deleting or merging capability directories in this change.
+
+**Non-Goals:**
+
+- Do not restructure `openspec/specs/` into nested subdirectories.
+- Do not edit archived changes under `openspec/changes/archive/**`.
+- Do not modify application code, package dependencies, generated agent adapter files, public APIs, runtime behavior, or build configuration.
+- Do not merge or delete capability directories in this change.
+
+## Decisions
+
+1. Keep first-level capability directories and add a capability map.
+
+   `openspec/specs/README.md` will group existing specs by area prefix and explain ownership boundaries. This gives humans the navigation benefit of subdirectories without breaking OpenSpec commands. The alternative, moving specs into nested area folders, was rejected because current OpenSpec discovery only treats first-level directories containing `spec.md` as capabilities.
+
+2. Treat the capability map as non-normative.
+
+   Requirement behavior remains in each capability's `spec.md`. The map should summarize purpose, ownership, and related specs, but it must not introduce new product requirements. This avoids a second source of truth.
+
+3. Limit normative deltas to backend browser boundary wording.
+
+   Main specs already validate, and most cleanup is editorial. The only requirement-level change in this cleanup is to align browser content/service wording with the current `BrowserService` aggregate boundary. This keeps the change small enough to review while still removing stale public-boundary language.
+
+4. Defer capability consolidation.
+
+   Specs such as `apps-backend-browser-agent-capture`, `apps-backend-browser-automation`, `apps-backend-agent-state`, and the small GitOps specs are possible future consolidation candidates. They should not be merged here because OpenSpec has no first-class capability-directory merge operation, and deleting capability directories is a larger governance decision than adding a map and normalizing docs.
+
+## Risks / Trade-offs
+
+- [Risk] The capability map can drift from individual specs. Mitigation: keep it short, link to capability names, and update it only as part of OpenSpec changes that add, remove, or meaningfully move specs.
+- [Risk] Purpose rewrites may accidentally imply new behavior. Mitigation: keep Purpose text descriptive and avoid SHALL/MUST language outside Requirements.
+- [Risk] Backend browser docs may still contain implementation-internal names after this cleanup. Mitigation: tasks include targeted searches for `BrowserContentModule`, `BrowserContentService`, and stale browser-automation references after edits.
+- [Risk] Deferring consolidation leaves small specs in place. Mitigation: the capability map will make their status visible, and a later dedicated consolidation change can handle directory removal with explicit manual cleanup tasks.
+
+## Migration Plan
+
+1. Create delta specs for the backend browser wording that changes normative requirements.
+2. Add the capability map and normalize main spec titles/Purpose sections during implementation.
+3. Validate main specs and the active change with OpenSpec.
+4. Leave follow-up consolidation candidates documented, but do not delete capability directories in this change.
+
+## Open Questions
+
+- Should a future consolidation change merge retired backend browser marker specs into `apps-backend-browser-service` or `apps-backend-desktop-browser-runtime`?
+- Should the small GitOps specs stay separate because they map to different cluster ownership surfaces, or become one broader GitOps delivery capability?

--- a/openspec/changes/organize-openspec-spec-docs/proposal.md
+++ b/openspec/changes/organize-openspec-spec-docs/proposal.md
@@ -1,0 +1,37 @@
+## Why
+
+The main OpenSpec specifications validate successfully, but the spec set has grown to 56 capabilities and is becoming hard to navigate without an explicit map. Several specs still carry archived-change placeholder Purpose sections or inconsistent document structure, and the backend browser specs now need documentation cleanup around the newer `BrowserService` aggregate boundary rather than the older runtime-boundary conflict.
+
+## What Changes
+
+- Normalize main spec document structure so every `openspec/specs/<capability>/spec.md` has a clear top-level title, a useful Purpose, and consistent section spacing.
+- Replace archived-change placeholder Purpose text with concise capability summaries.
+- Add `openspec/specs/README.md` as a non-normative capability map that groups existing first-level capability directories by area prefix and summarizes ownership boundaries, including the current backend browser, browser protocol/client SDK, observability, GitOps, apps, packages, Codex plugin, and collection-hub areas.
+- Preserve existing capability directory names and area prefixes; do not rename `collection-hub-*` or other already clear area-prefixed specs.
+- Do not restructure specs into nested subdirectories; OpenSpec CLI support remains centered on `openspec/specs/<capability>/spec.md` and `openspec/changes/<change>/specs/<capability>/spec.md`.
+- Review low-signal capability specs for consolidation, limited to retired, placeholder, or boundary-only specs where the requirement belongs more naturally inside an existing owning capability; record consolidation candidates in the design and tasks rather than merging capability directories in this change.
+- Avoid merging large or actively evolving product/module capabilities solely to reduce directory count; large specs should be handled by clearer mapping first and split later only when ownership or change cadence requires it.
+- Leave `openspec/changes/archive/**` historical artifacts unchanged.
+- Clean up backend browser documentation around the current aggregate boundary:
+  - `BrowserService` is the backend business-facing facade for approved browser workflows.
+  - `DesktopBrowserRuntimeModule` remains the lower-level backend client for typed desktop browser runtime operations.
+  - Content/auth specs should avoid stale public-boundary wording that suggests backend business modules import content/auth internals directly.
+- Keep the change documentation-focused: no application code, public APIs, runtime behavior, package dependencies, or generated adapter folders are changed.
+
+## Capabilities
+
+### New Capabilities
+
+- None.
+
+### Modified Capabilities
+
+- `apps-backend-browser-content`: Clean up residual public-boundary wording so content workflows are described as exposed through `BrowserService` while content helpers remain internal implementation details.
+- `apps-backend-browser-service`: Clarify the aggregate browser boundary as the capability-map anchor for backend browser workflows.
+
+## Impact
+
+- Affected artifacts are limited to OpenSpec documents under `openspec/specs/**`, the non-normative capability map at `openspec/specs/README.md`, and this change's OpenSpec artifacts.
+- No source code, APIs, database schemas, package dependencies, build scripts, or runtime configuration are expected to change.
+- Future OpenSpec work should get clearer capability summaries and fewer contradictory backend browser boundary requirements.
+- Potential future consolidation of retired or boundary-only specs will require a separate scoped change because OpenSpec delta application updates requirement content but does not provide a first-class capability-directory merge operation.

--- a/openspec/changes/organize-openspec-spec-docs/specs/apps-backend-browser-content/spec.md
+++ b/openspec/changes/organize-openspec-spec-docs/specs/apps-backend-browser-content/spec.md
@@ -1,9 +1,5 @@
-# apps-backend-browser-content Specification
+## MODIFIED Requirements
 
-## Purpose
-Define backend browser content workflow behavior exposed through BrowserService, including site policy, controlled capture, detection, diagnostics, and observability.
-
-## Requirements
 ### Requirement: Browser content module
 The backend SHALL expose browser page content retrieval through `BrowserService`; any content-specific providers SHALL be internal implementation details that do not own public browser API routes, browser profile reporting routes, site configuration storage, browser auth coordination, or concrete agent/browser runtime command execution.
 

--- a/openspec/changes/organize-openspec-spec-docs/specs/apps-backend-browser-service/spec.md
+++ b/openspec/changes/organize-openspec-spec-docs/specs/apps-backend-browser-service/spec.md
@@ -1,0 +1,13 @@
+## ADDED Requirements
+
+### Requirement: Browser service anchors backend browser documentation
+The backend browser documentation SHALL identify `BrowserService` as the business-facing aggregate boundary for approved browser workflows, while lower-level runtime, protocol, content, auth, diagnostics, and site-policy details remain in their owning capability specs.
+
+#### Scenario: Capability map lists backend browser workflow owner
+- **WHEN** a developer reads the OpenSpec capability map for backend browser workflows
+- **THEN** `apps-backend-browser-service` is identified as the aggregate entry point for business-facing browser workflows
+- **AND** lower-level runtime or protocol capabilities are listed as supporting boundaries rather than alternate business-module entry points
+
+#### Scenario: Browser internals stay linked to owning specs
+- **WHEN** the capability map describes browser content, auth, runtime protocol, public API, or client SDK capabilities
+- **THEN** it links those capabilities to their owning specs without moving their requirements into the map

--- a/openspec/changes/organize-openspec-spec-docs/tasks.md
+++ b/openspec/changes/organize-openspec-spec-docs/tasks.md
@@ -1,0 +1,27 @@
+## 1. Spec Inventory And Map
+
+- [x] 1.1 Inventory current first-level `openspec/specs/<capability>/spec.md` directories and group them by ownership-visible area prefix.
+- [x] 1.2 Create `openspec/specs/README.md` as a non-normative capability map covering backend browser, browser protocol/client SDK, observability, GitOps, apps, packages, Codex plugin, and collection-hub areas.
+- [x] 1.3 Mark retired, placeholder, or boundary-only specs as consolidation candidates in the capability map without deleting or moving their directories.
+- [x] 1.4 Confirm the map links to existing capability names and does not introduce SHALL/MUST product requirements.
+
+## 2. Main Spec Documentation Cleanup
+
+- [x] 2.1 Replace archived-change placeholder Purpose text in main specs with concise descriptive Purpose sections.
+- [x] 2.2 Add missing top-level `# <capability> Specification` headings to specs that currently start at `## Purpose`.
+- [x] 2.3 Preserve existing first-level capability directory names and avoid nested `openspec/specs/<area>/<capability>/` layouts.
+- [x] 2.4 Leave `openspec/changes/archive/**` unchanged.
+
+## 3. Backend Browser Boundary Wording
+
+- [x] 3.1 Apply the `apps-backend-browser-service` delta so OpenSpec documentation identifies `BrowserService` as the backend browser aggregate entry point.
+- [x] 3.2 Apply the `apps-backend-browser-content` delta so browser content workflows are described as exposed through `BrowserService` while content helpers remain internal.
+- [x] 3.3 Search backend browser specs for stale public-boundary wording such as direct business-module imports of `BrowserContentModule` or `BrowserContentService`, and update only wording covered by this change.
+- [x] 3.4 Keep `DesktopBrowserRuntimeModule` documented as the lower-level runtime client rather than a business-facing facade.
+
+## 4. Verification
+
+- [x] 4.1 Run `openspec validate --specs` and confirm all main specs pass.
+- [x] 4.2 Run `openspec validate organize-openspec-spec-docs` and confirm the active change passes.
+- [x] 4.3 Confirm no application source files, package manifests, generated `.claude/`, `.codex/`, or `.cursor/` adapter files were changed.
+- [x] 4.4 Review `git diff` to confirm the change is limited to OpenSpec documentation and this change's artifacts.

--- a/openspec/specs/README.md
+++ b/openspec/specs/README.md
@@ -1,0 +1,93 @@
+# OpenSpec Capability Map
+
+This map is a non-normative guide to the first-level capability specs under `openspec/specs/`. Requirement behavior lives in each capability's `spec.md`; this file is only for navigation and ownership context.
+
+OpenSpec currently treats each `openspec/specs/<capability>/spec.md` directory as a first-class capability. Area prefixes keep ownership visible without adding nested spec directories.
+
+## Backend
+
+### Agent Transport
+
+- [apps-backend-agent-registry](apps-backend-agent-registry/spec.md): connected desktop agent registration, heartbeat, status, and command delegation boundaries.
+- [apps-backend-agent-command-gateway](apps-backend-agent-command-gateway/spec.md): typed command dispatch and response correlation over agent transport.
+- [apps-backend-agent-state](apps-backend-agent-state/spec.md): boundary marker that keeps capability-specific state out of generic agent state. Consolidation candidate for a later registry or transport-boundary change.
+
+### Browser Workflows
+
+- [apps-backend-browser-service](apps-backend-browser-service/spec.md): aggregate backend entry point for business-facing browser workflows.
+- [apps-backend-browser-content](apps-backend-browser-content/spec.md): controlled page content, diagnostics, detection, and content workflow behavior exposed through `BrowserService`.
+- [apps-backend-browser-auth](apps-backend-browser-auth/spec.md): browser profile status, login, verification, and interaction challenge behavior exposed through `BrowserService`.
+- [apps-backend-browser-public-api](apps-backend-browser-public-api/spec.md): trusted third-party browser session and action API surface.
+- [apps-backend-desktop-browser-runtime](apps-backend-desktop-browser-runtime/spec.md): lower-level backend client for typed desktop browser runtime operations.
+- [apps-backend-sites-config](apps-backend-sites-config/spec.md): backend effective site configuration loading, lookup, and browser consumer compatibility.
+- [apps-backend-browser-agent-capture](apps-backend-browser-agent-capture/spec.md): retired browser capture marker. Consolidation candidate for a later browser runtime/service cleanup.
+- [apps-backend-browser-automation](apps-backend-browser-automation/spec.md): retired browser automation composition marker. Consolidation candidate for a later browser service/runtime cleanup.
+
+### Backend Domains And Delivery
+
+- [apps-backend-douban-movie-info](apps-backend-douban-movie-info/spec.md): Douban movie information retrieval and parsing through controlled browser content.
+- [apps-backend-image-ci](apps-backend-image-ci/spec.md): backend image CI build and verification behavior.
+- [apps-backend-image-delivery](apps-backend-image-delivery/spec.md): backend image publishing and deployment consumption behavior.
+- [apps-backend-observability](apps-backend-observability/spec.md): backend request context, events, readiness, metrics, and trace semantics.
+
+## CLI
+
+- [apps-cli-agent-contract](apps-cli-agent-contract/spec.md): shared CLI runtime contract, interactivity, JSON output, quiet mode, and stable command errors.
+- [apps-cli-bundled-script-execution](apps-cli-bundled-script-execution/spec.md): bundled script discovery, invocation, interactive selection, and JSON-safe execution.
+- [apps-cli-codex-config](apps-cli-codex-config/spec.md): reproducible Codex configuration maintenance and repository-managed Codex state.
+- [apps-cli-codex-plugin-management](apps-cli-codex-plugin-management/spec.md): repository-owned Codex plugin discovery, install, cache sync, and language-coach hook behavior.
+- [apps-cli-distribution-ci](apps-cli-distribution-ci/spec.md): CLI distribution CI behavior.
+- [apps-cli-observability](apps-cli-observability/spec.md): CLI command diagnostics, JSON-safe observability, stderr behavior, and redaction.
+- [apps-cli-self-installation](apps-cli-self-installation/spec.md): GitHub-based personal installation, lifecycle status, and update behavior.
+- [apps-cli-shell-completion](apps-cli-shell-completion/spec.md): PowerShell and zsh completion behavior for `chc`.
+
+## Desktop
+
+- [apps-desktop-agent-console](apps-desktop-agent-console/spec.md): desktop agent connection configuration, identity, and status presentation.
+- [apps-desktop-browser-host](apps-desktop-browser-host/spec.md): desktop-owned browser runtime, profile, login, verification, and controlled command handling.
+- [apps-desktop-douban-movie-info](apps-desktop-douban-movie-info/spec.md): desktop UI for Douban movie lookup by subject id or URL.
+- [apps-desktop-observability](apps-desktop-observability/spec.md): desktop observability and safe diagnostic semantics.
+- [apps-desktop-packaging-ci](apps-desktop-packaging-ci/spec.md): desktop icon assets, packaging configuration, and artifact workflow behavior.
+- [apps-desktop-product-shell](apps-desktop-product-shell/spec.md): CthuDesktop product shell, navigation, visual system, window behavior, and settings surfaces.
+
+## Web And Docs
+
+- [apps-web-project-shell](apps-web-project-shell/spec.md): browser-hosted management console scaffold and workspace integration.
+- [apps-web-observability](apps-web-observability/spec.md): web frontend observability, API correlation, console diagnostics, and UI error reporting.
+- [apps-docs-site](apps-docs-site/spec.md): Astro Starlight documentation site, information architecture, content model, and OpenSpec capability discovery.
+- [apps-root-engineering-config](apps-root-engineering-config/spec.md): root monorepo governance, package scripts, CI policy, and engineering configuration.
+- [apps-runtime-structured-logs](apps-runtime-structured-logs/spec.md): shared runtime structured logging semantics across apps.
+
+## Packages
+
+- [packages-agent-protocol](packages-agent-protocol/spec.md): shared agent protocol envelopes, command messages, and compatibility behavior.
+- [packages-agent-protocol-observability](packages-agent-protocol-observability/spec.md): agent protocol observability metadata, validation, and redaction.
+- [packages-app-shell-runtime](packages-app-shell-runtime/spec.md): host-neutral app shell runtime contracts and shared page composition.
+- [packages-app-shell-observability](packages-app-shell-observability/spec.md): app shell observability semantics.
+- [packages-browser-runtime-protocol](packages-browser-runtime-protocol/spec.md): typed browser runtime method names, payload schemas, JSON-RPC helpers, and operation challenges.
+- [packages-browser-client-sdk](packages-browser-client-sdk/spec.md): TypeScript SDK for the backend public browser API.
+- [packages-config-browser-sites](packages-config-browser-sites/spec.md): versioned browser sites JSON schema, loading, merge behavior, and sensitive-data exclusion.
+- [packages-config-observability](packages-config-observability/spec.md): shared observability configuration schema, defaults, validation, environment naming, and redaction.
+- [packages-ui-shared-components](packages-ui-shared-components/spec.md): shared React UI primitives, semantic tokens, and accessible interaction patterns.
+
+## Codex Plugins
+
+- [codex-plugins-cthu-codex-anki-mcp](codex-plugins-cthu-codex-anki-mcp/spec.md): CthuCodex Anki MCP server integration and note creation workflows.
+- [codex-plugins-cthu-codex-english-expression-skill](codex-plugins-cthu-codex-english-expression-skill/spec.md): English expression Anki note skill.
+- [codex-plugins-cthu-codex-japanese-sentence-skill](codex-plugins-cthu-codex-japanese-sentence-skill/spec.md): Japanese sentence Anki note skill.
+- [codex-plugins-cthu-codex-japanese-vocabulary-skill](codex-plugins-cthu-codex-japanese-vocabulary-skill/spec.md): Japanese vocabulary Anki note skill.
+- [codex-plugins-cthu-codex-language-coach](codex-plugins-cthu-codex-language-coach/spec.md): prompt-time English prose coaching hook behavior.
+
+## Collection Hub
+
+- [collection-hub-workspace](collection-hub-workspace/spec.md): isolated experimental Collection Hub workspace, package boundaries, and local development commands.
+- [collection-hub-import-api](collection-hub-import-api/spec.md): local API import validation, persistence, dashboard data, and item mutations.
+- [collection-hub-import-extension](collection-hub-import-extension/spec.md): browser extension page matching, extraction, and local API submission.
+- [collection-hub-dashboard](collection-hub-dashboard/spec.md): dashboard browsing, author views, rating filters, and item triage.
+
+## GitOps
+
+- [gitops-argo-applications](gitops-argo-applications/spec.md): ArgoCD Application resources for deployed apps. Consolidation candidate for a later GitOps delivery cleanup.
+- [gitops-bootstrap](gitops-bootstrap/spec.md): bootstrap scaffold for future ArgoCD self-management manifests. Consolidation candidate for a later GitOps delivery cleanup.
+- [gitops-cluster-namespaces](gitops-cluster-namespaces/spec.md): Kubernetes namespace resources for deployed applications. Consolidation candidate for a later GitOps delivery cleanup.
+- [gitops-observability-stack](gitops-observability-stack/spec.md): GitOps-managed Kubernetes observability stack and telemetry extension boundaries.

--- a/openspec/specs/apps-backend-agent-command-gateway/spec.md
+++ b/openspec/specs/apps-backend-agent-command-gateway/spec.md
@@ -1,7 +1,8 @@
 # apps-backend-agent-command-gateway Specification
 
 ## Purpose
-TBD - created by archiving change apps-backend-agent-browser-layer-split. Update Purpose after archive.
+Define the backend command gateway boundary for JSON-RPC command dispatch, response correlation, transport hiding, capability neutrality, and command observability.
+
 ## Requirements
 ### Requirement: Agent command gateway
 The backend SHALL provide an agent command gateway that dispatches JSON-RPC 2.0-compatible command requests to registered desktop agents and correlates JSON-RPC success or error responses without exposing raw WebSocket internals or capability-specific business logic to callers.
@@ -69,4 +70,3 @@ The agent command gateway SHALL emit observable command lifecycle events that co
 #### Scenario: Command timeout is observable
 - **WHEN** a pending command times out
 - **THEN** the gateway records a timeout event and removes the pending correlation entry without exposing raw WebSocket internals to business modules
-

--- a/openspec/specs/apps-backend-agent-registry/spec.md
+++ b/openspec/specs/apps-backend-agent-registry/spec.md
@@ -1,7 +1,8 @@
 # apps-backend-agent-registry Specification
 
 ## Purpose
-TBD - created by archiving change apps-desktop-agent-console. Update Purpose after archive.
+Define the backend desktop agent registry for WebSocket registration, heartbeat freshness, connected-agent status, diagnostics, and transport-only delegation.
+
 ## Requirements
 ### Requirement: Agent WebSocket endpoint
 The backend SHALL expose a WebSocket endpoint that accepts desktop agent connections.

--- a/openspec/specs/apps-backend-agent-state/spec.md
+++ b/openspec/specs/apps-backend-agent-state/spec.md
@@ -1,7 +1,8 @@
 # apps-backend-agent-state Specification
 
 ## Purpose
-TBD - created by archiving change apps-backend-agent-browser-layer-split. Update Purpose after archive.
+Define the backend agent state boundary that keeps capability-specific browser, auth, page, and diagnostic state out of generic agent status.
+
 ## Requirements
 ### Requirement: Agent state excludes capability state
 The backend SHALL NOT use agent state modules to store capability-specific browser profiles, pending auth tasks, page state, diagnostics, or site-specific browser status.
@@ -13,4 +14,3 @@ The backend SHALL NOT use agent state modules to store capability-specific brows
 #### Scenario: Agent status is needed
 - **WHEN** a caller needs connected desktop client status
 - **THEN** it reads registry-owned public agent status containing only client metadata, online state, freshness, and capabilities
-

--- a/openspec/specs/apps-backend-browser-agent-capture/spec.md
+++ b/openspec/specs/apps-backend-browser-agent-capture/spec.md
@@ -1,7 +1,8 @@
 # apps-backend-browser-agent-capture Specification
 
 ## Purpose
-TBD - created by archiving change apps-backend-browser-agent-capture-module. Update Purpose after archive.
+Define the retired browser agent capture marker and document that browser capture execution is owned by the desktop browser runtime boundary.
+
 ## Requirements
 ### Requirement: Browser agent capture capability retired
 The backend SHALL NOT expose browser capture as an agent-named module capability; browser capture execution MUST be owned by `apps-backend-desktop-browser-runtime`.
@@ -9,4 +10,3 @@ The backend SHALL NOT expose browser capture as an agent-named module capability
 #### Scenario: Capture execution is requested
 - **WHEN** backend browser content or auth workflows need desktop browser capture
 - **THEN** they use `desktop-browser-runtime` instead of `BrowserAgentCaptureModule`
-

--- a/openspec/specs/apps-backend-browser-auth/spec.md
+++ b/openspec/specs/apps-backend-browser-auth/spec.md
@@ -1,7 +1,8 @@
 # apps-backend-browser-auth Specification
 
 ## Purpose
-TBD - created by archiving change apps-backend-agent-browser-layer-split. Update Purpose after archive.
+Define backend browser auth workflow behavior exposed through BrowserService, including runtime profile status, login verification, and interaction challenges.
+
 ## Requirements
 ### Requirement: Browser auth workflow service
 The backend SHALL keep browser login workflow semantics behind `BrowserService` while desktop remains the source of truth for actual browser login state and browser profile status is queried on demand through the desktop browser runtime.
@@ -39,4 +40,3 @@ The backend browser auth workflow exposed through `BrowserService` SHALL return 
 #### Scenario: Login challenge is resolved
 - **WHEN** a caller asks desktop to open login or verify the profile for a challenge
 - **THEN** `BrowserService` dispatches the request through `DesktopBrowserRuntimeModule` and returns public verification status
-

--- a/openspec/specs/apps-backend-browser-automation/spec.md
+++ b/openspec/specs/apps-backend-browser-automation/spec.md
@@ -1,5 +1,8 @@
+# apps-backend-browser-automation Specification
+
 ## Purpose
 Define backend-owned browser automation services, browser auth profiles, controlled diagnostics, and CLI auth helper behavior for internal page content retrieval.
+
 ## Requirements
 ### Requirement: Browser automation composition module retired
 The backend SHALL NOT expose `BrowserAutomationModule` as a standalone browser domain or composition module, and the `apps/backend/src/modules/browser-automation/` directory SHALL be removed after surviving errors, types, auth helpers, and stores move under browser-owned module boundaries.

--- a/openspec/specs/apps-backend-browser-service/spec.md
+++ b/openspec/specs/apps-backend-browser-service/spec.md
@@ -1,7 +1,8 @@
 # apps-backend-browser-service Specification
 
 ## Purpose
-TBD - created by archiving change apps-browser-runtime-protocol-hardening. Update Purpose after archive.
+Define BrowserModule and BrowserService as the backend aggregate boundary for approved browser workflows and browser workflow policy.
+
 ## Requirements
 ### Requirement: BrowserModule aggregate boundary
 The backend SHALL expose `BrowserModule` as the public aggregate module for backend browser workflows.
@@ -73,3 +74,15 @@ The backend SHALL expose a `BrowserService` facade as the single supported brows
 #### Scenario: Runtime operation is needed
 - **WHEN** a new browser capability is required
 - **THEN** the capability is added as a typed browser runtime protocol method and then surfaced through `BrowserService` only when it matches an approved backend workflow
+
+### Requirement: Browser service anchors backend browser documentation
+The backend browser documentation SHALL identify `BrowserService` as the business-facing aggregate boundary for approved browser workflows, while lower-level runtime, protocol, content, auth, diagnostics, and site-policy details remain in their owning capability specs.
+
+#### Scenario: Capability map lists backend browser workflow owner
+- **WHEN** a developer reads the OpenSpec capability map for backend browser workflows
+- **THEN** `apps-backend-browser-service` is identified as the aggregate entry point for business-facing browser workflows
+- **AND** lower-level runtime or protocol capabilities are listed as supporting boundaries rather than alternate business-module entry points
+
+#### Scenario: Browser internals stay linked to owning specs
+- **WHEN** the capability map describes browser content, auth, runtime protocol, public API, or client SDK capabilities
+- **THEN** it links those capabilities to their owning specs without moving their requirements into the map

--- a/openspec/specs/apps-backend-desktop-browser-runtime/spec.md
+++ b/openspec/specs/apps-backend-desktop-browser-runtime/spec.md
@@ -1,7 +1,8 @@
 # apps-backend-desktop-browser-runtime Specification
 
 ## Purpose
-TBD - created by archiving change apps-backend-agent-transport-boundary. Update Purpose after archive.
+Define the backend desktop browser runtime client for typed browser operations, session lifecycle commands, runtime errors, challenges, and observability.
+
 ## Requirements
 ### Requirement: Desktop browser runtime module
 The backend SHALL provide a `DesktopBrowserRuntimeModule` that exposes desktop browser capability operations without exposing agent transport internals or backend-local Playwright APIs.

--- a/openspec/specs/apps-backend-douban-movie-info/spec.md
+++ b/openspec/specs/apps-backend-douban-movie-info/spec.md
@@ -2,6 +2,7 @@
 
 ## Purpose
 Define the backend API and parsing contract for retrieving Douban movie information by subject id through the controlled browser content pipeline.
+
 ## Requirements
 ### Requirement: Douban movie info API
 The backend SHALL provide a Douban movie info API that retrieves one movie by Douban subject id.

--- a/openspec/specs/apps-backend-image-ci/spec.md
+++ b/openspec/specs/apps-backend-image-ci/spec.md
@@ -1,7 +1,8 @@
 # apps-backend-image-ci Specification
 
 ## Purpose
-TBD - created by archiving change improve-ci-coverage-and-speed. Update Purpose after archive.
+Define backend container image CI validation, affected-input handling, deployment manifest updates, pinned tool versions, and workflow naming.
+
 ## Requirements
 ### Requirement: Backend image CI validates pull request Docker builds
 The backend image workflow SHALL expose a stable pull request validation job and SHALL build backend Docker images only when affected inputs change.
@@ -65,4 +66,3 @@ The backend image workflow SHALL be stored in an area-named workflow file while 
 - **THEN** backend image behavior is defined in `.github/workflows/backend.yml`
 - **AND** the workflow display name identifies backend image behavior
 - **AND** the old `.github/workflows/backend-image.yml` file is not retained as a duplicate workflow
-

--- a/openspec/specs/apps-backend-image-delivery/spec.md
+++ b/openspec/specs/apps-backend-image-delivery/spec.md
@@ -1,7 +1,8 @@
 # apps-backend-image-delivery Specification
 
 ## Purpose
-TBD - created by archiving change add-homelab-gitops. Update Purpose after archive.
+Define backend container image publishing to GitHub Container Registry and downstream deployment image consumption.
+
 ## Requirements
 ### Requirement: Backend image is published to GHCR
 

--- a/openspec/specs/apps-backend-observability/spec.md
+++ b/openspec/specs/apps-backend-observability/spec.md
@@ -2,6 +2,7 @@
 
 ## Purpose
 Define backend request context, structured event, readiness, metrics, and trace semantics so CthuTool backend operations can be safely correlated and monitored.
+
 ## Requirements
 ### Requirement: Backend request context
 The backend SHALL assign or preserve a request context for HTTP entry points that includes a request identifier, start time, method, route or path, response status, duration, and optional upstream correlation metadata.

--- a/openspec/specs/apps-backend-sites-config/spec.md
+++ b/openspec/specs/apps-backend-sites-config/spec.md
@@ -2,6 +2,7 @@
 
 ## Purpose
 Define the backend-owned module and service boundary for effective site configuration loading, override merging, lookup, and browser automation consumer compatibility.
+
 ## Requirements
 ### Requirement: Backend sites config module
 The backend SHALL provide a `SitesConfigModule` that owns effective site configuration loading and lookup without depending on browser runtime, agent state, browser command dispatch, profile storage, pending auth tasks, or diagnostics.

--- a/openspec/specs/apps-cli-agent-contract/spec.md
+++ b/openspec/specs/apps-cli-agent-contract/spec.md
@@ -1,5 +1,8 @@
+# apps-cli-agent-contract Specification
+
 ## Purpose
 Define the apps/cli shared runtime contract for interactivity, JSON output, quiet output, prompt suppression, and stable command errors.
+
 ## Requirements
 ### Requirement: Shared CLI Context
 The CLI SHALL derive a shared command context containing TTY state, interactivity, JSON output mode, and quiet output mode before command implementations perform prompt or rendering decisions.

--- a/openspec/specs/apps-cli-bundled-script-execution/spec.md
+++ b/openspec/specs/apps-cli-bundled-script-execution/spec.md
@@ -1,3 +1,5 @@
+# apps-cli-bundled-script-execution Specification
+
 ## Purpose
 Define how apps/cli discovers and invokes bundled scripts, forwards script arguments, preserves interactive selection, and exposes JSON-safe execution behavior.
 

--- a/openspec/specs/apps-cli-codex-config/spec.md
+++ b/openspec/specs/apps-cli-codex-config/spec.md
@@ -1,5 +1,8 @@
+# apps-cli-codex-config Specification
+
 ## Purpose
 Define apps/cli behavior for reproducible Codex configuration maintenance, safe repository-managed Codex state, and machine-readable output.
+
 ## Requirements
 ### Requirement: Codex command group
 The CLI SHALL expose a `codex` command group for Codex maintenance commands.

--- a/openspec/specs/apps-cli-codex-plugin-management/spec.md
+++ b/openspec/specs/apps-cli-codex-plugin-management/spec.md
@@ -1,5 +1,8 @@
+# apps-cli-codex-plugin-management Specification
+
 ## Purpose
 Define apps/cli repository-owned Codex plugin discovery, status reporting, local installation, cache synchronization, and CthuCodex language-coach hook behavior through the current `chc codex status` and `chc codex install` command surface.
+
 ## Requirements
 ### Requirement: Repository plugin status reporting
 The `chc codex status` command SHALL report repository-owned Codex plugin state without exposing a separate `chc codex plugins` command.

--- a/openspec/specs/apps-cli-distribution-ci/spec.md
+++ b/openspec/specs/apps-cli-distribution-ci/spec.md
@@ -1,7 +1,8 @@
 # apps-cli-distribution-ci Specification
 
 ## Purpose
-TBD - created by archiving change refine-ci-required-workflows. Update Purpose after archive.
+Define CLI distribution CI behavior for required-safe bundle validation, affected inputs, and workflow naming.
+
 ## Requirements
 ### Requirement: CLI distribution workflow is required-safe
 The repository SHALL validate the committed CLI distribution bundle through a dedicated GitHub Actions workflow whose check can be marked required.
@@ -37,4 +38,3 @@ The CLI distribution workflow SHALL be stored in an area-named workflow file whi
 - **THEN** CLI distribution behavior is defined in `.github/workflows/cli.yml`
 - **AND** the workflow display name identifies CLI distribution behavior
 - **AND** `.github/workflows/ci.yml` does not define the `cli-dist` job
-

--- a/openspec/specs/apps-cli-observability/spec.md
+++ b/openspec/specs/apps-cli-observability/spec.md
@@ -2,6 +2,7 @@
 
 ## Purpose
 Define CLI command, bundled script, stderr diagnostics, JSON-safe, and redaction semantics for apps/cli observability.
+
 ## Requirements
 ### Requirement: CLI invocation observability
 The CLI SHALL define structured invocation diagnostics for every top-level command, including source, command name, subcommand, script id when applicable, mode, duration, exit code, and stable error code, and those diagnostics MUST NOT prevent deterministic command termination.

--- a/openspec/specs/apps-cli-self-installation/spec.md
+++ b/openspec/specs/apps-cli-self-installation/spec.md
@@ -1,3 +1,5 @@
+# apps-cli-self-installation Specification
+
 ## Purpose
 Define GitHub-based personal installation, lifecycle status, and update behavior for the `chc` CLI.
 

--- a/openspec/specs/apps-cli-shell-completion/spec.md
+++ b/openspec/specs/apps-cli-shell-completion/spec.md
@@ -1,5 +1,8 @@
+# apps-cli-shell-completion Specification
+
 ## Purpose
 Define PowerShell and zsh shell completion behavior for the `chc` CLI.
+
 ## Requirements
 ### Requirement: Completion command group
 The CLI SHALL expose a `completion` command group for shell completion setup scripts.

--- a/openspec/specs/apps-desktop-agent-console/spec.md
+++ b/openspec/specs/apps-desktop-agent-console/spec.md
@@ -1,7 +1,8 @@
 # apps-desktop-agent-console Specification
 
 ## Purpose
-TBD - created by archiving change apps-desktop-agent-console. Update Purpose after archive.
+Define the CthuDesktop agent console application, backend connection configuration, WebSocket agent connection, home page, and observable state.
+
 ## Requirements
 ### Requirement: Desktop workspace application
 The system SHALL add a first-class Electron desktop application package under the root workspace.
@@ -84,4 +85,3 @@ The desktop agent console SHALL display agent and browser capability status usin
 #### Scenario: Browser capability status is visible
 - **WHEN** browser capability is unavailable or degraded
 - **THEN** the agent console displays a safe runtime diagnostic summary and does not expose local profile internals
-

--- a/openspec/specs/apps-desktop-browser-host/spec.md
+++ b/openspec/specs/apps-desktop-browser-host/spec.md
@@ -1,7 +1,8 @@
 # apps-desktop-browser-host Specification
 
 ## Purpose
-TBD - created by archiving change apps-browser-agent-auth. Update Purpose after archive.
+Define CthuDesktop browser host behavior for controlled browser commands, local profiles, login and verification flows, runtime limits, and site-aware browser execution.
+
 ## Requirements
 ### Requirement: Desktop browser capability
 CthuDesktop SHALL advertise a browser capability after it can receive controlled browser commands from the backend and execute them through its local Playwright host.

--- a/openspec/specs/apps-desktop-douban-movie-info/spec.md
+++ b/openspec/specs/apps-desktop-douban-movie-info/spec.md
@@ -2,6 +2,7 @@
 
 ## Purpose
 Define the CthuDesktop user interface contract for looking up Douban movie information by subject id or subject URL.
+
 ## Requirements
 ### Requirement: Desktop Douban movie lookup panel
 CthuDesktop SHALL provide a simple Douban movie lookup panel for fetching movie information by subject id.

--- a/openspec/specs/apps-desktop-observability/spec.md
+++ b/openspec/specs/apps-desktop-observability/spec.md
@@ -1,7 +1,8 @@
 # apps-desktop-observability Specification
 
 ## Purpose
-TBD - created by archiving change apps-desktop-observability-semantics. Update Purpose after archive.
+Define CthuDesktop observability behavior for agent lifecycle, browser host operations, safe local diagnostics, and shared observability contracts.
+
 ## Requirements
 ### Requirement: Desktop agent observability
 CthuDesktop SHALL define structured observability events for agent connection lifecycle, registration, reconnect attempts, heartbeat state, backend rejection, and local stop/start transitions.
@@ -44,4 +45,3 @@ The Desktop app SHALL emit structured local diagnostics that align with the shar
 - **WHEN** Desktop observability records a diagnostic event
 - **THEN** the event includes a stable source, level, event name, message, timestamp, and safe details
 - **AND** the event is not sent to `POST /api/client-events` by default
-

--- a/openspec/specs/apps-desktop-packaging-ci/spec.md
+++ b/openspec/specs/apps-desktop-packaging-ci/spec.md
@@ -1,7 +1,8 @@
 # apps-desktop-packaging-ci Specification
 
 ## Purpose
-TBD - created by archiving change apps-desktop-product-shell. Update Purpose after archive.
+Define desktop icon assets, packaging configuration, artifact workflows, dependency-aware validation, and desktop workflow naming.
+
 ## Requirements
 ### Requirement: Desktop icon assets
 The repository SHALL provide CthuDesktop icon assets suitable for renderer display and desktop packaging.

--- a/openspec/specs/apps-desktop-product-shell/spec.md
+++ b/openspec/specs/apps-desktop-product-shell/spec.md
@@ -1,7 +1,8 @@
 # apps-desktop-product-shell Specification
 
 ## Purpose
-TBD - created by archiving change apps-desktop-product-shell. Update Purpose after archive.
+Define the CthuDesktop product shell, app identity, window chrome, navigation, settings, visual system, runtime status, and desktop page patterns.
+
 ## Requirements
 ### Requirement: CthuDesktop app identity
 The desktop application SHALL present itself as CthuDesktop in product chrome, package metadata, and renderer-visible app identity.

--- a/openspec/specs/apps-docs-site/spec.md
+++ b/openspec/specs/apps-docs-site/spec.md
@@ -2,6 +2,7 @@
 
 ## Purpose
 CthuTool provides an Astro Starlight documentation site under `apps/docs` as the primary user and operator documentation surface for homelab deployment, client installation, module usage, operations, architecture, reference material, and OpenSpec capability discovery.
+
 ## Requirements
 ### Requirement: Docs workspace application
 The repository SHALL include a first-class documentation site package under `apps/docs`.

--- a/openspec/specs/apps-root-engineering-config/spec.md
+++ b/openspec/specs/apps-root-engineering-config/spec.md
@@ -1,7 +1,8 @@
 # apps-root-engineering-config Specification
 
 ## Purpose
-TBD - created by archiving change apps-root-engineering-config-governance. Update Purpose after archive.
+Define root monorepo engineering configuration for validation scripts, CI gates, package governance, Turbo orchestration, generated adapter policy, and OpenSpec ownership.
+
 ## Requirements
 ### Requirement: Root lint gate passes for managed workspace
 The root workspace SHALL provide a lint command that validates all root-managed source files under `apps/*` and `packages/*` without failing on supported syntax used by those packages.

--- a/openspec/specs/apps-runtime-structured-logs/spec.md
+++ b/openspec/specs/apps-runtime-structured-logs/spec.md
@@ -1,7 +1,8 @@
 # apps-runtime-structured-logs Specification
 
 ## Purpose
-TBD - created by archiving change apps-runtime-structured-logs. Update Purpose after archive.
+Define shared structured log envelope semantics and local-first runtime diagnostics across CthuTool applications.
+
 ## Requirements
 ### Requirement: Shared runtime log envelope
 CthuTool application runtimes SHALL use a shared structured log envelope for application diagnostics so events can be correlated across backend, web, desktop, and CLI without relying on runtime-specific formatting.

--- a/openspec/specs/apps-web-observability/spec.md
+++ b/openspec/specs/apps-web-observability/spec.md
@@ -2,6 +2,7 @@
 
 ## Purpose
 Define the web frontend observability contract for API correlation, safe console diagnostics, and UI error reporting in the browser-hosted CthuTool management console.
+
 ## Requirements
 ### Requirement: Web API correlation
 The web app SHALL route production frontend API requests through structured API observability so requests are correlated with backend request identifiers, route or action labels, response status, duration, and safe error codes.

--- a/openspec/specs/apps-web-project-shell/spec.md
+++ b/openspec/specs/apps-web-project-shell/spec.md
@@ -1,7 +1,8 @@
 # apps-web-project-shell Specification
 
 ## Purpose
-TBD - created by archiving change apps-web-project-scaffold. Update Purpose after archive.
+Define the apps/web project shell, Next.js scaffold, styling baseline, shared page readiness, script integration, documentation naming, and diagnostics baseline.
+
 ## Requirements
 ### Requirement: Web App Workspace
 

--- a/openspec/specs/codex-plugins-cthu-codex-anki-mcp/spec.md
+++ b/openspec/specs/codex-plugins-cthu-codex-anki-mcp/spec.md
@@ -1,7 +1,8 @@
 # codex-plugins-cthu-codex-anki-mcp Specification
 
 ## Purpose
-TBD - created by archiving change add-cthu-codex-anki-mcp-server. Update Purpose after archive.
+Define the CthuCodex Anki MCP server integration, AnkiConnect status, schema discovery, note lookup, candidate validation, note creation, media storage, and browser opening workflows.
+
 ## Requirements
 ### Requirement: Plugin-bundled Anki MCP server
 CthuCodex SHALL bundle a stdio MCP server for Anki card creation utilities without changing the existing language-coach hook behavior.

--- a/openspec/specs/codex-plugins-cthu-codex-english-expression-skill/spec.md
+++ b/openspec/specs/codex-plugins-cthu-codex-english-expression-skill/spec.md
@@ -1,7 +1,8 @@
 # codex-plugins-cthu-codex-english-expression-skill Specification
 
 ## Purpose
-TBD - created by archiving change add-cthu-codex-english-expression-skill. Update Purpose after archive.
+Define the CthuCodex English expression card skill for parsing source sentences, generating Anki note candidates, handling tags, and using Anki MCP creation tools.
+
 ## Requirements
 ### Requirement: Plugin-local English expression card skill
 CthuCodex SHALL provide a plugin-local explicit-only skill for creating `English Expression` Anki notes from user-provided English sentences, excerpts, and target expressions.
@@ -108,4 +109,3 @@ The skill SHALL use existing CthuCodex Anki MCP tools to validate and create Eng
 - **WHEN** the note is successfully created
 - **THEN** the skill requests post-create review by using `openAfterCreate: true`
 - **AND** Browser-opening warnings do not turn successful note creation into a failure
-

--- a/openspec/specs/codex-plugins-cthu-codex-language-coach/spec.md
+++ b/openspec/specs/codex-plugins-cthu-codex-language-coach/spec.md
@@ -1,7 +1,8 @@
 # codex-plugins-cthu-codex-language-coach Specification
 
 ## Purpose
-TBD - created by archiving change codex-plugins-cthu-codex-language-coach-detector. Update Purpose after archive.
+Define the CthuCodex language-coach prompt hook, English prose detection, non-user-prose filtering, Chinese workflow silence, and trailing-intent handling.
+
 ## Requirements
 ### Requirement: Language coach hook emits coaching only for English prose intent
 The CthuCodex language-coach hook SHALL inject English coaching context only when the latest user prompt contains English prose intent after local filtering.
@@ -71,4 +72,3 @@ The language-coach detector SHALL evaluate a short trailing user-authored segmen
 #### Scenario: Balanced multi-sentence prompt is evaluated as a whole
 - **WHEN** the prompt contains multiple normal-length prose segments without a short-tail pattern
 - **THEN** the detector evaluates the full cleaned prompt
-

--- a/openspec/specs/collection-hub-dashboard/spec.md
+++ b/openspec/specs/collection-hub-dashboard/spec.md
@@ -1,3 +1,5 @@
+# collection-hub-dashboard Specification
+
 ## Purpose
 Define the Collection Hub web dashboard behavior for browsing imported collections, authors, rating filters, and item triage actions.
 

--- a/openspec/specs/collection-hub-import-api/spec.md
+++ b/openspec/specs/collection-hub-import-api/spec.md
@@ -1,3 +1,5 @@
+# collection-hub-import-api Specification
+
 ## Purpose
 Define the Collection Hub local API behavior for validating imports, persisting fixed destination collections, exposing dashboard data, and mutating imported items.
 

--- a/openspec/specs/collection-hub-import-extension/spec.md
+++ b/openspec/specs/collection-hub-import-extension/spec.md
@@ -1,5 +1,8 @@
+# collection-hub-import-extension Specification
+
 ## Purpose
 Define the Collection Hub browser extension behavior for matching source pages, extracting collection items, and submitting imports to the local API.
+
 ## Requirements
 ### Requirement: Configurable page activation
 The extension SHALL activate collection extraction only on pages matching user-configured match patterns.
@@ -259,4 +262,3 @@ The extension SHALL include a DOM adapter for rendered Bilibili favlist pages on
 - **THEN** the extension content script is not injected into those local development pages
 - **AND** extension development hot reloads do not refresh the Collection Hub frontend
 - **AND** the content script manifest targets supported source sites instead of all URLs
-

--- a/openspec/specs/collection-hub-workspace/spec.md
+++ b/openspec/specs/collection-hub-workspace/spec.md
@@ -1,5 +1,8 @@
+# collection-hub-workspace Specification
+
 ## Purpose
 Define the isolated Collection Hub prototype workspace, package boundaries, shared contracts package, and local development commands.
+
 ## Requirements
 ### Requirement: Isolated nested workspace
 The system SHALL create an isolated pnpm workspace at `scratches/collection-hub` for the Collection Hub prototype.

--- a/openspec/specs/gitops-argo-applications/spec.md
+++ b/openspec/specs/gitops-argo-applications/spec.md
@@ -1,7 +1,8 @@
 # gitops-argo-applications Specification
 
 ## Purpose
-TBD - created by archiving change add-homelab-gitops. Update Purpose after archive.
+Define GitOps ArgoCD Application custom resources for deployed applications, source wiring, destination namespaces, auto-sync, retry, and organization.
+
 ## Requirements
 ### Requirement: ArgoCD Application CR per deployed app
 

--- a/openspec/specs/gitops-bootstrap/spec.md
+++ b/openspec/specs/gitops-bootstrap/spec.md
@@ -1,7 +1,8 @@
 # gitops-bootstrap Specification
 
 ## Purpose
-TBD - created by archiving change add-homelab-gitops. Update Purpose after archive.
+Define the GitOps bootstrap scaffold reserved for future ArgoCD self-management manifests.
+
 ## Requirements
 ### Requirement: Bootstrap directory scaffold exists
 

--- a/openspec/specs/gitops-cluster-namespaces/spec.md
+++ b/openspec/specs/gitops-cluster-namespaces/spec.md
@@ -1,7 +1,8 @@
 # gitops-cluster-namespaces Specification
 
 ## Purpose
-TBD - created by archiving change add-homelab-gitops. Update Purpose after archive.
+Define GitOps-managed Kubernetes namespace manifests for deployed applications and namespace labeling conventions.
+
 ## Requirements
 ### Requirement: Namespace for each deployed application
 

--- a/openspec/specs/gitops-observability-stack/spec.md
+++ b/openspec/specs/gitops-observability-stack/spec.md
@@ -2,6 +2,7 @@
 
 ## Purpose
 Define the GitOps-managed Kubernetes observability stack for CthuTool, including metrics, dashboards, log collection, platform integration boundaries, and future telemetry ingestion extension points.
+
 ## Requirements
 ### Requirement: GitOps-managed observability stack
 The repository SHALL define a GitOps-managed observability stack for the Kubernetes cluster using existing open source components rather than a custom CthuTool observability or logging service.

--- a/openspec/specs/packages-agent-protocol/spec.md
+++ b/openspec/specs/packages-agent-protocol/spec.md
@@ -1,7 +1,8 @@
 # packages-agent-protocol Specification
 
 ## Purpose
-TBD - created by archiving change apps-browser-runtime-protocol-hardening. Update Purpose after archive.
+Define the shared agent protocol package for capability-neutral lifecycle messages, JSON-RPC command envelopes, and browser-contract separation.
+
 ## Requirements
 ### Requirement: Generic agent lifecycle protocol
 The `@cthutool/agent-protocol` package SHALL define only capability-neutral agent lifecycle messages, public agent metadata, public agent status, and command transport primitives.

--- a/openspec/specs/packages-app-shell-observability/spec.md
+++ b/openspec/specs/packages-app-shell-observability/spec.md
@@ -1,7 +1,8 @@
 # packages-app-shell-observability Specification
 
 ## Purpose
-TBD - created by archiving change packages-app-shell-observability-semantics. Update Purpose after archive.
+Define shared app-shell observability semantics for frontend logging and observable status presentation.
+
 ## Requirements
 ### Requirement: Shared frontend logger
 The app-shell package SHALL define shared frontend logger semantics for levels, scopes, event names, correlation fields, safe contextual details, and environment-specific console behavior.
@@ -24,4 +25,3 @@ The app-shell package SHALL define host-neutral presentation semantics for backe
 #### Scenario: Diagnostics link is safe
 - **WHEN** a shared page displays a diagnostics identifier or link
 - **THEN** it presents only safe identifiers and summaries, not raw artifacts or local paths
-

--- a/openspec/specs/packages-app-shell-runtime/spec.md
+++ b/openspec/specs/packages-app-shell-runtime/spec.md
@@ -1,7 +1,8 @@
 # packages-app-shell-runtime Specification
 
 ## Purpose
-TBD - created by archiving change apps-desktop-shared-ui-foundation. Update Purpose after archive.
+Define the shared app-shell runtime package for host-neutral runtime contracts, shared page composition, adapters, page frames, and status patterns.
+
 ## Requirements
 ### Requirement: Host-neutral runtime contract
 The shared app-shell runtime package SHALL define a runtime contract that describes host capabilities and host actions without depending on Electron.
@@ -112,4 +113,3 @@ The shared app-shell runtime SHALL allow shared pages to use a host-provided fro
 #### Scenario: Shared page logs through runtime
 - **WHEN** a shared page emits a diagnostic event
 - **THEN** it uses the runtime-provided logger or a safe no-op/default logger rather than directly depending on a host-specific console implementation
-

--- a/openspec/specs/packages-browser-client-sdk/spec.md
+++ b/openspec/specs/packages-browser-client-sdk/spec.md
@@ -1,7 +1,8 @@
 # packages-browser-client-sdk Specification
 
 ## Purpose
-TBD - created by archiving change packages-browser-client-sdk. Update Purpose after archive.
+Define the TypeScript browser client SDK for trusted applications using the backend public browser API.
+
 ## Requirements
 ### Requirement: Browser client package
 The repository SHALL provide a TypeScript browser client SDK package for
@@ -95,4 +96,3 @@ lifecycle, and supported page methods.
 - **THEN** it states that the SDK talks to the CthuTool backend, does not connect
   to Playwright directly, does not expose raw browser storage, and assumes a
   trusted backend deployment until API authentication is added
-

--- a/openspec/specs/packages-browser-runtime-protocol/spec.md
+++ b/openspec/specs/packages-browser-runtime-protocol/spec.md
@@ -1,7 +1,8 @@
 # packages-browser-runtime-protocol Specification
 
 ## Purpose
-TBD - created by archiving change apps-browser-runtime-protocol-hardening. Update Purpose after archive.
+Define the browser runtime protocol package for typed browser methods, payload schemas, JSON-RPC helpers, and operation-scoped challenges.
+
 ## Requirements
 ### Requirement: Browser runtime protocol package
 The browser runtime protocol boundary SHALL define browser method names, params, results, public browser status metadata, detections, application error codes, and operation-scoped interaction challenges outside the generic agent protocol package.

--- a/openspec/specs/packages-config-browser-sites/spec.md
+++ b/openspec/specs/packages-config-browser-sites/spec.md
@@ -1,7 +1,8 @@
 # packages-config-browser-sites Specification
 
 ## Purpose
-TBD - created by archiving change packages-config-browser-sites. Update Purpose after archive.
+Define the browser sites configuration package for versioned site JSON schema, file loading, deterministic merge behavior, and sensitive-data exclusion.
+
 ## Requirements
 ### Requirement: Browser sites JSON schema
 The config package SHALL define a versioned browser sites JSON format that represents site identifiers, display names, auth policy, default profile names, allowed origins, login URLs, verification URLs, default timeout, and default resource blocking.

--- a/openspec/specs/packages-ui-shared-components/spec.md
+++ b/openspec/specs/packages-ui-shared-components/spec.md
@@ -1,7 +1,8 @@
 # packages-ui-shared-components Specification
 
 ## Purpose
-TBD - created by archiving change apps-desktop-shared-ui-foundation. Update Purpose after archive.
+Define the shared React UI package for workspace UI primitives, semantic tokens, accessibility behavior, shell controls, and scan-friendly layout patterns.
+
 ## Requirements
 ### Requirement: Shared UI package
 The repository SHALL provide a shared React UI package for workspace applications that need CthuTool interface primitives.


### PR DESCRIPTION
## Summary
- Replace placeholder Purpose text across backend, CLI, desktop, web, and Codex plugin specs
- Clarify browser workflow boundaries, runtime ownership, and aggregate service entry points
- Normalize several spec headers and wording to match the current capability map

## Testing
- Not run (not requested)