### PR TITLE
fix(cli): expand zsh completion candidates

### DIFF
--- a/apps/cli/dist/index.js
+++ b/apps/cli/dist/index.js
@@ -5584,7 +5584,7 @@ var powershellScript = `Register-ArgumentCompleter -Native -CommandName chc -Scr
   }
 }
 `;
-var zshScript = String.raw`#compdef chc
+var zshScript = `#compdef chc
 _chc_completion() {
   local -a candidates
   candidates=("\${(@f)$(chc __complete "\${words[@]:1}")}")

--- a/apps/cli/src/command/completion.command.ts
+++ b/apps/cli/src/command/completion.command.ts
@@ -50,7 +50,7 @@ const powershellScript = `Register-ArgumentCompleter -Native -CommandName chc -S
 }
 `;
 
-const zshScript = String.raw`#compdef chc
+const zshScript = `#compdef chc
 _chc_completion() {
   local -a candidates
   candidates=("\${(@f)$(chc __complete "\${words[@]:1}")}")

--- a/apps/cli/tests/integration/completion-command.test.ts
+++ b/apps/cli/tests/integration/completion-command.test.ts
@@ -5,6 +5,7 @@ import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const cliRoot = join(dirname(fileURLToPath(import.meta.url)), '../..');
+const zshExecutable = Bun.which('zsh');
 
 async function runCli(args: string[], env: Record<string, string> = {}) {
   const proc = Bun.spawn(['bun', 'run', 'src/index.ts', ...args], {
@@ -64,7 +65,43 @@ describe('shell completion command', () => {
     expect(zsh.out).toContain('#compdef chc');
     expect(zsh.out).toContain('compdef _chc_completion chc');
     expect(zsh.out).toContain('chc __complete');
+    expect(zsh.out).not.toContain('\\${');
   });
+
+  test.skipIf(!zshExecutable)(
+    'expands zsh completion candidates instead of inserting array syntax',
+    async () => {
+      const tempRoot = await mkdtemp(join(tmpdir(), 'chc-zsh-adapter-'));
+      const adapterPath = join(tempRoot, '_chc');
+
+      try {
+        const zsh = await runCli(['completion', 'zsh']);
+        expect(zsh.code).toBe(0);
+        expect(zsh.err).toBe('');
+        await writeFile(adapterPath, zsh.out);
+
+        const result = await runProcess(zshExecutable ?? 'zsh', [
+          '-fc',
+          [
+            'compdef() { :; }',
+            "chc() { printf 'codex\\ncompletion\\n'; }",
+            'compadd() { printf \'<%s>\\n\' "$@"; }',
+            'words=(chc "")',
+            'source "$1"',
+            '_chc_completion',
+          ].join('\n'),
+          'zsh',
+          adapterPath,
+        ]);
+
+        expect(result.code).toBe(0);
+        expect(result.err).toBe('');
+        expect(result.out).toBe('<-->\n<codex>\n<completion>\n');
+      } finally {
+        await rm(tempRoot, { force: true, recursive: true });
+      }
+    },
+  );
 
   test('rejects unsupported shell names clearly', async () => {
     const result = await runCli(['completion', 'fish']);

--- a/openspec/changes/archive/2026-07-13-apps-cli-fix-zsh-completion-expansion/.openspec.yaml
+++ b/openspec/changes/archive/2026-07-13-apps-cli-fix-zsh-completion-expansion/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-13

--- a/openspec/changes/archive/2026-07-13-apps-cli-fix-zsh-completion-expansion/design.md
+++ b/openspec/changes/archive/2026-07-13-apps-cli-fix-zsh-completion-expansion/design.md
@@ -1,0 +1,36 @@
+## Context
+
+The zsh adapter is embedded in TypeScript as a template literal. It previously used `String.raw` while also escaping zsh `${...}` expressions for JavaScript parsing. Because raw templates preserve escape characters, the generated script contained `\${...}` and zsh treated those expressions as literal text. Existing tests asserted only broad markers in the generated script, so they did not exercise shell expansion.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Emit valid zsh parameter expansion from `chc completion zsh`.
+- Verify the generated adapter forwards line-oriented candidates to `compadd`.
+- Keep the committed CLI bundle consistent with the TypeScript source.
+
+**Non-Goals:**
+
+- Redesign the internal `chc __complete` protocol.
+- Change PowerShell completion behavior or persistent profile management.
+- Add zsh as a required test-host dependency when it is unavailable.
+
+## Decisions
+
+1. Use a normal JavaScript template literal for the zsh adapter. The existing `\${...}` JavaScript escapes then produce unescaped `${...}` text at runtime. Keeping `String.raw` would require indirect interpolation or post-processing that obscures the intended shell script.
+2. Retain a generated-text assertion that rejects literal `\${` output. This catches the exact escaping regression on every test host.
+3. When zsh is installed, execute the generated script with stubbed `chc`, `compdef`, and `compadd` functions. This verifies candidate splitting and array expansion without depending on an interactive terminal; the behavior test is skipped on hosts without zsh.
+
+## Risks / Trade-offs
+
+- [Risk] Future edits can confuse JavaScript escaping with zsh escaping. → Mitigation: Keep both the exact output assertion and the shell-level behavior test.
+- [Risk] Shell-level tests are platform-dependent. → Mitigation: Run the behavior test conditionally while retaining platform-independent generated-text coverage.
+
+## Migration Plan
+
+Rebuild and publish the committed CLI bundle. Existing users receive the corrected adapter after updating `chc` and reloading their zsh profile or restarting zsh. Rollback consists of reverting the source, test, and generated bundle changes together.
+
+## Open Questions
+
+None.

--- a/openspec/changes/archive/2026-07-13-apps-cli-fix-zsh-completion-expansion/proposal.md
+++ b/openspec/changes/archive/2026-07-13-apps-cli-fix-zsh-completion-expansion/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+The generated zsh completion adapter preserves escape characters around zsh array expressions, so pressing Tab can insert the literal text `${candidates[@]}` instead of a CLI candidate. The adapter must emit executable zsh parameter expansion so interactive completion works as documented.
+
+## What Changes
+
+- Render the zsh completion adapter without literal backslashes before its parameter expansions.
+- Add integration coverage that executes the generated adapter in zsh and observes the candidates passed to `compadd`.
+- Regenerate the committed CLI distribution bundle.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `apps-cli-shell-completion`: Require the generated zsh adapter to expand and forward completion candidates rather than insert shell array syntax literally.
+
+## Impact
+
+- Affects zsh completion rendering in `apps/cli/src/command/completion.command.ts`.
+- Adds zsh adapter integration coverage in `apps/cli/tests/integration/completion-command.test.ts`.
+- Updates the committed Node CLI bundle in `apps/cli/dist/index.js`.
+- Does not change the `chc __complete` protocol or command-line API.

--- a/openspec/changes/archive/2026-07-13-apps-cli-fix-zsh-completion-expansion/specs/apps-cli-shell-completion/spec.md
+++ b/openspec/changes/archive/2026-07-13-apps-cli-fix-zsh-completion-expansion/specs/apps-cli-shell-completion/spec.md
@@ -1,0 +1,13 @@
+## ADDED Requirements
+
+### Requirement: zsh candidate expansion
+The zsh completion adapter SHALL expand the candidates returned by `chc __complete` and pass each candidate to zsh completion without exposing shell array syntax as a candidate.
+
+#### Scenario: Root candidates are forwarded to compadd
+- **WHEN** the generated zsh completion function receives line-oriented candidates from `chc __complete`
+- **THEN** it passes each returned candidate as a separate argument to `compadd`
+- **AND** it does not pass literal `${candidates[@]}` text as a completion candidate
+
+#### Scenario: Generated parameter expressions remain executable
+- **WHEN** a user runs `chc completion zsh`
+- **THEN** the emitted zsh parameter expressions are not prefixed with escape characters that make them literal text

--- a/openspec/changes/archive/2026-07-13-apps-cli-fix-zsh-completion-expansion/tasks.md
+++ b/openspec/changes/archive/2026-07-13-apps-cli-fix-zsh-completion-expansion/tasks.md
@@ -1,0 +1,14 @@
+## 1. Adapter Rendering
+
+- [x] 1.1 Render the zsh adapter with executable parameter expansion instead of literal escaped array expressions.
+- [x] 1.2 Rebuild the committed Node CLI distribution bundle.
+
+## 2. Regression Coverage
+
+- [x] 2.1 Assert the generated zsh adapter does not contain escaped `${...}` parameter expressions.
+- [x] 2.2 Execute the generated adapter under zsh when available and verify candidates reach `compadd` separately.
+
+## 3. Verification
+
+- [x] 3.1 Run CLI tests, type checking, lint, and distribution bundle consistency checks.
+- [x] 3.2 Validate the OpenSpec change and confirm generated agent adapter files remain unchanged.

--- a/openspec/specs/apps-cli-shell-completion/spec.md
+++ b/openspec/specs/apps-cli-shell-completion/spec.md
@@ -209,3 +209,15 @@ The CLI SHALL provide explicit commands for managing persistent zsh completion s
 - **WHEN** a user runs `chc completion enable fish`
 - **THEN** the CLI exits with a non-zero status
 - **AND** stderr explains that the managed completion shell is unsupported
+
+### Requirement: zsh candidate expansion
+The zsh completion adapter SHALL expand the candidates returned by `chc __complete` and pass each candidate to zsh completion without exposing shell array syntax as a candidate.
+
+#### Scenario: Root candidates are forwarded to compadd
+- **WHEN** the generated zsh completion function receives line-oriented candidates from `chc __complete`
+- **THEN** it passes each returned candidate as a separate argument to `compadd`
+- **AND** it does not pass literal `${candidates[@]}` text as a completion candidate
+
+#### Scenario: Generated parameter expressions remain executable
+- **WHEN** a user runs `chc completion zsh`
+- **THEN** the emitted zsh parameter expressions are not prefixed with escape characters that make them literal text


### PR DESCRIPTION
## Summary

- render the zsh completion adapter with executable parameter expansion
- add generated-output and shell-level regression coverage
- rebuild the committed CLI bundle
- sync and archive the OpenSpec change `apps-cli-fix-zsh-completion-expansion`

## Root cause

The adapter used `String.raw` together with escaped zsh `${...}` expressions. Raw template rendering preserved the backslashes, so zsh treated `${candidates[@]}` as literal text and Tab inserted that text instead of a completion candidate.

## User impact

After updating `chc` and reloading zsh completion, pressing Tab now inserts the candidates returned by `chc __complete` instead of shell array syntax.

## Validation

- `pnpm --filter @cthutool/cli test` (62 unit and 59 integration tests)
- `pnpm --filter @cthutool/cli typecheck`
- `pnpm --filter @cthutool/cli lint`
- `pnpm run check:cli-dist`
- strict OpenSpec validation for the archived change and updated main spec
