### PR TITLE
feat(cli): unify lifecycle, command discovery, and updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,11 +97,36 @@ mode. `CHC_INSTALL_COMPLETION` accepts `auto`, `zsh`, or `none`.
 After the first install, update from the CLI:
 
 ```bash
-chc version
+chc --version
 chc status
+chc update --check
 chc update
 chc update --ref v0.1.0
 ```
+
+Use `chc --version` for the lightweight version-only check. `chc status`
+includes that version together with the detected installation mode and source
+checkout diagnostics. `chc update --check` reports whether installation or an
+update is needed without changing checkout files or the global command. A safe
+managed `chc update` runs directly, reports commit progress, and skips the
+global reinstall when already current. Dirty or diverged checkouts are blocked
+without automatic stash, reset, or rebase. Update checks are explicit; the CLI
+does not run a periodic background checker.
+
+Discover command groups and bundled scripts directly from the CLI:
+
+```bash
+chc completion
+chc scripts
+chc scripts list
+chc scripts run convert-to-cbz --input ./samples
+```
+
+`chc completion` lists the `powershell`, `zsh`, `enable`, `disable`, and
+`status` operations. `chc scripts` shows `list`, `run`, and an
+`AVAILABLE SCRIPTS` catalog. Existing `chc scripts <id>` and
+`chc scripts --script <id>` forms remain supported as shorthand for
+`chc scripts run <id>`.
 
 For full install, update, uninstall, and command usage docs, use the docs site
 under `apps/docs/src/content/docs/client/cli.md` and

--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -54,16 +54,40 @@ apply to `remote` mode.
 Update an installed CLI in place:
 
 ```bash
-chc version
+chc --version
 chc status
+chc update --check
 chc update
 chc update --ref v0.1.0
 ```
 
-`chc status` automatically detects whether the running command is linked to a
-local checkout or the default remote managed checkout and reports that source
-as `mode: local` or `mode: remote`. Use `--install-dir` only to inspect a
-different checkout explicitly.
+Use `chc --version` for the lightweight version-only check. `chc status`
+includes that version, automatically detects whether the running command is
+linked to a local checkout or the default remote managed checkout, and reports
+that source as `mode: local` or `mode: remote`. Use `--install-dir` only to
+inspect a different checkout explicitly.
+
+`chc update --check` resolves the selected remote ref and reports
+`install_required`, `update_available`, or `up_to_date` without changing
+checkout files or the global installation. A normal update of a clean managed
+checkout proceeds directly without a redundant confirmation, shows TTY-aware
+phase progress and a bounded commit summary, and skips checkout plus
+`npm install -g` when already current.
+
+The updater refuses dirty or diverged checkouts and never automatically
+stashes, resets, cleans, or rebases local work. Use output modes as needed:
+
+```bash
+chc update --quiet
+chc update --verbose
+chc update --json
+chc update --check --json
+```
+
+`--verbose` writes bounded Git and npm diagnostics to stderr. JSON mode keeps
+one result value on stdout with stable status, commit identities, phases, and
+bounded change or failure metadata. Update checks only run when requested; the
+CLI does not install a periodic or shell-startup background checker.
 
 ## Shell Completion
 
@@ -74,6 +98,7 @@ login shell is zsh. Skip automatic setup with
 Manage completion explicitly when needed:
 
 ```bash
+chc completion
 chc completion enable zsh
 chc completion status zsh
 chc completion disable zsh
@@ -88,7 +113,30 @@ chc completion powershell | Out-String | Invoke-Expression
 ```
 
 The global or locally linked `chc` command must be available before loading
-either completion adapter.
+either completion adapter. Bare `chc completion` prints the registered
+`powershell`, `zsh`, `enable`, `disable`, and `status` child commands without
+changing a shell profile.
+
+## Bundled Scripts
+
+Use the discoverable catalog and canonical `run` operation:
+
+```bash
+chc scripts
+chc scripts list
+chc scripts list --json
+chc scripts run convert-to-cbz --input ./samples
+```
+
+Bare `chc scripts` prints group help plus an `AVAILABLE SCRIPTS` catalog.
+`chc scripts list` prints that same catalog, and `--json` returns bounded
+metadata for automation. The earlier forms remain supported as shorthand and
+route through the same runner:
+
+```bash
+chc scripts convert-to-cbz --input ./samples
+chc scripts --script convert-to-cbz --input ./samples
+```
 
 ## Local Development
 

--- a/apps/cli/dist/index.js
+++ b/apps/cli/dist/index.js
@@ -2328,11 +2328,58 @@ async function runMain(cmd, opts = {}) {
 }
 
 // src/index.ts
-var import_picocolors5 = __toESM(require_picocolors(), 1);
+var import_picocolors7 = __toESM(require_picocolors(), 1);
+
+// src/command/command-discovery.ts
+var registrationsByCommand = new WeakMap;
+var positionalCandidatesByCommand = new WeakMap;
+var helpAppendixByCommand = new WeakMap;
+function buildRegisteredSubCommands(registrations) {
+  return Object.fromEntries(registrations.map((registration) => [
+    registration.name,
+    registration.command
+  ]));
+}
+function registerCommandGroup(command, registrations) {
+  registrationsByCommand.set(command, registrations);
+  return command;
+}
+function getCommandRegistrations(command) {
+  return registrationsByCommand.get(command);
+}
+function getCommandRegistration(command, name) {
+  return getCommandRegistrations(command)?.find((registration) => registration.name === name);
+}
+function normalizeRegisteredArgs(rootCommand, rawArgs) {
+  const [name, ...commandArgs] = rawArgs;
+  if (!name) {
+    return [...rawArgs];
+  }
+  const registration = getCommandRegistration(rootCommand, name);
+  if (!registration?.normalizeArgs) {
+    return [...rawArgs];
+  }
+  return [name, ...registration.normalizeArgs(commandArgs)];
+}
+function registerPositionalCandidates(command, provider) {
+  positionalCandidatesByCommand.set(command, provider);
+  return command;
+}
+function getPositionalCandidateProvider(command) {
+  return positionalCandidatesByCommand.get(command);
+}
+function registerCommandHelpAppendix(command, provider) {
+  helpAppendixByCommand.set(command, provider);
+  return command;
+}
+function getCommandHelpAppendixProvider(command) {
+  return helpAppendixByCommand.get(command);
+}
 
 // ../../node_modules/.pnpm/@clack+core@0.3.5/node_modules/@clack/core/dist/index.mjs
 var import_sisteransi = __toESM(require_src(), 1);
 import { stdin as $, stdout as k2 } from "node:process";
+import * as f3 from "node:readline";
 import _3 from "node:readline";
 import { WriteStream as U } from "node:tty";
 function q2({ onlyFirst: e2 = false } = {}) {
@@ -2686,6 +2733,27 @@ var $D2 = class extends x2 {
   }
 };
 var WD = globalThis.process.platform.startsWith("win");
+function OD({ input: e2 = $, output: u3 = k2, overwrite: F3 = true, hideCursor: t2 = true } = {}) {
+  const s2 = f3.createInterface({ input: e2, output: u3, prompt: "", tabSize: 1 });
+  f3.emitKeypressEvents(e2, s2), e2.isTTY && e2.setRawMode(true);
+  const C3 = (D2, { name: i2 }) => {
+    if (String(D2) === "\x03") {
+      t2 && u3.write(import_sisteransi.cursor.show), process.exit(0);
+      return;
+    }
+    if (!F3)
+      return;
+    let n2 = i2 === "return" ? 0 : -1, E = i2 === "return" ? -1 : 0;
+    f3.moveCursor(u3, n2, E, () => {
+      f3.clearLine(u3, 1, () => {
+        e2.once("keypress", C3);
+      });
+    });
+  };
+  return t2 && u3.write(import_sisteransi.cursor.hide), e2.once("keypress", C3), () => {
+    e2.off("keypress", C3), t2 && u3.write(import_sisteransi.cursor.show), e2.isTTY && !WD && e2.setRawMode(false), s2.terminal = false, s2.close();
+  };
+}
 
 // ../../node_modules/.pnpm/@clack+prompts@0.8.2/node_modules/@clack/prompts/dist/index.mjs
 var import_picocolors = __toESM(require_picocolors(), 1);
@@ -2735,9 +2803,9 @@ var E = (s2) => {
   let l3 = 0;
   n2 >= l3 + c3 - 3 ? l3 = Math.max(Math.min(n2 - c3 + 3, t2.length - c3), 0) : n2 < l3 + 2 && (l3 = Math.max(n2 - 2, 0));
   const d3 = c3 < t2.length && l3 > 0, p = c3 < t2.length && l3 + c3 < t2.length;
-  return t2.slice(l3, l3 + c3).map((S4, f3, x3) => {
-    const g4 = f3 === 0 && d3, m3 = f3 === x3.length - 1 && p;
-    return g4 || m3 ? import_picocolors.default.dim("...") : i2(S4, f3 + l3 === n2);
+  return t2.slice(l3, l3 + c3).map((S4, f4, x3) => {
+    const g4 = f4 === 0 && d3, m3 = f4 === x3.length - 1 && p;
+    return g4 || m3 ? import_picocolors.default.dim("...") : i2(S4, f4 + l3 === n2);
   });
 };
 var ce2 = (s2) => {
@@ -2794,6 +2862,34 @@ ${import_picocolors.default.cyan($2)}
 var pe = (s2 = "") => {
   process.stdout.write(`${import_picocolors.default.gray(Q3)}  ${s2}
 `);
+};
+var _4 = () => {
+  const s2 = C3 ? ["◒", "◐", "◓", "◑"] : ["•", "o", "O", "0"], n2 = C3 ? 80 : 120;
+  let t2, i2, r4 = false, o3 = "";
+  const c3 = (g4) => {
+    const m3 = g4 > 1 ? "Something went wrong" : "Canceled";
+    r4 && x3(m3, g4);
+  }, l3 = () => c3(2), d3 = () => c3(1), p = () => {
+    process.on("uncaughtExceptionMonitor", l3), process.on("unhandledRejection", l3), process.on("SIGINT", d3), process.on("SIGTERM", d3), process.on("exit", c3);
+  }, S4 = () => {
+    process.removeListener("uncaughtExceptionMonitor", l3), process.removeListener("unhandledRejection", l3), process.removeListener("SIGINT", d3), process.removeListener("SIGTERM", d3), process.removeListener("exit", c3);
+  }, f4 = (g4 = "") => {
+    r4 = true, t2 = OD(), o3 = g4.replace(/\.+$/, ""), process.stdout.write(`${import_picocolors.default.gray(a3)}
+`);
+    let m3 = 0, w3 = 0;
+    p(), i2 = setInterval(() => {
+      const L4 = import_picocolors.default.magenta(s2[m3]), O4 = ".".repeat(Math.floor(w3)).slice(0, 3);
+      process.stdout.write(import_sisteransi2.cursor.move(-999, 0)), process.stdout.write(import_sisteransi2.erase.down(1)), process.stdout.write(`${L4}  ${o3}${O4}`), m3 = m3 + 1 < s2.length ? m3 + 1 : 0, w3 = w3 < s2.length ? w3 + 0.125 : 0;
+    }, n2);
+  }, x3 = (g4 = "", m3 = 0) => {
+    o3 = g4 ?? o3, r4 = false, clearInterval(i2);
+    const w3 = m3 === 0 ? import_picocolors.default.green(M2) : m3 === 1 ? import_picocolors.default.red(P4) : import_picocolors.default.red(V3);
+    process.stdout.write(import_sisteransi2.cursor.move(-999, 0)), process.stdout.write(import_sisteransi2.erase.down(1)), process.stdout.write(`${w3}  ${o3}
+`), S4(), t2();
+  };
+  return { start: f4, stop: x3, message: (g4 = "") => {
+    o3 = g4 ?? o3;
+  } };
 };
 
 // src/command/codex.command.ts
@@ -4520,27 +4616,398 @@ var codexCommand = defineCommand({
 
 // src/command/completion.command.ts
 import { execFile } from "node:child_process";
-import { mkdir as mkdir3, readFile as readFile4, writeFile as writeFile3 } from "node:fs/promises";
+import { mkdir as mkdir3, readFile as readFile3, writeFile as writeFile3 } from "node:fs/promises";
 import { homedir as homedir2, platform as platform2 } from "node:os";
-import { dirname as dirname6, join as join5 } from "node:path";
+import { dirname as dirname5, join as join3 } from "node:path";
 import { promisify } from "node:util";
 
-// src/infra/bundled-scripts-root.ts
-import { existsSync as existsSync2 } from "node:fs";
-import { dirname as dirname5, join as join3 } from "node:path";
-import { fileURLToPath } from "node:url";
-function getBundledScriptsRoot() {
-  const moduleDir = dirname5(fileURLToPath(import.meta.url));
-  const candidates = [
-    join3(moduleDir, "../scripts"),
-    join3(moduleDir, "../src/scripts")
-  ];
-  return candidates.find((candidate) => existsSync2(candidate)) ?? candidates[0];
+// src/domain/completion-candidates.ts
+async function resolveValue2(value) {
+  if (typeof value === "function") {
+    return await value();
+  }
+  return await value;
+}
+function toKebabCase(value) {
+  return value.replace(/[A-Z]/g, (char) => `-${char.toLowerCase()}`);
+}
+async function getSubCommands(command) {
+  const subCommands = await resolveValue2(command.subCommands);
+  if (!subCommands) {
+    return {};
+  }
+  const entries = await Promise.all(Object.entries(subCommands).map(async ([name, value]) => [
+    name,
+    await resolveValue2(value)
+  ]));
+  const publicNames = new Set(getCommandRegistrations(command)?.filter((registration) => registration.visibility === "public").map((registration) => registration.name));
+  return Object.fromEntries(publicNames.size === 0 ? entries : entries.filter(([name]) => publicNames.has(name)));
+}
+async function getArgs(command) {
+  return await resolveValue2(command.args) ?? {};
+}
+function isFlag(word) {
+  return word.startsWith("-");
+}
+function isCompleteFlag(word) {
+  return word.startsWith("--") && word.length > 2 && !word.includes("=");
+}
+function flagName(name, _arg) {
+  return `--${toKebabCase(name)}`;
+}
+async function traverseCommand(rootCommand, completedWords) {
+  let command = rootCommand;
+  const path = [];
+  let skipFlagValue = false;
+  for (const word of completedWords) {
+    if (skipFlagValue) {
+      skipFlagValue = false;
+      continue;
+    }
+    if (isFlag(word)) {
+      const args = await getArgs(command);
+      const arg = Object.entries(args).find(([name]) => flagName(name, args[name]) === word)?.[1];
+      skipFlagValue = arg?.type === "string";
+      continue;
+    }
+    const subCommands = await getSubCommands(command);
+    const next = subCommands[word];
+    if (!next) {
+      return { command, path };
+    }
+    command = next;
+    path.push(word);
+  }
+  return { command, path };
+}
+function filterByPrefix(candidates, prefix) {
+  return [...new Set(candidates)].filter((candidate) => candidate.startsWith(prefix)).sort((a4, b4) => a4.localeCompare(b4));
+}
+async function getFlagCandidates(command, completedWords, prefix) {
+  const args = await getArgs(command);
+  const used = new Set(completedWords.filter(isCompleteFlag));
+  const candidates = Object.entries(args).filter(([, arg]) => arg.type !== "positional").map(([name, arg]) => flagName(name, arg)).filter((candidate) => !used.has(candidate));
+  return filterByPrefix(candidates, prefix);
+}
+async function getCompletionCandidates({
+  rootCommand,
+  words
+}) {
+  const currentWord = words.at(-1) ?? "";
+  const completedWords = words.slice(0, -1);
+  const state = await traverseCommand(rootCommand, completedWords);
+  if (!state) {
+    return [];
+  }
+  if (currentWord.startsWith("-")) {
+    return getFlagCandidates(state.command, completedWords, currentWord);
+  }
+  const positionalCandidates = getPositionalCandidateProvider(state.command);
+  const subCommands = await getSubCommands(state.command);
+  const dynamicCandidates = positionalCandidates ? await positionalCandidates({
+    currentWord,
+    completedWords,
+    path: state.path
+  }) : [];
+  const staticCandidates = completedWords.length === state.path.length ? Object.keys(subCommands) : [];
+  return filterByPrefix([...staticCandidates, ...dynamicCandidates], currentWord);
 }
 
-// src/infra/discover-scripts.ts
-import { readdir as readdir3, readFile as readFile3, stat as stat2 } from "node:fs/promises";
-import { join as join4 } from "node:path";
+// src/command/completion.command.ts
+var supportedCompletionShells = ["powershell", "zsh"];
+var emptyCompletionWord = "__cthutool_empty_completion_word__";
+var powershellProfileEnv = "CHC_COMPLETION_POWERSHELL_PROFILE";
+var zshProfileEnv = "CHC_COMPLETION_ZSH_PROFILE";
+var powershellCompletionLoadLine = "chc completion powershell | Out-String | Invoke-Expression";
+var powershellCompletionReloadHint = `Restart PowerShell to load it, or run: ${powershellCompletionLoadLine}`;
+var legacyPowerShellCompletionComment = "# CthuTool CLI completion";
+var completionStartMarker = "# >>> cthutool chc completion >>>";
+var completionEndMarker = "# <<< cthutool chc completion <<<";
+var powershellCompletionBlock = `${completionStartMarker}
+${powershellCompletionLoadLine}
+${completionEndMarker}`;
+var zshCompletionLoadLine = "source <(chc completion zsh)";
+var zshCompletionBlock = `${completionStartMarker}
+if (( ! $+functions[compdef] )); then
+  autoload -Uz compinit
+  compinit
+fi
+${zshCompletionLoadLine}
+${completionEndMarker}`;
+var execFileAsync = promisify(execFile);
+var powershellScript = `Register-ArgumentCompleter -Native -CommandName chc -ScriptBlock {
+  param($wordToComplete, $commandAst, $cursorPosition)
+  $words = @($commandAst.CommandElements | Select-Object -Skip 1 | ForEach-Object { $_.Extent.Text })
+  if ($words.Count -eq 0 -or $words[-1] -ne $wordToComplete) {
+    if ($wordToComplete -eq '') {
+      $words += '__cthutool_empty_completion_word__'
+    } else {
+      $words += $wordToComplete
+    }
+  }
+  chc __complete @words | ForEach-Object {
+    $completionText = if ($_.StartsWith('-')) { $_ } else { "$_ " }
+    [System.Management.Automation.CompletionResult]::new($completionText, $_, 'ParameterValue', $_)
+  }
+}
+`;
+var zshScript = `#compdef chc
+_chc_completion() {
+  local -a candidates
+  candidates=("\${(@f)$(chc __complete "\${words[@]:1}")}")
+  compadd -- "\${candidates[@]}"
+}
+compdef _chc_completion chc
+`;
+var completionShellScripts = {
+  powershell: powershellScript,
+  zsh: zshScript
+};
+function isCompletionShell(value) {
+  return supportedCompletionShells.some((shell) => shell === value);
+}
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+function removeManagedCompletionBlock(content) {
+  const pattern = new RegExp(`${escapeRegExp(completionStartMarker)}\\r?\\n[\\s\\S]*?\\r?\\n${escapeRegExp(completionEndMarker)}\\r?\\n?`, "g");
+  const nextContent = content.replace(pattern, "");
+  return { content: nextContent, removed: nextContent !== content };
+}
+function removeLegacyCompletionBlock(content) {
+  const legacyBlockPattern = new RegExp(`${escapeRegExp(legacyPowerShellCompletionComment)}\\r?\\n${escapeRegExp(powershellCompletionLoadLine)}\\r?\\n?`, "g");
+  return content.replace(legacyBlockPattern, "");
+}
+function removeLegacyZshCompletionLine(content) {
+  const legacyLinePattern = new RegExp(`^${escapeRegExp(zshCompletionLoadLine)}\\r?\\n?`, "gm");
+  return content.replace(legacyLinePattern, "");
+}
+async function readTextIfExists(path) {
+  try {
+    return await readFile3(path, "utf8");
+  } catch (error) {
+    if (error && typeof error === "object" && "code" in error && error.code === "ENOENT") {
+      return "";
+    }
+    throw error;
+  }
+}
+async function resolvePowerShellProfilePath() {
+  const override = process.env[powershellProfileEnv]?.trim();
+  if (override) {
+    return override;
+  }
+  for (const executable of ["pwsh", "powershell"]) {
+    try {
+      const { stdout: stdout2 } = await execFileAsync(executable, [
+        "-NoProfile",
+        "-NonInteractive",
+        "-Command",
+        "$PROFILE.CurrentUserCurrentHost"
+      ]);
+      const profilePath = stdout2.trim();
+      if (profilePath.length > 0) {
+        return profilePath;
+      }
+    } catch {}
+  }
+  if (platform2() === "win32") {
+    return join3(process.env.USERPROFILE || homedir2(), "Documents", "PowerShell", "Microsoft.PowerShell_profile.ps1");
+  }
+  return join3(homedir2(), ".config", "powershell", "Microsoft.PowerShell_profile.ps1");
+}
+function resolveZshProfilePath() {
+  const override = process.env[zshProfileEnv]?.trim();
+  if (override) {
+    return override;
+  }
+  const zdotdir = process.env.ZDOTDIR?.trim();
+  return join3(zdotdir || homedir2(), ".zshrc");
+}
+async function handlePowerShellProfileAction(action) {
+  const profilePath = await resolvePowerShellProfilePath();
+  const content = await readTextIfExists(profilePath);
+  const installed = content.includes(completionStartMarker) && content.includes(completionEndMarker);
+  if (action === "status") {
+    process.stdout.write(`PowerShell completion ${installed ? "enabled" : "disabled"}: ${profilePath}
+`);
+    if (installed) {
+      process.stdout.write(`${powershellCompletionReloadHint}
+`);
+    }
+    process.exitCode = 0;
+    return;
+  }
+  if (action === "disable") {
+    const cleaned2 = removeManagedCompletionBlock(content);
+    if (cleaned2.removed) {
+      await writeFile3(profilePath, cleaned2.content);
+    }
+    process.stdout.write(`PowerShell completion disabled: ${profilePath}
+`);
+    process.exitCode = 0;
+    return;
+  }
+  const cleaned = removeManagedCompletionBlock(content);
+  const migratedContent = removeLegacyCompletionBlock(cleaned.content);
+  const prefix = migratedContent.length === 0 || migratedContent.endsWith(`
+`) ? migratedContent : `${migratedContent}
+`;
+  await mkdir3(dirname5(profilePath), { recursive: true });
+  await writeFile3(profilePath, `${prefix}${powershellCompletionBlock}
+`);
+  process.stdout.write(`PowerShell completion ${installed ? "already enabled" : "enabled"}: ${profilePath}
+`);
+  process.stdout.write(`${powershellCompletionReloadHint}
+`);
+  process.exitCode = 0;
+}
+async function handleZshProfileAction(action) {
+  const profilePath = resolveZshProfilePath();
+  const content = await readTextIfExists(profilePath);
+  const installed = content.includes(completionStartMarker) && content.includes(completionEndMarker);
+  const reloadHint = `Restart zsh to load it, or run: source ${profilePath}`;
+  if (action === "status") {
+    process.stdout.write(`zsh completion ${installed ? "enabled" : "disabled"}: ${profilePath}
+`);
+    if (installed) {
+      process.stdout.write(`${reloadHint}
+`);
+    }
+    process.exitCode = 0;
+    return;
+  }
+  if (action === "disable") {
+    const cleaned2 = removeManagedCompletionBlock(content);
+    if (cleaned2.removed) {
+      await writeFile3(profilePath, cleaned2.content);
+    }
+    process.stdout.write(`zsh completion disabled: ${profilePath}
+`);
+    process.exitCode = 0;
+    return;
+  }
+  const cleaned = removeManagedCompletionBlock(content);
+  const migratedContent = removeLegacyZshCompletionLine(cleaned.content);
+  const prefix = migratedContent.length === 0 || migratedContent.endsWith(`
+`) ? migratedContent : `${migratedContent}
+`;
+  await mkdir3(dirname5(profilePath), { recursive: true });
+  await writeFile3(profilePath, `${prefix}${zshCompletionBlock}
+`);
+  process.stdout.write(`zsh completion ${installed ? "already enabled" : "enabled"}: ${profilePath}
+`);
+  process.stdout.write(`${reloadHint}
+`);
+  process.exitCode = 0;
+}
+function createCompletionShellCommand(shell) {
+  return defineCommand({
+    meta: {
+      name: shell,
+      description: `Print the ${shell} completion adapter.`
+    },
+    async run({ args }) {
+      await runObservedCliCommand(args, { command: "completion", subcommand: shell }, async () => {
+        process.stdout.write(completionShellScripts[shell]);
+        process.exitCode = 0;
+      });
+    }
+  });
+}
+function createCompletionProfileCommand(action) {
+  const command = defineCommand({
+    meta: {
+      name: action,
+      description: `${action[0]?.toUpperCase()}${action.slice(1)} persistent shell completion.`
+    },
+    args: {
+      shell: {
+        type: "positional",
+        description: "Shell profile to manage (powershell or zsh)",
+        required: true
+      }
+    },
+    async run({ args }) {
+      await runObservedCliCommand(args, { command: "completion", subcommand: action }, async ({ fail }) => {
+        const shell = typeof args.shell === "string" ? args.shell : "";
+        if (!isCompletionShell(shell)) {
+          const error = createCliError("invalid_option", `unsupported managed completion shell: ${shell || "<missing>"}`);
+          fail(error, { details: { action, shell } });
+          process.stderr.write(`${error.message}
+`);
+          process.exitCode = error.exitCode;
+          return;
+        }
+        try {
+          if (shell === "powershell") {
+            await handlePowerShellProfileAction(action);
+          } else {
+            await handleZshProfileAction(action);
+          }
+        } catch (error) {
+          const cliError = createCliError("invalid_option", error instanceof Error ? error.message : String(error));
+          fail(cliError, { details: { action, shell } });
+          process.stderr.write(`${cliError.message}
+`);
+          process.exitCode = cliError.exitCode;
+        }
+      });
+    }
+  });
+  return registerPositionalCandidates(command, ({ completedWords, path }) => completedWords.length === path.length ? supportedCompletionShells : []);
+}
+function createCompletionCommand() {
+  const registrations = [
+    ...supportedCompletionShells.map((shell) => ({
+      name: shell,
+      command: createCompletionShellCommand(shell),
+      visibility: "public",
+      bareBehavior: "run"
+    })),
+    ...["enable", "disable", "status"].map((action) => ({
+      name: action,
+      command: createCompletionProfileCommand(action),
+      visibility: "public",
+      bareBehavior: "run"
+    }))
+  ];
+  return registerCommandGroup(defineCommand({
+    meta: {
+      name: "completion",
+      description: "Print or manage shell completion setup."
+    },
+    subCommands: buildRegisteredSubCommands(registrations)
+  }), registrations);
+}
+function createInternalCompleteCommand(resolveRootCommand) {
+  return defineCommand({
+    meta: {
+      name: "__complete",
+      description: "Internal shell completion protocol."
+    },
+    async run({ rawArgs }) {
+      try {
+        const words = rawArgs.map((word) => word === emptyCompletionWord ? "" : word);
+        const candidates = await getCompletionCandidates({
+          rootCommand: resolveRootCommand(),
+          words
+        });
+        if (candidates.length > 0) {
+          process.stdout.write(`${candidates.join(`
+`)}
+`);
+        }
+        process.exitCode = 0;
+      } catch {
+        process.exitCode = 0;
+      }
+    }
+  });
+}
+
+// src/command/run-scripts.command.ts
+var import_picocolors4 = __toESM(require_picocolors(), 1);
 
 // ../../node_modules/.pnpm/neverthrow@8.2.0/node_modules/neverthrow/dist/index.cjs.js
 var defaultErrorConfig = {
@@ -4606,20 +5073,20 @@ function __asyncGenerator(thisArg, _arguments, generator) {
   return i2 = Object.create((typeof AsyncIterator === "function" ? AsyncIterator : Object).prototype), verb("next"), verb("throw"), verb("return", awaitReturn), i2[Symbol.asyncIterator] = function() {
     return this;
   }, i2;
-  function awaitReturn(f3) {
+  function awaitReturn(f4) {
     return function(v3) {
-      return Promise.resolve(v3).then(f3, reject);
+      return Promise.resolve(v3).then(f4, reject);
     };
   }
-  function verb(n2, f3) {
+  function verb(n2, f4) {
     if (g4[n2]) {
       i2[n2] = function(v3) {
         return new Promise(function(a4, b4) {
           q3.push([n2, v3, a4, b4]) > 1 || resume(n2, v3);
         });
       };
-      if (f3)
-        i2[n2] = f3(i2[n2]);
+      if (f4)
+        i2[n2] = f4(i2[n2]);
     }
   }
   function resume(n2, v3) {
@@ -4638,8 +5105,8 @@ function __asyncGenerator(thisArg, _arguments, generator) {
   function reject(value) {
     resume("throw", value);
   }
-  function settle(f3, v3) {
-    if (f3(v3), q3.shift(), q3.length)
+  function settle(f4, v3) {
+    if (f4(v3), q3.shift(), q3.length)
       resume(q3[0][0], q3[0][1]);
   }
 }
@@ -4650,10 +5117,10 @@ function __asyncDelegator(o3) {
   }), verb("return"), i2[Symbol.iterator] = function() {
     return this;
   }, i2;
-  function verb(n2, f3) {
+  function verb(n2, f4) {
     i2[n2] = o3[n2] ? function(v3) {
-      return (p = !p) ? { value: __await(o3[n2](v3)), done: false } : f3 ? f3(v3) : v3;
-    } : f3;
+      return (p = !p) ? { value: __await(o3[n2](v3)), done: false } : f4 ? f4(v3) : v3;
+    } : f4;
   }
 }
 function __asyncValues(o3) {
@@ -4705,69 +5172,69 @@ class ResultAsync {
   static combineWithAllErrors(asyncResultList) {
     return combineResultAsyncListWithAllErrors(asyncResultList);
   }
-  map(f3) {
+  map(f4) {
     return new ResultAsync(this._promise.then((res) => __awaiter(this, undefined, undefined, function* () {
       if (res.isErr()) {
         return new Err(res.error);
       }
-      return new Ok(yield f3(res.value));
+      return new Ok(yield f4(res.value));
     })));
   }
-  andThrough(f3) {
+  andThrough(f4) {
     return new ResultAsync(this._promise.then((res) => __awaiter(this, undefined, undefined, function* () {
       if (res.isErr()) {
         return new Err(res.error);
       }
-      const newRes = yield f3(res.value);
+      const newRes = yield f4(res.value);
       if (newRes.isErr()) {
         return new Err(newRes.error);
       }
       return new Ok(res.value);
     })));
   }
-  andTee(f3) {
+  andTee(f4) {
     return new ResultAsync(this._promise.then((res) => __awaiter(this, undefined, undefined, function* () {
       if (res.isErr()) {
         return new Err(res.error);
       }
       try {
-        yield f3(res.value);
+        yield f4(res.value);
       } catch (e3) {}
       return new Ok(res.value);
     })));
   }
-  orTee(f3) {
+  orTee(f4) {
     return new ResultAsync(this._promise.then((res) => __awaiter(this, undefined, undefined, function* () {
       if (res.isOk()) {
         return new Ok(res.value);
       }
       try {
-        yield f3(res.error);
+        yield f4(res.error);
       } catch (e3) {}
       return new Err(res.error);
     })));
   }
-  mapErr(f3) {
+  mapErr(f4) {
     return new ResultAsync(this._promise.then((res) => __awaiter(this, undefined, undefined, function* () {
       if (res.isOk()) {
         return new Ok(res.value);
       }
-      return new Err(yield f3(res.error));
+      return new Err(yield f4(res.error));
     })));
   }
-  andThen(f3) {
+  andThen(f4) {
     return new ResultAsync(this._promise.then((res) => {
       if (res.isErr()) {
         return new Err(res.error);
       }
-      const newValue = f3(res.value);
+      const newValue = f4(res.value);
       return newValue instanceof ResultAsync ? newValue._promise : newValue;
     }));
   }
-  orElse(f3) {
+  orElse(f4) {
     return new ResultAsync(this._promise.then((res) => __awaiter(this, undefined, undefined, function* () {
       if (res.isErr()) {
-        return f3(res.error);
+        return f4(res.error);
       }
       return new Ok(res.value);
     })));
@@ -4867,21 +5334,21 @@ class Ok {
   isErr() {
     return !this.isOk();
   }
-  map(f3) {
-    return ok(f3(this.value));
+  map(f4) {
+    return ok(f4(this.value));
   }
   mapErr(_f) {
     return ok(this.value);
   }
-  andThen(f3) {
-    return f3(this.value);
+  andThen(f4) {
+    return f4(this.value);
   }
-  andThrough(f3) {
-    return f3(this.value).map((_value) => this.value);
+  andThrough(f4) {
+    return f4(this.value).map((_value) => this.value);
   }
-  andTee(f3) {
+  andTee(f4) {
     try {
-      f3(this.value);
+      f4(this.value);
     } catch (e3) {}
     return ok(this.value);
   }
@@ -4891,14 +5358,14 @@ class Ok {
   orElse(_f) {
     return ok(this.value);
   }
-  asyncAndThen(f3) {
-    return f3(this.value);
+  asyncAndThen(f4) {
+    return f4(this.value);
   }
-  asyncAndThrough(f3) {
-    return f3(this.value).map(() => this.value);
+  asyncAndThrough(f4) {
+    return f4(this.value).map(() => this.value);
   }
-  asyncMap(f3) {
-    return ResultAsync.fromSafePromise(f3(this.value));
+  asyncMap(f4) {
+    return ResultAsync.fromSafePromise(f4(this.value));
   }
   unwrapOr(_v) {
     return this.value;
@@ -4912,7 +5379,7 @@ class Ok {
       return value;
     }();
   }
-  _unsafeUnwrap(_4) {
+  _unsafeUnwrap(_5) {
     return this.value;
   }
   _unsafeUnwrapErr(config) {
@@ -4936,8 +5403,8 @@ class Err {
   map(_f) {
     return err(this.error);
   }
-  mapErr(f3) {
-    return err(f3(this.error));
+  mapErr(f4) {
+    return err(f4(this.error));
   }
   andThrough(_f) {
     return err(this.error);
@@ -4945,17 +5412,17 @@ class Err {
   andTee(_f) {
     return err(this.error);
   }
-  orTee(f3) {
+  orTee(f4) {
     try {
-      f3(this.error);
+      f4(this.error);
     } catch (e3) {}
     return err(this.error);
   }
   andThen(_f) {
     return err(this.error);
   }
-  orElse(f3) {
-    return f3(this.error);
+  orElse(f4) {
+    return f4(this.error);
   }
   asyncAndThen(_f) {
     return errAsync(this.error);
@@ -4982,7 +5449,7 @@ class Err {
   _unsafeUnwrap(config) {
     throw createNeverThrowError("Called `_unsafeUnwrap` on an Err", this, config);
   }
-  _unsafeUnwrapErr(_4) {
+  _unsafeUnwrapErr(_5) {
     return this.error;
   }
   *[Symbol.iterator]() {
@@ -4999,7 +5466,11 @@ var $ok = ok;
 
 // src/domain/script-catalog.ts
 var ENTRY_FILE = "index.ts";
-var listSelectable = (catalog) => [...catalog.packages].sort((a4, b4) => a4.id.localeCompare(b4.id)).map((p) => ({ id: p.id, title: p.manifest.title }));
+var listSelectable = (catalog) => [...catalog.packages].sort((a4, b4) => a4.id.localeCompare(b4.id)).map((p) => ({
+  id: p.id,
+  title: p.manifest.title,
+  description: p.manifest.description
+}));
 var resolvePackage = (catalog, id) => {
   const matches = catalog.packages.filter((p) => p.id === id);
   if (matches.length === 0) {
@@ -5011,6 +5482,106 @@ var resolvePackage = (catalog, id) => {
   const [first] = matches;
   return $ok(first);
 };
+
+// src/flow/run-bundled-script.ts
+import { join as join4 } from "node:path";
+import { pathToFileURL } from "node:url";
+function runBundledScript(pkg, args, context) {
+  const entryPath = join4(pkg.rootPath, pkg.entryRelative);
+  const href = pathToFileURL(entryPath).href;
+  const startedAt = Date.now();
+  const diagnostics = context.diagnostics?.child({ scriptId: pkg.id });
+  diagnostics?.emit({
+    level: "info",
+    event: "cli.script_started",
+    phase: "start",
+    scriptId: pkg.id,
+    details: {
+      entryPath,
+      scriptArgs: summarizeScriptArgs(args)
+    }
+  });
+  return $ResultAsync.fromPromise(import(href), (e3) => ({
+    kind: "load",
+    message: e3 instanceof Error ? e3.message : String(e3)
+  })).andThen((mod) => {
+    const fn = mod.default;
+    if (typeof fn !== "function") {
+      return $errAsync({
+        kind: "no_default_export",
+        message: "script entry must default-export a function (see script-package contract)"
+      });
+    }
+    const run = fn;
+    return $ResultAsync.fromPromise(Promise.resolve(run(args, context)), (e3) => {
+      if (isCliCommandError(e3)) {
+        return {
+          kind: "execution",
+          message: e3.message,
+          cliError: e3
+        };
+      }
+      return {
+        kind: "execution",
+        message: e3 instanceof Error ? e3.message : String(e3)
+      };
+    });
+  }).map(() => {
+    diagnostics?.emit({
+      level: "info",
+      event: "cli.script_completed",
+      phase: "complete",
+      scriptId: pkg.id,
+      durationMs: Math.max(0, Date.now() - startedAt)
+    });
+    return;
+  }).mapErr((error) => {
+    if (error.kind === "execution" && error.cliError) {
+      diagnostics?.emit({
+        level: "error",
+        event: "cli.script_failed",
+        phase: "execution",
+        scriptId: pkg.id,
+        durationMs: Math.max(0, Date.now() - startedAt),
+        exitCode: error.cliError.exitCode,
+        errorCode: error.cliError.code,
+        message: error.cliError.message,
+        details: { scriptArgs: summarizeScriptArgs(args) }
+      });
+      return error;
+    }
+    diagnostics?.emit({
+      level: "error",
+      event: "cli.script_failed",
+      phase: error.kind,
+      scriptId: pkg.id,
+      durationMs: Math.max(0, Date.now() - startedAt),
+      message: error.message,
+      details: { scriptArgs: summarizeScriptArgs(args) }
+    });
+    return error;
+  });
+}
+
+// src/infra/bundled-script-catalog.ts
+var import_picocolors3 = __toESM(require_picocolors(), 1);
+
+// src/infra/bundled-scripts-root.ts
+import { existsSync as existsSync2 } from "node:fs";
+import { dirname as dirname6, join as join5 } from "node:path";
+import { fileURLToPath } from "node:url";
+function getBundledScriptsRoot() {
+  const moduleDir = dirname6(fileURLToPath(import.meta.url));
+  const candidates = [
+    join5(moduleDir, "../scripts"),
+    join5(moduleDir, "../src/scripts")
+  ];
+  return candidates.find((candidate) => existsSync2(candidate)) ?? candidates[0];
+}
+
+// src/infra/discover-scripts.ts
+import { readdir as readdir3, readFile as readFile4, stat as stat2 } from "node:fs/promises";
+import { join as join6 } from "node:path";
 
 // src/domain/script-id.ts
 var KEBAB_CASE_RE = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
@@ -5342,6 +5913,7 @@ var parseScriptManifest = (raw) => {
 
 // src/infra/discover-scripts.ts
 var MANIFEST_FILE = "script.json";
+var reservedScriptIds = new Set(["list", "run"]);
 var pushWarning = (warnings, path, message) => {
   warnings.push({ path, message });
 };
@@ -5363,14 +5935,14 @@ async function scanScriptsRoot(scriptsRoot) {
   }
   const names = entries.filter((e3) => e3.isDirectory()).map((e3) => e3.name).sort((a4, b4) => a4.localeCompare(b4));
   for (const name of names) {
-    const dirPath = join4(scriptsRoot, name);
+    const dirPath = join6(scriptsRoot, name);
     const dirIdResult = validateScriptId(name);
     if (dirIdResult.isErr()) {
       pushWarning(warnings, dirPath, `skip non-kebab-case script folder: ${dirIdResult.error.message}`);
       continue;
     }
-    const manifestPath = join4(dirPath, MANIFEST_FILE);
-    const entryPath = join4(dirPath, ENTRY_FILE);
+    const manifestPath = join6(dirPath, MANIFEST_FILE);
+    const entryPath = join6(dirPath, ENTRY_FILE);
     let manifestStat;
     let entryStat;
     try {
@@ -5388,7 +5960,7 @@ async function scanScriptsRoot(scriptsRoot) {
     }
     let rawJson;
     try {
-      rawJson = await readFile3(manifestPath, "utf8");
+      rawJson = await readFile4(manifestPath, "utf8");
     } catch (e3) {
       const msg = e3 instanceof Error ? e3.message : String(e3);
       pushWarning(warnings, manifestPath, `cannot read manifest: ${msg}`);
@@ -5412,6 +5984,10 @@ async function scanScriptsRoot(scriptsRoot) {
       pushWarning(warnings, manifestPath, `manifest id "${manifest.id}" does not match folder name "${name}"`);
       continue;
     }
+    if (reservedScriptIds.has(manifest.id)) {
+      pushWarning(warnings, manifestPath, `script id "${manifest.id}" is reserved for a scripts command operation`);
+      continue;
+    }
     if (seenIds.has(manifest.id)) {
       pushWarning(warnings, dirPath, `duplicate script id "${manifest.id}" ignored (keep first in discovery order)`);
       continue;
@@ -5427,489 +6003,71 @@ async function scanScriptsRoot(scriptsRoot) {
   return { packages, warnings };
 }
 
-// src/domain/completion-candidates.ts
-async function resolveValue2(value) {
-  if (typeof value === "function") {
-    return await value();
+// src/infra/bundled-script-catalog.ts
+var maxDescriptionLength = 160;
+var maxWarnings = 5;
+function boundedDescription(value) {
+  if (!value) {
+    return;
   }
-  return await value;
+  return value.length <= maxDescriptionLength ? value : `${value.slice(0, maxDescriptionLength - 1)}…`;
 }
-function toKebabCase(value) {
-  return value.replace(/[A-Z]/g, (char) => `-${char.toLowerCase()}`);
+function toBundledScriptCatalogRows(catalog) {
+  return listSelectable(catalog).map((row) => ({
+    ...row,
+    description: boundedDescription(row.description)
+  }));
 }
-async function getSubCommands(command) {
-  const subCommands = await resolveValue2(command.subCommands);
-  if (!subCommands) {
-    return {};
+function loadBundledScriptCatalog() {
+  return discoverScripts(getBundledScriptsRoot());
+}
+async function getBundledScriptIdCandidates() {
+  const discovered = await loadBundledScriptCatalog();
+  return discovered.isOk() ? toBundledScriptCatalogRows(discovered.value).map((row) => row.id) : [];
+}
+function formatBundledScriptCatalog(catalog, heading = "AVAILABLE SCRIPTS") {
+  const rows = toBundledScriptCatalogRows(catalog);
+  const width = Math.max(0, ...rows.map((row) => row.id.length));
+  const lines = [heading, ""];
+  if (rows.length === 0) {
+    lines.push("  No bundled scripts available.");
+  } else {
+    for (const row of rows) {
+      const detail = row.description ? `${row.title} — ${row.description}` : row.title;
+      lines.push(`  ${import_picocolors3.default.cyan(row.id.padEnd(width + 2))}${detail}`);
+    }
   }
-  const entries = await Promise.all(Object.entries(subCommands).map(async ([name, value]) => [
-    name,
-    await resolveValue2(value)
-  ]));
-  return Object.fromEntries(entries);
-}
-async function getArgs(command) {
-  return await resolveValue2(command.args) ?? {};
-}
-function isFlag(word) {
-  return word.startsWith("-");
-}
-function isCompleteFlag(word) {
-  return word.startsWith("--") && word.length > 2 && !word.includes("=");
-}
-function flagName(name, _arg) {
-  return `--${toKebabCase(name)}`;
-}
-async function traverseCommand(rootCommand, completedWords) {
-  let command = rootCommand;
-  const path = [];
-  let skipFlagValue = false;
-  for (const word of completedWords) {
-    if (skipFlagValue) {
-      skipFlagValue = false;
-      continue;
+  if (catalog.warnings.length > 0) {
+    lines.push("", "WARNINGS", "");
+    for (const warning of catalog.warnings.slice(0, maxWarnings)) {
+      lines.push(`  ${warning.path}: ${warning.message}`);
     }
-    if (isFlag(word)) {
-      const args = await getArgs(command);
-      const arg = Object.entries(args).find(([name]) => flagName(name, args[name]) === word)?.[1];
-      skipFlagValue = arg?.type === "string";
-      continue;
+    const omitted = catalog.warnings.length - maxWarnings;
+    if (omitted > 0) {
+      lines.push(`  ... ${omitted} more warnings`);
     }
-    const subCommands = await getSubCommands(command);
-    const next = subCommands[word];
-    if (!next) {
-      return { command, path };
-    }
-    command = next;
-    path.push(word);
   }
-  return { command, path };
+  return lines.join(`
+`);
 }
-function filterByPrefix(candidates, prefix) {
-  return [...new Set(candidates)].filter((candidate) => candidate.startsWith(prefix)).sort((a4, b4) => a4.localeCompare(b4));
-}
-async function getFlagCandidates(command, completedWords, prefix) {
-  const args = await getArgs(command);
-  const used = new Set(completedWords.filter(isCompleteFlag));
-  const candidates = Object.entries(args).filter(([, arg]) => arg.type !== "positional").map(([name, arg]) => flagName(name, arg)).filter((candidate) => !used.has(candidate));
-  return filterByPrefix(candidates, prefix);
-}
-async function getScriptCandidates(prefix) {
-  const discovered = await discoverScripts(getBundledScriptsRoot());
+async function renderBundledScriptHelpAppendix() {
+  const discovered = await loadBundledScriptCatalog();
   if (discovered.isErr()) {
-    return [];
-  }
-  return filterByPrefix(listSelectable(discovered.value).map((row) => row.id), prefix);
-}
-function shouldCompleteScriptId(path, completedWords) {
-  if (path.join(" ") !== "scripts") {
-    return false;
-  }
-  const hasScriptFlag = completedWords.at(-1) === "--script";
-  const hasExplicitId = completedWords.some((word, index) => {
-    if (index === 0 || isFlag(word)) {
-      return false;
-    }
-    const previous = completedWords[index - 1];
-    return previous !== "--script";
-  });
-  return hasScriptFlag || !hasExplicitId;
-}
-function shouldCompleteShellName(path, completedWords) {
-  return path.join(" ") === "completion" && completedWords.length === 1;
-}
-function shouldCompleteManagedShellName(path, completedWords) {
-  return path.join(" ") === "completion" && completedWords.length === 2 && ["disable", "enable", "status"].includes(completedWords[1]);
-}
-async function getCompletionCandidates({
-  rootCommand,
-  words
-}) {
-  const currentWord = words.at(-1) ?? "";
-  const completedWords = words.slice(0, -1);
-  const state = await traverseCommand(rootCommand, completedWords);
-  if (!state) {
-    return [];
-  }
-  if (currentWord.startsWith("-")) {
-    return getFlagCandidates(state.command, completedWords, currentWord);
-  }
-  if (shouldCompleteScriptId(state.path, completedWords)) {
-    return getScriptCandidates(currentWord);
-  }
-  if (shouldCompleteShellName(state.path, completedWords)) {
-    return filterByPrefix(["disable", "enable", "powershell", "status", "zsh"], currentWord);
-  }
-  if (shouldCompleteManagedShellName(state.path, completedWords)) {
-    return filterByPrefix(["powershell", "zsh"], currentWord);
-  }
-  const subCommands = await getSubCommands(state.command);
-  return filterByPrefix(Object.keys(subCommands).filter((candidate) => candidate !== "__complete"), currentWord);
-}
-
-// src/command/completion.command.ts
-var emptyCompletionWord = "__cthutool_empty_completion_word__";
-var powershellProfileEnv = "CHC_COMPLETION_POWERSHELL_PROFILE";
-var zshProfileEnv = "CHC_COMPLETION_ZSH_PROFILE";
-var powershellCompletionLoadLine = "chc completion powershell | Out-String | Invoke-Expression";
-var powershellCompletionReloadHint = `Restart PowerShell to load it, or run: ${powershellCompletionLoadLine}`;
-var legacyPowerShellCompletionComment = "# CthuTool CLI completion";
-var completionStartMarker = "# >>> cthutool chc completion >>>";
-var completionEndMarker = "# <<< cthutool chc completion <<<";
-var powershellCompletionBlock = `${completionStartMarker}
-${powershellCompletionLoadLine}
-${completionEndMarker}`;
-var zshCompletionLoadLine = "source <(chc completion zsh)";
-var zshCompletionBlock = `${completionStartMarker}
-if (( ! $+functions[compdef] )); then
-  autoload -Uz compinit
-  compinit
-fi
-${zshCompletionLoadLine}
-${completionEndMarker}`;
-var execFileAsync = promisify(execFile);
-var powershellScript = `Register-ArgumentCompleter -Native -CommandName chc -ScriptBlock {
-  param($wordToComplete, $commandAst, $cursorPosition)
-  $words = @($commandAst.CommandElements | Select-Object -Skip 1 | ForEach-Object { $_.Extent.Text })
-  if ($words.Count -eq 0 -or $words[-1] -ne $wordToComplete) {
-    if ($wordToComplete -eq '') {
-      $words += '__cthutool_empty_completion_word__'
-    } else {
-      $words += $wordToComplete
-    }
-  }
-  chc __complete @words | ForEach-Object {
-    $completionText = if ($_.StartsWith('-')) { $_ } else { "$_ " }
-    [System.Management.Automation.CompletionResult]::new($completionText, $_, 'ParameterValue', $_)
-  }
-}
-`;
-var zshScript = `#compdef chc
-_chc_completion() {
-  local -a candidates
-  candidates=("\${(@f)$(chc __complete "\${words[@]:1}")}")
-  compadd -- "\${candidates[@]}"
-}
-compdef _chc_completion chc
-`;
-function renderShellScript(shell) {
-  if (shell === "powershell") {
-    return powershellScript;
-  }
-  if (shell === "zsh") {
-    return zshScript;
-  }
-  return;
-}
-function isCompletionProfileAction(value) {
-  return value === "enable" || value === "disable" || value === "status";
-}
-function escapeRegExp(value) {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-}
-function removeManagedCompletionBlock(content) {
-  const pattern = new RegExp(`${escapeRegExp(completionStartMarker)}\\r?\\n[\\s\\S]*?\\r?\\n${escapeRegExp(completionEndMarker)}\\r?\\n?`, "g");
-  const nextContent = content.replace(pattern, "");
-  return { content: nextContent, removed: nextContent !== content };
-}
-function removeLegacyCompletionBlock(content) {
-  const legacyBlockPattern = new RegExp(`${escapeRegExp(legacyPowerShellCompletionComment)}\\r?\\n${escapeRegExp(powershellCompletionLoadLine)}\\r?\\n?`, "g");
-  return content.replace(legacyBlockPattern, "");
-}
-function removeLegacyZshCompletionLine(content) {
-  const legacyLinePattern = new RegExp(`^${escapeRegExp(zshCompletionLoadLine)}\\r?\\n?`, "gm");
-  return content.replace(legacyLinePattern, "");
-}
-async function readTextIfExists(path) {
-  try {
-    return await readFile4(path, "utf8");
-  } catch (error) {
-    if (error && typeof error === "object" && "code" in error && error.code === "ENOENT") {
-      return "";
-    }
-    throw error;
-  }
-}
-async function resolvePowerShellProfilePath() {
-  const override = process.env[powershellProfileEnv]?.trim();
-  if (override) {
-    return override;
-  }
-  for (const executable of ["pwsh", "powershell"]) {
-    try {
-      const { stdout: stdout2 } = await execFileAsync(executable, [
-        "-NoProfile",
-        "-NonInteractive",
-        "-Command",
-        "$PROFILE.CurrentUserCurrentHost"
-      ]);
-      const profilePath = stdout2.trim();
-      if (profilePath.length > 0) {
-        return profilePath;
-      }
-    } catch {}
-  }
-  if (platform2() === "win32") {
-    return join5(process.env.USERPROFILE || homedir2(), "Documents", "PowerShell", "Microsoft.PowerShell_profile.ps1");
-  }
-  return join5(homedir2(), ".config", "powershell", "Microsoft.PowerShell_profile.ps1");
-}
-function resolveZshProfilePath() {
-  const override = process.env[zshProfileEnv]?.trim();
-  if (override) {
-    return override;
-  }
-  const zdotdir = process.env.ZDOTDIR?.trim();
-  return join5(zdotdir || homedir2(), ".zshrc");
-}
-async function handlePowerShellProfileAction(action) {
-  const profilePath = await resolvePowerShellProfilePath();
-  const content = await readTextIfExists(profilePath);
-  const installed = content.includes(completionStartMarker) && content.includes(completionEndMarker);
-  if (action === "status") {
-    process.stdout.write(`PowerShell completion ${installed ? "enabled" : "disabled"}: ${profilePath}
+    return [
+      "AVAILABLE SCRIPTS",
+      "",
+      `  Unavailable: ${discovered.error.message}`
+    ].join(`
 `);
-    if (installed) {
-      process.stdout.write(`${powershellCompletionReloadHint}
-`);
-    }
-    process.exitCode = 0;
-    return;
   }
-  if (action === "disable") {
-    const cleaned2 = removeManagedCompletionBlock(content);
-    if (cleaned2.removed) {
-      await writeFile3(profilePath, cleaned2.content);
-    }
-    process.stdout.write(`PowerShell completion disabled: ${profilePath}
-`);
-    process.exitCode = 0;
-    return;
-  }
-  const cleaned = removeManagedCompletionBlock(content);
-  const migratedContent = removeLegacyCompletionBlock(cleaned.content);
-  const prefix = migratedContent.length === 0 || migratedContent.endsWith(`
-`) ? migratedContent : `${migratedContent}
-`;
-  await mkdir3(dirname6(profilePath), { recursive: true });
-  await writeFile3(profilePath, `${prefix}${powershellCompletionBlock}
-`);
-  process.stdout.write(`PowerShell completion ${installed ? "already enabled" : "enabled"}: ${profilePath}
-`);
-  process.stdout.write(`${powershellCompletionReloadHint}
-`);
-  process.exitCode = 0;
-}
-async function handleZshProfileAction(action) {
-  const profilePath = resolveZshProfilePath();
-  const content = await readTextIfExists(profilePath);
-  const installed = content.includes(completionStartMarker) && content.includes(completionEndMarker);
-  const reloadHint = `Restart zsh to load it, or run: source ${profilePath}`;
-  if (action === "status") {
-    process.stdout.write(`zsh completion ${installed ? "enabled" : "disabled"}: ${profilePath}
-`);
-    if (installed) {
-      process.stdout.write(`${reloadHint}
-`);
-    }
-    process.exitCode = 0;
-    return;
-  }
-  if (action === "disable") {
-    const cleaned2 = removeManagedCompletionBlock(content);
-    if (cleaned2.removed) {
-      await writeFile3(profilePath, cleaned2.content);
-    }
-    process.stdout.write(`zsh completion disabled: ${profilePath}
-`);
-    process.exitCode = 0;
-    return;
-  }
-  const cleaned = removeManagedCompletionBlock(content);
-  const migratedContent = removeLegacyZshCompletionLine(cleaned.content);
-  const prefix = migratedContent.length === 0 || migratedContent.endsWith(`
-`) ? migratedContent : `${migratedContent}
-`;
-  await mkdir3(dirname6(profilePath), { recursive: true });
-  await writeFile3(profilePath, `${prefix}${zshCompletionBlock}
-`);
-  process.stdout.write(`zsh completion ${installed ? "already enabled" : "enabled"}: ${profilePath}
-`);
-  process.stdout.write(`${reloadHint}
-`);
-  process.exitCode = 0;
-}
-function createCompletionCommand() {
-  return defineCommand({
-    meta: {
-      name: "completion",
-      description: "Print or manage shell completion setup."
-    },
-    args: {
-      shell: {
-        type: "positional",
-        description: "Shell to generate completion for (powershell or zsh), or action to manage persistent completion",
-        required: true
-      }
-    },
-    async run({ args, rawArgs }) {
-      await runObservedCliCommand(args, { command: "completion" }, async ({ fail }) => {
-        const first = rawArgs[0] ?? "";
-        if (isCompletionProfileAction(first)) {
-          const shell2 = rawArgs[1] ?? "";
-          if (shell2 !== "powershell" && shell2 !== "zsh") {
-            const error = createCliError("invalid_option", `unsupported managed completion shell: ${shell2 || "<missing>"}`);
-            fail(error, { details: { action: first, shell: shell2 } });
-            process.stderr.write(`${error.message}
-`);
-            process.exitCode = error.exitCode;
-            return;
-          }
-          try {
-            if (shell2 === "powershell") {
-              await handlePowerShellProfileAction(first);
-            } else {
-              await handleZshProfileAction(first);
-            }
-          } catch (error) {
-            const cliError = createCliError("invalid_option", error instanceof Error ? error.message : String(error));
-            fail(cliError, { details: { action: first, shell: shell2 } });
-            process.stderr.write(`${cliError.message}
-`);
-            process.exitCode = cliError.exitCode;
-          }
-          return;
-        }
-        const shell = typeof args.shell === "string" ? args.shell : "";
-        const script = renderShellScript(shell);
-        if (!script) {
-          const error = createCliError("invalid_option", `unsupported shell: ${shell}`);
-          fail(error, { details: { shell } });
-          process.stderr.write(`${error.message}
-`);
-          process.exitCode = error.exitCode;
-          return;
-        }
-        process.stdout.write(script);
-        process.exitCode = 0;
-      });
-    }
-  });
-}
-function createInternalCompleteCommand(resolveRootCommand) {
-  return defineCommand({
-    meta: {
-      name: "__complete",
-      description: "Internal shell completion protocol."
-    },
-    async run({ rawArgs }) {
-      try {
-        const words = rawArgs.map((word) => word === emptyCompletionWord ? "" : word);
-        const candidates = await getCompletionCandidates({
-          rootCommand: resolveRootCommand(),
-          words
-        });
-        if (candidates.length > 0) {
-          process.stdout.write(`${candidates.join(`
-`)}
-`);
-        }
-        process.exitCode = 0;
-      } catch {
-        process.exitCode = 0;
-      }
-    }
-  });
-}
-
-// src/command/run-scripts.command.ts
-var import_picocolors3 = __toESM(require_picocolors(), 1);
-
-// src/flow/run-bundled-script.ts
-import { join as join6 } from "node:path";
-import { pathToFileURL } from "node:url";
-function runBundledScript(pkg, args, context) {
-  const entryPath = join6(pkg.rootPath, pkg.entryRelative);
-  const href = pathToFileURL(entryPath).href;
-  const startedAt = Date.now();
-  const diagnostics = context.diagnostics?.child({ scriptId: pkg.id });
-  diagnostics?.emit({
-    level: "info",
-    event: "cli.script_started",
-    phase: "start",
-    scriptId: pkg.id,
-    details: {
-      entryPath,
-      scriptArgs: summarizeScriptArgs(args)
-    }
-  });
-  return $ResultAsync.fromPromise(import(href), (e3) => ({
-    kind: "load",
-    message: e3 instanceof Error ? e3.message : String(e3)
-  })).andThen((mod) => {
-    const fn = mod.default;
-    if (typeof fn !== "function") {
-      return $errAsync({
-        kind: "no_default_export",
-        message: "script entry must default-export a function (see script-package contract)"
-      });
-    }
-    const run = fn;
-    return $ResultAsync.fromPromise(Promise.resolve(run(args, context)), (e3) => {
-      if (isCliCommandError(e3)) {
-        return {
-          kind: "execution",
-          message: e3.message,
-          cliError: e3
-        };
-      }
-      return {
-        kind: "execution",
-        message: e3 instanceof Error ? e3.message : String(e3)
-      };
-    });
-  }).map(() => {
-    diagnostics?.emit({
-      level: "info",
-      event: "cli.script_completed",
-      phase: "complete",
-      scriptId: pkg.id,
-      durationMs: Math.max(0, Date.now() - startedAt)
-    });
-    return;
-  }).mapErr((error) => {
-    if (error.kind === "execution" && error.cliError) {
-      diagnostics?.emit({
-        level: "error",
-        event: "cli.script_failed",
-        phase: "execution",
-        scriptId: pkg.id,
-        durationMs: Math.max(0, Date.now() - startedAt),
-        exitCode: error.cliError.exitCode,
-        errorCode: error.cliError.code,
-        message: error.cliError.message,
-        details: { scriptArgs: summarizeScriptArgs(args) }
-      });
-      return error;
-    }
-    diagnostics?.emit({
-      level: "error",
-      event: "cli.script_failed",
-      phase: error.kind,
-      scriptId: pkg.id,
-      durationMs: Math.max(0, Date.now() - startedAt),
-      message: error.message,
-      details: { scriptArgs: summarizeScriptArgs(args) }
-    });
-    return error;
-  });
+  return formatBundledScriptCatalog(discovered.value);
 }
 
 // src/command/run-scripts.command.ts
 var defaultDeps = {
   isInteractive: () => process.stdin.isTTY === true,
   pickScriptId: async (rows) => {
-    pe(import_picocolors3.default.cyan("▶ Script Selection"));
+    pe(import_picocolors4.default.cyan("▶ Script Selection"));
     const choice = await le2({
       message: "Choose a bundled script to run",
       options: rows.map((o3) => ({
@@ -5921,6 +6079,20 @@ var defaultDeps = {
       return;
     }
     return choice;
+  }
+};
+var scriptRunnerArgs = {
+  ...cliContractArgs,
+  id: {
+    type: "positional",
+    description: "Script id (folder name under apps/cli/src/scripts/)",
+    required: false
+  },
+  script: {
+    type: "string",
+    description: "Same as positional id (for non-interactive CI)",
+    alias: "s",
+    valueHint: "id"
   }
 };
 function resolveExplicitId(args) {
@@ -5941,162 +6113,223 @@ function toScriptArgs(args) {
   ]);
   return Object.fromEntries(Object.entries(args).filter(([key]) => !skipped.has(key)));
 }
-var createScriptsCommand = (deps = defaultDeps) => defineCommand({
-  meta: {
-    name: "scripts",
-    description: [
-      "Discover and run bundled scripts under apps/cli/src/scripts/<id>/ (script.json + index.ts).",
-      "",
-      "Examples:",
-      "  chc scripts hello-world",
-      "  chc scripts --script hello-world",
-      "  bun run apps/cli/src/scripts/hello-world/index.ts"
-    ].join(`
-`)
-  },
-  args: {
-    ...cliContractArgs,
-    id: {
-      type: "positional",
-      description: "Script id (folder name under apps/cli/src/scripts/)",
-      required: false
-    },
-    script: {
-      type: "string",
-      description: "Same as positional id (for non-interactive CI)",
-      alias: "s",
-      valueHint: "id"
+function shouldOfferScriptIds({
+  completedWords,
+  path
+}) {
+  const tail = completedWords.slice(path.length);
+  const last = tail.at(-1);
+  if (last === "--script" || last === "-s") {
+    return true;
+  }
+  return !tail.some((word) => !word.startsWith("-"));
+}
+async function scriptIdCandidates(context) {
+  return shouldOfferScriptIds(context) ? await getBundledScriptIdCandidates() : [];
+}
+function normalizeScriptsArgs(args) {
+  const [first] = args;
+  if (!first || first === "list" || first === "run" || first === "--help" || first === "-h") {
+    return args;
+  }
+  return ["run", ...args];
+}
+async function executeBundledScript(args, deps) {
+  const context = createCliContext(args, { isTty: deps.isInteractive });
+  const commandDiagnostics = createCliCommandDiagnostics(context, processOutput, { command: "scripts" });
+  const diagnostics = createCliDiagnostics(context, processOutput, {
+    command: "scripts"
+  });
+  const fail = (error, details) => {
+    commandDiagnostics.fail(error, { details });
+    writeCommandError(context, processOutput, error);
+    process.exitCode = error.exitCode;
+  };
+  const root = getBundledScriptsRoot();
+  const discovered = await loadBundledScriptCatalog();
+  if (discovered.isErr()) {
+    const error = createCliError("discovery_failed", discovered.error.message);
+    fail(error, { phase: "discovery", scriptsRoot: root });
+    return;
+  }
+  const catalog = discovered.value;
+  diagnostics.emit({
+    level: "debug",
+    event: "cli.scripts_discovered",
+    phase: "discovery",
+    details: {
+      packageCount: catalog.packages.length,
+      warningCount: catalog.warnings.length
     }
-  },
-  async run({ args }) {
-    const context = createCliContext(args, { isTty: deps.isInteractive });
-    const commandDiagnostics = createCliCommandDiagnostics(context, processOutput, { command: "scripts" });
-    const diagnostics = createCliDiagnostics(context, processOutput, {
-      command: "scripts"
-    });
-    const fail = (error, details) => {
-      commandDiagnostics.fail(error, { details });
-      writeCommandError(context, processOutput, error);
-      process.exitCode = error.exitCode;
-    };
-    const root = getBundledScriptsRoot();
-    const discovered = await discoverScripts(root);
-    if (discovered.isErr()) {
-      const error = createCliError("discovery_failed", discovered.error.message);
-      fail(error, { phase: "discovery", scriptsRoot: root });
-      return;
-    }
-    const catalog = discovered.value;
+  });
+  for (const warning of catalog.warnings) {
+    writeWarning(processOutput, import_picocolors4.default.yellow(`${warning.path}: ${warning.message}`));
     diagnostics.emit({
-      level: "debug",
-      event: "cli.scripts_discovered",
+      level: "warn",
+      event: "cli.script_discovery_warning",
       phase: "discovery",
       details: {
-        packageCount: catalog.packages.length,
-        warningCount: catalog.warnings.length
+        message: warning.message,
+        path: warning.path
       }
     });
-    for (const w3 of catalog.warnings) {
-      writeWarning(processOutput, import_picocolors3.default.yellow(`${w3.path}: ${w3.message}`));
-      diagnostics.emit({
-        level: "warn",
-        event: "cli.script_discovery_warning",
-        phase: "discovery",
-        details: {
-          message: w3.message,
-          path: w3.path
-        }
-      });
-    }
-    if (catalog.packages.length === 0) {
-      const error = createCliError("discovery_failed", "no valid bundled script packages found (see apps/cli/src/scripts/)");
-      fail(error, { phase: "discovery", scriptsRoot: root });
+  }
+  if (catalog.packages.length === 0) {
+    const error = createCliError("discovery_failed", "no valid bundled script packages found (see apps/cli/src/scripts/)");
+    fail(error, { phase: "discovery", scriptsRoot: root });
+    return;
+  }
+  const explicitId = resolveExplicitId(args);
+  let targetId = explicitId;
+  if (!targetId) {
+    if (!context.interactive) {
+      const error = createCliError("missing_required_argument", "script id is required in non-interactive mode (use: chc scripts run <id>, chc scripts <id>, or --script <id>)");
+      fail(error, { phase: "selection" });
       return;
     }
-    const explicitId = resolveExplicitId(args);
-    let targetId = explicitId;
-    if (!targetId) {
-      if (!context.interactive) {
-        const error = createCliError("missing_required_argument", "script id is required in non-interactive mode (use: chc scripts <id> or --script <id>)");
-        fail(error, { phase: "selection" });
-        return;
-      }
-      const options = listSelectable(catalog);
-      if (options.length === 1) {
-        const [only] = options;
-        targetId = only.id;
-        diagnostics.emit({
-          level: "info",
-          event: "cli.script_selected",
-          phase: "selection",
-          scriptId: targetId,
-          details: { selectionMode: "single-option" }
-        });
-      } else {
-        const choice = await deps.pickScriptId(options);
-        if (choice === undefined) {
-          const error = createCliError("invalid_option", "selection cancelled");
-          fail(error, { phase: "selection" });
-          return;
-        }
-        targetId = choice;
-        diagnostics.emit({
-          level: "info",
-          event: "cli.script_selected",
-          phase: "selection",
-          scriptId: targetId,
-          details: { selectionMode: "interactive" }
-        });
-      }
-    } else {
+    const options = listSelectable(catalog);
+    if (options.length === 1) {
+      const [only] = options;
+      targetId = only.id;
       diagnostics.emit({
         level: "info",
         event: "cli.script_selected",
         phase: "selection",
         scriptId: targetId,
-        details: {
-          selectionMode: explicitId === args.script ? "flag" : "positional"
-        }
+        details: { selectionMode: "single-option" }
       });
-    }
-    const resolved = resolvePackage(catalog, targetId);
-    if (resolved.isErr()) {
-      const error = resolved.error.kind === "not_found" ? createCliError("unknown_selection", `unknown script id: ${resolved.error.id}`) : createCliError("ambiguous_selection", `ambiguous script id: ${resolved.error.id}`);
-      fail(error, {
+    } else {
+      const choice = await deps.pickScriptId(options);
+      if (choice === undefined) {
+        const error = createCliError("invalid_option", "selection cancelled");
+        fail(error, { phase: "selection" });
+        return;
+      }
+      targetId = choice;
+      diagnostics.emit({
+        level: "info",
+        event: "cli.script_selected",
         phase: "selection",
-        requestedScriptId: resolved.error.id
+        scriptId: targetId,
+        details: { selectionMode: "interactive" }
       });
-      return;
     }
-    const executed = await runBundledScript(resolved.value, toScriptArgs(args), {
-      cli: context,
-      diagnostics: diagnostics.child({
-        scriptId: resolved.value.id
-      })
-    });
-    if (executed.isErr()) {
-      const e3 = executed.error;
-      const error = e3.kind === "load" ? createCliError("script_load_failed", e3.message) : e3.kind === "no_default_export" ? createCliError("script_load_failed", e3.message) : e3.cliError ?? createCliError("script_execution_failed", e3.message);
-      fail(error, {
-        phase: e3.kind,
-        scriptId: resolved.value.id,
-        scriptArgs: summarizeScriptArgs(toScriptArgs(args))
-      });
-      return;
-    }
-    commandDiagnostics.complete({
+  } else {
+    diagnostics.emit({
+      level: "info",
+      event: "cli.script_selected",
+      phase: "selection",
+      scriptId: targetId,
       details: {
-        scriptId: resolved.value.id,
-        scriptArgs: summarizeScriptArgs(toScriptArgs(args))
+        selectionMode: explicitId === args.script ? "flag" : "positional"
       }
     });
-    process.exitCode = 0;
   }
-});
+  const resolved = resolvePackage(catalog, targetId);
+  if (resolved.isErr()) {
+    const error = resolved.error.kind === "not_found" ? createCliError("unknown_selection", `unknown script id: ${resolved.error.id}`) : createCliError("ambiguous_selection", `ambiguous script id: ${resolved.error.id}`);
+    fail(error, {
+      phase: "selection",
+      requestedScriptId: resolved.error.id
+    });
+    return;
+  }
+  const executed = await runBundledScript(resolved.value, toScriptArgs(args), {
+    cli: context,
+    diagnostics: diagnostics.child({
+      scriptId: resolved.value.id
+    })
+  });
+  if (executed.isErr()) {
+    const error = executed.error.kind === "load" || executed.error.kind === "no_default_export" ? createCliError("script_load_failed", executed.error.message) : executed.error.cliError ?? createCliError("script_execution_failed", executed.error.message);
+    fail(error, {
+      phase: executed.error.kind,
+      scriptId: resolved.value.id,
+      scriptArgs: summarizeScriptArgs(toScriptArgs(args))
+    });
+    return;
+  }
+  commandDiagnostics.complete({
+    details: {
+      scriptId: resolved.value.id,
+      scriptArgs: summarizeScriptArgs(toScriptArgs(args))
+    }
+  });
+  process.exitCode = 0;
+}
+function createScriptListCommand() {
+  return defineCommand({
+    meta: {
+      name: "list",
+      description: "List discovered bundled scripts."
+    },
+    args: cliContractArgs,
+    async run({ args }) {
+      await runObservedCliCommand(args, { command: "scripts", subcommand: "list" }, async ({ context, fail }) => {
+        const discovered = await loadBundledScriptCatalog();
+        if (discovered.isErr()) {
+          const error = createCliError("discovery_failed", discovered.error.message);
+          fail(error, { details: { phase: "discovery" } });
+          writeCommandError(context, processOutput, error);
+          process.exitCode = error.exitCode;
+          return;
+        }
+        if (context.json) {
+          writeJsonValue(processOutput, {
+            ok: true,
+            command: "scripts list",
+            scripts: toBundledScriptCatalogRows(discovered.value)
+          });
+        } else {
+          writeHumanStatus(context, processOutput, formatBundledScriptCatalog(discovered.value));
+        }
+        process.exitCode = 0;
+      });
+    }
+  });
+}
+function createScriptRunCommand(deps) {
+  const command = defineCommand({
+    meta: {
+      name: "run",
+      description: "Run a discovered bundled script."
+    },
+    args: scriptRunnerArgs,
+    async run({ args }) {
+      await executeBundledScript(args, deps);
+    }
+  });
+  return registerPositionalCandidates(command, scriptIdCandidates);
+}
+var createScriptsCommand = (deps = defaultDeps) => {
+  const registrations = [
+    {
+      name: "list",
+      command: createScriptListCommand(),
+      visibility: "public",
+      bareBehavior: "run"
+    },
+    {
+      name: "run",
+      command: createScriptRunCommand(deps),
+      visibility: "public",
+      bareBehavior: "run"
+    }
+  ];
+  const command = registerCommandGroup(defineCommand({
+    meta: {
+      name: "scripts",
+      description: "Discover, list, and run bundled scripts under apps/cli/src/scripts/<id>/."
+    },
+    subCommands: buildRegisteredSubCommands(registrations)
+  }), registrations);
+  registerPositionalCandidates(command, scriptIdCandidates);
+  return registerCommandHelpAppendix(command, renderBundledScriptHelpAppendix);
+};
 var scriptsCommand = createScriptsCommand();
 
 // src/command/self-update.command.ts
-var import_picocolors4 = __toESM(require_picocolors(), 1);
+var import_picocolors6 = __toESM(require_picocolors(), 1);
 
 // src/domain/self-update-manager.ts
 import { spawn } from "node:child_process";
@@ -6108,19 +6341,34 @@ import { fileURLToPath as fileURLToPath2 } from "node:url";
 var defaultSelfUpdateRepo = "https://github.com/mickmetalholic/CthuTool.git";
 var defaultSelfUpdateRef = "main";
 var committedCliBundlePath = "apps/cli/dist/index.js";
+var maxChangeHighlights = 5;
+var maxSubjectLength = 120;
+var maxDetailLines = 8;
+var maxDetailLineLength = 240;
 
 class SelfUpdateError extends Error {
+  phase;
+  summary;
+  causeText;
+  hint;
   result;
-  constructor(result) {
-    super(formatFailedCommand(result));
+  constructor(options) {
+    const cause = options.cause ? `
+Cause: ${options.cause}` : "";
+    super(`${options.summary}${cause}
+Next: ${options.hint}`);
     this.name = "SelfUpdateError";
-    this.result = result;
+    this.phase = options.phase;
+    this.summary = options.summary;
+    this.causeText = options.cause;
+    this.hint = options.hint;
+    this.result = options.result;
   }
 }
 function getDefaultSelfUpdateInstallDir(home = homedir3()) {
   return join7(home, ".cthutool", "source", "CthuTool");
 }
-function createSelfUpdateDeps(onStep) {
+function createSelfUpdateDeps(onEvent) {
   return {
     exists: existsSync3,
     mkdir: async (path) => {
@@ -6129,7 +6377,7 @@ function createSelfUpdateDeps(onStep) {
     run: runCommand2,
     env: process.env,
     home: homedir3,
-    onStep
+    onEvent
   };
 }
 function getCliVersion() {
@@ -6143,69 +6391,331 @@ function resolveSelfUpdateOptions(options, deps) {
     installDir: options.installDir ?? deps.env.CHC_INSTALL_DIR ?? getDefaultSelfUpdateInstallDir(home)
   };
 }
-function emitStep(deps, step) {
-  deps.onStep?.(step);
+function emit(deps, event) {
+  deps.onEvent?.(event);
 }
-function ensureOk(result) {
-  if (result.code !== 0) {
-    throw new SelfUpdateError(result);
+async function runPhase(deps, phase, action) {
+  emit(deps, { type: "phase_started", phase });
+  try {
+    const value = await action();
+    emit(deps, { type: "phase_completed", phase });
+    return value;
+  } catch (error) {
+    const failure = toPhaseError(error, phase);
+    emit(deps, {
+      type: "failure",
+      phase: failure.phase,
+      summary: failure.summary,
+      cause: failure.causeText,
+      hint: failure.hint
+    });
+    throw failure;
   }
 }
-async function runRequired(deps, command, args, options) {
-  ensureOk(await deps.run(command, args, options));
+function phaseHint(phase) {
+  switch (phase) {
+    case "preflight":
+      return "Check the selected directory and local Git state, then retry.";
+    case "check_remote":
+      return "Check the repository URL, ref, network access, and Git credentials.";
+    case "clone":
+      return "Check repository access and permissions for the managed source directory.";
+    case "fetch":
+      return "Check network access and the configured origin, then retry.";
+    case "checkout":
+      return "Inspect the checkout state and selected ref before retrying.";
+    case "verify_bundle":
+      return `Select a ref containing ${committedCliBundlePath}.`;
+    case "install_global":
+      return "Check npm global-install permissions, then retry the update.";
+  }
 }
-async function remoteRefExists(deps, installDir, ref) {
-  const result = await deps.run("git", ["rev-parse", "--verify", `origin/${ref}`], { cwd: installDir, allowFailure: true });
-  return result.code === 0;
+function toPhaseError(error, phase) {
+  if (error instanceof SelfUpdateError) {
+    return error;
+  }
+  return new SelfUpdateError({
+    phase,
+    summary: `Update failed during ${formatPhase(phase)}.`,
+    cause: boundedText(error instanceof Error ? error.message : String(error)),
+    hint: phaseHint(phase)
+  });
+}
+function commandFailure(phase, result) {
+  return new SelfUpdateError({
+    phase,
+    summary: `Update failed during ${formatPhase(phase)}.`,
+    cause: boundedCommandOutput(result) || `Command exited with code ${result.code}.`,
+    hint: phaseHint(phase),
+    result
+  });
+}
+async function execute(deps, phase, command, args, options = {}) {
+  let result;
+  try {
+    result = await deps.run(command, args, options);
+  } catch (error) {
+    throw new SelfUpdateError({
+      phase,
+      summary: `Unable to start ${command} during ${formatPhase(phase)}.`,
+      cause: boundedText(error instanceof Error ? error.message : String(error)),
+      hint: phaseHint(phase)
+    });
+  }
+  emit(deps, {
+    type: "command",
+    phase,
+    command,
+    args: redactArgs(args),
+    cwd: options.cwd,
+    code: result.code,
+    stdout: boundedText(result.stdout),
+    stderr: boundedText(result.stderr)
+  });
+  if (result.code !== 0 && options.allowFailure !== true) {
+    throw commandFailure(phase, result);
+  }
+  return result;
+}
+async function requiredOutput(deps, phase, args, cwd) {
+  const result = await execute(deps, phase, "git", args, { cwd });
+  const value = result.stdout.trim();
+  if (value.length === 0) {
+    throw new SelfUpdateError({
+      phase,
+      summary: `Git returned no identity during ${formatPhase(phase)}.`,
+      hint: phaseHint(phase)
+    });
+  }
+  return value;
+}
+async function readIdentity(deps, phase, cwd, fallbackRef, revision = "HEAD") {
+  const commit = await requiredOutput(deps, phase, ["rev-parse", "--verify", `${revision}^{commit}`], cwd);
+  const refResult = revision === "HEAD" ? await execute(deps, phase, "git", ["symbolic-ref", "--quiet", "--short", "HEAD"], { cwd, allowFailure: true }) : undefined;
+  return {
+    ref: refResult?.code === 0 ? refResult.stdout.trim() || fallbackRef : fallbackRef,
+    commit,
+    shortCommit: commit.slice(0, 7)
+  };
+}
+function finishPlan(deps, plan) {
+  emit(deps, { type: "plan", plan });
+  return plan;
+}
+async function planSelfUpdate(options = {}, deps = createSelfUpdateDeps()) {
+  const resolved = resolveSelfUpdateOptions(options, deps);
+  const publicResolved = {
+    ...resolved,
+    repo: redactValue(resolved.repo)
+  };
+  const phases = [];
+  const gitRoot = join7(resolved.installDir, ".git");
+  const initial = await runPhase(deps, "preflight", async () => {
+    if (!deps.exists(gitRoot)) {
+      return;
+    }
+    const status = await execute(deps, "preflight", "git", ["status", "--porcelain", "--untracked-files=normal"], { cwd: resolved.installDir });
+    if (status.stdout.trim().length > 0) {
+      return "dirty";
+    }
+    return readIdentity(deps, "preflight", resolved.installDir, resolved.ref);
+  });
+  phases.push("preflight");
+  if (initial === undefined) {
+    return finishPlan(deps, {
+      status: "install_required",
+      ...publicResolved,
+      phases
+    });
+  }
+  if (initial === "dirty") {
+    return finishPlan(deps, {
+      status: "blocked",
+      ...publicResolved,
+      block: {
+        kind: "dirty_checkout",
+        message: "The selected checkout has uncommitted or untracked changes.",
+        hint: "Commit, stash, or remove the local changes, then retry."
+      },
+      phases
+    });
+  }
+  const remote = await runPhase(deps, "check_remote", async () => {
+    await execute(deps, "check_remote", "git", ["fetch", "--no-tags", resolved.repo, resolved.ref], { cwd: resolved.installDir });
+    const target = await readIdentity(deps, "check_remote", resolved.installDir, resolved.ref, "FETCH_HEAD");
+    const branch = await execute(deps, "check_remote", "git", ["ls-remote", "--exit-code", "--heads", resolved.repo, resolved.ref], { cwd: resolved.installDir, allowFailure: true });
+    return {
+      target,
+      isBranch: branch.code === 0 && branch.stdout.trim().length > 0
+    };
+  });
+  phases.push("check_remote");
+  if (initial.commit === remote.target.commit) {
+    return finishPlan(deps, {
+      status: "up_to_date",
+      ...publicResolved,
+      before: initial,
+      target: remote.target,
+      phases
+    });
+  }
+  if (remote.isBranch) {
+    const ancestor = await execute(deps, "check_remote", "git", ["merge-base", "--is-ancestor", initial.commit, remote.target.commit], { cwd: resolved.installDir, allowFailure: true });
+    if (ancestor.code === 1) {
+      return finishPlan(deps, {
+        status: "blocked",
+        ...publicResolved,
+        before: initial,
+        target: remote.target,
+        block: {
+          kind: "diverged_branch",
+          message: "The selected checkout cannot fast-forward to the remote branch.",
+          hint: "Reconcile the local branch manually, then retry."
+        },
+        phases
+      });
+    }
+    if (ancestor.code !== 0) {
+      throw commandFailure("check_remote", ancestor);
+    }
+  }
+  const changes = await loadChangeSummary(deps, resolved.installDir, initial.commit, remote.target.commit);
+  return finishPlan(deps, {
+    status: "update_available",
+    ...publicResolved,
+    before: initial,
+    target: remote.target,
+    changes,
+    phases
+  });
+}
+async function loadChangeSummary(deps, cwd, before, target) {
+  const countResult = await execute(deps, "check_remote", "git", ["rev-list", "--count", `${before}..${target}`], { cwd, allowFailure: true });
+  const parsedCount = Number.parseInt(countResult.stdout.trim(), 10);
+  const count = countResult.code === 0 && Number.isFinite(parsedCount) ? parsedCount : 0;
+  const logResult = await execute(deps, "check_remote", "git", [
+    "log",
+    `--max-count=${maxChangeHighlights}`,
+    "--format=%h%x09%s",
+    `${before}..${target}`
+  ], { cwd, allowFailure: true });
+  const highlights = logResult.code === 0 ? logResult.stdout.split(/\r?\n/).filter(Boolean).slice(0, maxChangeHighlights).map((line) => {
+    const [commit = "", ...subject] = line.split("\t");
+    return {
+      commit: commit.slice(0, 12),
+      subject: boundedLine(subject.join("\t"), maxSubjectLength)
+    };
+  }) : [];
+  return {
+    count: Math.max(count, highlights.length),
+    highlights,
+    omitted: Math.max(0, count - highlights.length)
+  };
+}
+function blockedError(plan) {
+  return new SelfUpdateError({
+    phase: "preflight",
+    summary: `Update blocked: ${plan.block?.message ?? "The selected checkout is not safe to update."}`,
+    hint: plan.block?.hint ?? phaseHint("preflight")
+  });
+}
+function assertSelfUpdatePlanReady(plan) {
+  if (plan.status === "blocked") {
+    throw blockedError(plan);
+  }
 }
 async function runSelfUpdate(options = {}, deps = createSelfUpdateDeps()) {
   const resolved = resolveSelfUpdateOptions(options, deps);
-  const completedSteps = [];
-  const recordStep = (step) => {
-    completedSteps.push(step);
-    emitStep(deps, step);
-  };
-  if (deps.exists(join7(resolved.installDir, ".git"))) {
-    recordStep("fetch");
-    await runRequired(deps, "git", ["remote", "set-url", "origin", resolved.repo], {
-      cwd: resolved.installDir
+  const plan = await planSelfUpdate(options, deps);
+  assertSelfUpdatePlanReady(plan);
+  if (plan.status === "up_to_date") {
+    return {
+      status: "up_to_date",
+      repo: plan.repo,
+      ref: plan.ref,
+      installDir: plan.installDir,
+      before: plan.before,
+      target: plan.target,
+      after: plan.before,
+      phases: plan.phases,
+      steps: []
+    };
+  }
+  const phases = [...plan.phases];
+  const steps = [];
+  const isInstall = plan.status === "install_required";
+  if (isInstall) {
+    await runPhase(deps, "clone", async () => {
+      await deps.mkdir(dirname7(plan.installDir));
+      await execute(deps, "clone", "git", [
+        "clone",
+        resolved.repo,
+        plan.installDir
+      ]);
     });
-    await runRequired(deps, "git", ["fetch", "--tags", "origin"], {
-      cwd: resolved.installDir
-    });
+    phases.push("clone");
+    steps.push("clone");
   } else {
-    recordStep("clone");
-    await deps.mkdir(dirname7(resolved.installDir));
-    await runRequired(deps, "git", [
-      "clone",
-      resolved.repo,
-      resolved.installDir
-    ]);
-  }
-  recordStep("checkout");
-  await runRequired(deps, "git", ["checkout", resolved.ref], {
-    cwd: resolved.installDir
-  });
-  if (await remoteRefExists(deps, resolved.installDir, resolved.ref)) {
-    recordStep("pull");
-    await runRequired(deps, "git", ["pull", "--ff-only", "origin", resolved.ref], {
-      cwd: resolved.installDir
+    await runPhase(deps, "preflight", async () => {
+      const status = await execute(deps, "preflight", "git", ["status", "--porcelain", "--untracked-files=normal"], { cwd: plan.installDir });
+      if (status.stdout.trim().length > 0) {
+        throw new SelfUpdateError({
+          phase: "preflight",
+          summary: "Update blocked: the checkout changed after preflight.",
+          hint: "Preserve the new local changes, then retry."
+        });
+      }
     });
   }
-  recordStep("verify-bundle");
-  verifyCommittedBundle(deps, resolved.installDir);
-  recordStep("install-global");
-  await runRequired(deps, "npm", [
-    "install",
-    "-g",
-    "--ignore-scripts",
-    resolved.installDir
-  ]);
+  if (!isInstall) {
+    await runPhase(deps, "fetch", async () => {
+      await execute(deps, "fetch", "git", ["remote", "set-url", "origin", resolved.repo], { cwd: plan.installDir });
+      await execute(deps, "fetch", "git", ["fetch", "--tags", "origin"], {
+        cwd: plan.installDir
+      });
+    });
+    phases.push("fetch");
+    steps.push("fetch");
+  }
+  await runPhase(deps, "checkout", async () => {
+    await execute(deps, "checkout", "git", ["checkout", plan.ref], {
+      cwd: plan.installDir
+    });
+    steps.push("checkout");
+    const remoteBranch = await execute(deps, "checkout", "git", ["rev-parse", "--verify", `origin/${plan.ref}`], { cwd: plan.installDir, allowFailure: true });
+    if (remoteBranch.code === 0) {
+      await execute(deps, "checkout", "git", ["pull", "--ff-only", "origin", plan.ref], { cwd: plan.installDir });
+      steps.push("pull");
+    }
+  });
+  phases.push("checkout");
+  await runPhase(deps, "verify_bundle", async () => {
+    verifyCommittedBundle(deps, plan.installDir);
+  });
+  phases.push("verify_bundle");
+  steps.push("verify-bundle");
+  await runPhase(deps, "install_global", async () => {
+    await execute(deps, "install_global", "npm", [
+      "install",
+      "-g",
+      "--ignore-scripts",
+      plan.installDir
+    ]);
+  });
+  phases.push("install_global");
+  steps.push("install-global");
+  const after = await readIdentity(deps, "checkout", plan.installDir, plan.ref);
   return {
-    repo: resolved.repo,
-    ref: resolved.ref,
-    installDir: resolved.installDir,
-    steps: completedSteps
+    status: isInstall ? "installed" : "updated",
+    repo: plan.repo,
+    ref: plan.ref,
+    installDir: plan.installDir,
+    before: plan.before,
+    target: plan.target ?? after,
+    after,
+    changes: plan.changes,
+    phases,
+    steps
   };
 }
 async function getCliInstallationStatus(options = {}, deps = createSelfUpdateDeps()) {
@@ -6247,19 +6757,38 @@ async function runOptional(deps, command, args, options) {
 function verifyCommittedBundle(deps, installDir) {
   const bundlePath = join7(installDir, committedCliBundlePath);
   if (!deps.exists(bundlePath)) {
-    throw new Error(`missing committed CLI bundle: ${bundlePath}; the selected ref must include ${committedCliBundlePath}`);
+    throw new SelfUpdateError({
+      phase: "verify_bundle",
+      summary: "The selected ref does not contain the committed CLI bundle.",
+      cause: `Missing ${bundlePath}.`,
+      hint: phaseHint("verify_bundle")
+    });
   }
 }
-function formatFailedCommand(result) {
-  const cwd = result.cwd ? ` (cwd: ${result.cwd})` : "";
-  const output = `${result.stderr}
-${result.stdout}`.trim();
-  const suffix = output.length > 0 ? `
-${output}` : "";
-  return `command failed: ${result.command} ${result.args.join(" ")}${cwd}${suffix}`;
+function formatPhase(phase) {
+  return phase.replaceAll("_", " ");
+}
+function boundedLine(value, maxLength) {
+  const normalized = value.replaceAll(/\s+/g, " ").trim();
+  return normalized.length <= maxLength ? normalized : `${normalized.slice(0, maxLength - 1)}…`;
+}
+function boundedText(value) {
+  const lines = value.split(/\r?\n/).map((line) => boundedLine(line, maxDetailLineLength)).filter(Boolean).slice(0, maxDetailLines);
+  return lines.length > 0 ? lines.join(`
+`) : undefined;
+}
+function boundedCommandOutput(result) {
+  return boundedText(`${result.stderr}
+${result.stdout}`);
+}
+function redactArgs(args) {
+  return args.map(redactValue);
+}
+function redactValue(value) {
+  return value.replace(/:\/\/[^/@\s]+@/g, "://***@");
 }
 function runCommand2(command, args, options = {}) {
-  return new Promise((resolve5, reject) => {
+  return new Promise((resolvePromise, reject) => {
     const child = spawn(command, [...args], {
       cwd: options.cwd,
       stdio: ["ignore", "pipe", "pipe"]
@@ -6278,7 +6807,7 @@ function runCommand2(command, args, options = {}) {
       reject(error);
     });
     child.on("close", (code) => {
-      resolve5({
+      resolvePromise({
         command,
         args,
         cwd: options.cwd,
@@ -6318,9 +6847,167 @@ function readPackageVersion(root) {
   return pkg.version;
 }
 
+// src/command/self-update-output.ts
+var import_picocolors5 = __toESM(require_picocolors(), 1);
+var defaultDeps2 = {
+  output: processOutput,
+  isOutputTty: () => process.stdout.isTTY === true,
+  createSpinner: _4
+};
+var phaseLabels = {
+  preflight: "Checking local update state",
+  check_remote: "Checking the selected remote ref",
+  clone: "Cloning the managed source checkout",
+  fetch: "Fetching repository updates",
+  checkout: "Checking out the selected ref",
+  verify_bundle: "Verifying the committed CLI bundle",
+  install_global: "Installing the global command"
+};
+function identity(value) {
+  return `${value.ref}@${value.shortCommit}`;
+}
+function createSelfUpdateRenderer(context, options, deps = defaultDeps2) {
+  const human = !context.json && !context.quiet;
+  const interactiveOutput = human && context.isTty && deps.isOutputTty();
+  let activeSpinner;
+  let activePhase;
+  let headerWritten = false;
+  const writeHeader = () => {
+    if (!human || headerWritten)
+      return;
+    headerWritten = true;
+    deps.output.stdout.write(`${import_picocolors5.default.cyan("CthuTool update")}
+`);
+  };
+  const stopSpinner = (message, code) => {
+    if (!activeSpinner)
+      return;
+    activeSpinner.stop(message, code);
+    activeSpinner = undefined;
+    activePhase = undefined;
+  };
+  const renderPlan = (plan) => {
+    if (!human)
+      return;
+    writeHeader();
+    deps.output.stdout.write(`source: ${plan.installDir}
+`);
+    deps.output.stdout.write(`target: ${plan.repo}#${plan.ref}
+`);
+    if (plan.before) {
+      deps.output.stdout.write(`current: ${identity(plan.before)}
+`);
+    }
+    if (plan.target) {
+      deps.output.stdout.write(`latest:  ${identity(plan.target)}
+`);
+    }
+    if (plan.changes && plan.changes.count > 0) {
+      deps.output.stdout.write(`changes: ${plan.changes.count} commit(s)
+`);
+      for (const change of plan.changes.highlights) {
+        deps.output.stdout.write(`  ${change.commit}  ${change.subject}
+`);
+      }
+      if (plan.changes.omitted > 0) {
+        deps.output.stdout.write(`  … ${plan.changes.omitted} more commit(s)
+`);
+      }
+    }
+  };
+  const renderVerboseCommand = (event) => {
+    if (!options.verbose)
+      return;
+    const cwd = event.cwd ? ` (cwd: ${event.cwd})` : "";
+    deps.output.stderr.write(`${import_picocolors5.default.dim(`$ ${event.command} ${event.args.join(" ")}${cwd}`)}
+`);
+    for (const detail of [event.stderr, event.stdout]) {
+      if (detail)
+        deps.output.stderr.write(`${import_picocolors5.default.dim(detail)}
+`);
+    }
+  };
+  return {
+    onEvent(event) {
+      if (event.type === "command") {
+        renderVerboseCommand(event);
+        return;
+      }
+      if (event.type === "plan") {
+        renderPlan(event.plan);
+        return;
+      }
+      if (event.type === "failure") {
+        if (activeSpinner) {
+          stopSpinner(`${phaseLabels[event.phase]} failed`, 1);
+        }
+        return;
+      }
+      if (!human)
+        return;
+      writeHeader();
+      const label = phaseLabels[event.phase];
+      if (event.type === "phase_started") {
+        if (interactiveOutput) {
+          if (activeSpinner)
+            stopSpinner(phaseLabels[activePhase ?? event.phase]);
+          activeSpinner = deps.createSpinner();
+          activePhase = event.phase;
+          activeSpinner.start(label);
+        } else {
+          deps.output.stdout.write(`- ${label}
+`);
+        }
+        return;
+      }
+      if (interactiveOutput) {
+        stopSpinner(`${label} complete`);
+      } else {
+        deps.output.stdout.write(`${import_picocolors5.default.green("✓")} ${label}
+`);
+      }
+    },
+    renderCheckResult(plan) {
+      if (!human)
+        return;
+      if (plan.status === "up_to_date" && plan.target) {
+        deps.output.stdout.write(`${import_picocolors5.default.green("✓")} chc is already up to date · ${identity(plan.target)}
+`);
+      } else if (plan.status === "update_available" && plan.target) {
+        deps.output.stdout.write(`${import_picocolors5.default.cyan("Update available")} · ${identity(plan.target)}
+`);
+      } else if (plan.status === "install_required") {
+        deps.output.stdout.write(`${import_picocolors5.default.yellow("Managed installation required")} · run chc update
+`);
+      }
+    },
+    renderApplyResult(result) {
+      if (!human)
+        return;
+      const after = result.after ?? result.target;
+      if (result.status === "up_to_date" && after) {
+        deps.output.stdout.write(`${import_picocolors5.default.green("✓")} chc is already up to date · ${identity(after)}
+`);
+        return;
+      }
+      const before = result.before ? `${identity(result.before)} → ` : "";
+      const target = after ? identity(after) : result.ref;
+      const verb = result.status === "installed" ? "Installed" : "Updated";
+      deps.output.stdout.write(`${import_picocolors5.default.green("✓")} ${verb} chc successfully · ${before}${target}
+`);
+      deps.output.stdout.write("  Run `chc status` for installation details.\n");
+    },
+    stopForError(error) {
+      if (!activeSpinner)
+        return;
+      const phase = error && typeof error === "object" && "phase" in error ? error.phase : activePhase;
+      stopSpinner(phase ? `${phaseLabels[phase]} failed` : "Update failed", 1);
+    }
+  };
+}
+
 // src/command/self-update.command.ts
-var selfUpdateArgs = {
-  ...cliContractArgs,
+var selfUpdateSourceArgs = {
   repo: {
     type: "string",
     description: "Git repository URL to install from"
@@ -6334,30 +7021,39 @@ var selfUpdateArgs = {
     description: "Local source checkout directory"
   }
 };
+var selfUpdateArgs = {
+  ...cliContractArgs,
+  ...selfUpdateSourceArgs,
+  check: {
+    type: "boolean",
+    description: "Check update availability without applying changes"
+  },
+  verbose: {
+    type: "boolean",
+    description: "Show bounded Git and npm command details"
+  }
+};
 function getStringArg2(value) {
   return typeof value === "string" && value.trim().length > 0 ? value.trim() : undefined;
-}
-function formatStep(step) {
-  switch (step) {
-    case "clone":
-      return "cloning repository";
-    case "fetch":
-      return "fetching repository";
-    case "checkout":
-      return "checking out ref";
-    case "pull":
-      return "fast-forwarding branch";
-    case "verify-bundle":
-      return "verifying committed CLI bundle";
-    case "install-global":
-      return "installing global command";
-  }
 }
 function toUpdateCliError(error) {
   return error instanceof SelfUpdateError ? createCliError("update_failed", error.message) : createCliError("update_failed", error instanceof Error ? error.message : "update failed");
 }
-function writeFailure(context, cliError) {
-  writeCommandError(context, processOutput, cliError);
+function writeFailure(context, cliError, error) {
+  if (context.json && error instanceof SelfUpdateError) {
+    writeJsonValue(processOutput, {
+      ok: false,
+      error: {
+        code: cliError.code,
+        message: error.summary,
+        phase: error.phase,
+        cause: error.causeText,
+        hint: error.hint
+      }
+    });
+  } else {
+    writeCommandError(context, processOutput, cliError);
+  }
   process.exitCode = cliError.exitCode;
 }
 function createUpdateCommand() {
@@ -6372,14 +7068,27 @@ function createUpdateCommand() {
         const repo = getStringArg2(args.repo);
         const ref = getStringArg2(args.ref);
         const installDir = getStringArg2(args["install-dir"]);
-        writeHumanStatus(context, processOutput, import_picocolors4.default.cyan("CthuTool update"));
-        writeHumanStatus(context, processOutput, `repo: ${repo ?? defaultSelfUpdateRepo}`);
-        writeHumanStatus(context, processOutput, `ref:  ${ref ?? defaultSelfUpdateRef}`);
-        writeHumanStatus(context, processOutput, `dir:  ${installDir ?? getDefaultSelfUpdateInstallDir()}`);
+        const renderer = createSelfUpdateRenderer(context, {
+          verbose: args.verbose === true
+        });
+        const managerDeps = createSelfUpdateDeps(renderer.onEvent);
         try {
-          const result = await runSelfUpdate({ repo, ref, installDir }, createSelfUpdateDeps((step) => {
-            writeHumanStatus(context, processOutput, `- ${formatStep(step)}`);
-          }));
+          if (args.check === true) {
+            const result2 = await planSelfUpdate({ repo, ref, installDir }, managerDeps);
+            assertSelfUpdatePlanReady(result2);
+            if (context.json) {
+              writeJsonValue(processOutput, {
+                ok: true,
+                command: "update",
+                result: result2
+              });
+            } else {
+              renderer.renderCheckResult(result2);
+            }
+            process.exitCode = 0;
+            return;
+          }
+          const result = await runSelfUpdate({ repo, ref, installDir }, managerDeps);
           if (context.json) {
             writeJsonValue(processOutput, {
               ok: true,
@@ -6387,13 +7096,21 @@ function createUpdateCommand() {
               result
             });
           } else {
-            writeHumanStatus(context, processOutput, import_picocolors4.default.green("updated"));
+            renderer.renderApplyResult(result);
           }
           process.exitCode = 0;
         } catch (error) {
+          renderer.stopForError(error);
           const cliError = toUpdateCliError(error);
-          fail(cliError, { details: { installDir, ref, repo } });
-          writeFailure(context, cliError);
+          fail(cliError, {
+            details: {
+              installDir,
+              ref,
+              repo,
+              phase: error instanceof SelfUpdateError ? error.phase : undefined
+            }
+          });
+          writeFailure(context, cliError, error);
         }
       });
     }
@@ -6427,7 +7144,7 @@ var statusCommand = defineCommand({
     name: "status",
     description: "Show chc CLI installation status."
   },
-  args: selfUpdateArgs,
+  args: { ...cliContractArgs, ...selfUpdateSourceArgs },
   async run({ args }) {
     await runObservedCliCommand(args, { command: "status" }, async ({ context, fail }) => {
       try {
@@ -6443,7 +7160,7 @@ var statusCommand = defineCommand({
             status
           });
         } else {
-          writeHumanStatus(context, processOutput, import_picocolors4.default.cyan("CthuTool status"));
+          writeHumanStatus(context, processOutput, import_picocolors6.default.cyan("CthuTool status"));
           writeHumanStatus(context, processOutput, `version:     ${status.version}`);
           writeHumanStatus(context, processOutput, `mode:        ${status.mode}`);
           writeHumanStatus(context, processOutput, `install dir: ${status.installDir}`);
@@ -6456,7 +7173,7 @@ var statusCommand = defineCommand({
       } catch (error) {
         const cliError = toUpdateCliError(error);
         fail(cliError);
-        writeFailure(context, cliError);
+        writeFailure(context, cliError, error);
       }
     });
   }
@@ -6465,31 +7182,77 @@ var updateCommand = createUpdateCommand();
 
 // src/command/root.command.ts
 var rootCommand;
-rootCommand = defineCommand({
+var rootCommandRegistrations = [
+  {
+    name: "codex",
+    command: codexCommand,
+    visibility: "public",
+    bareBehavior: "help"
+  },
+  {
+    name: "version",
+    command: versionCommand,
+    visibility: "compat",
+    bareBehavior: "run"
+  },
+  {
+    name: "status",
+    command: statusCommand,
+    visibility: "public",
+    bareBehavior: "run"
+  },
+  {
+    name: "update",
+    command: updateCommand,
+    visibility: "public",
+    bareBehavior: "run"
+  },
+  {
+    name: "completion",
+    command: createCompletionCommand(),
+    visibility: "public",
+    bareBehavior: "help"
+  },
+  {
+    name: "__complete",
+    command: createInternalCompleteCommand(() => rootCommand),
+    visibility: "internal",
+    bareBehavior: "run"
+  },
+  {
+    name: "scripts",
+    command: scriptsCommand,
+    visibility: "public",
+    bareBehavior: "help",
+    normalizeArgs: normalizeScriptsArgs
+  }
+];
+rootCommand = registerCommandGroup(defineCommand({
   meta: {
     name: "chc",
     description: "CthuTool monorepo CLI"
   },
-  subCommands: {
-    codex: codexCommand,
-    version: versionCommand,
-    status: statusCommand,
-    update: updateCommand,
-    completion: createCompletionCommand(),
-    __complete: createInternalCompleteCommand(() => rootCommand),
-    scripts: scriptsCommand
-  }
-});
+  subCommands: buildRegisteredSubCommands(rootCommandRegistrations)
+}), rootCommandRegistrations);
 
 // src/index.ts
-function formatUsageForStdout(value) {
-  return normalizeCommandRows(value.replace(/`([^`]+)`/g, "$1").replace(/[ \t]+$/gm, ""));
+function formatUsageForStdout(value, hiddenCommands = new Set) {
+  return normalizeCommandRows(value.replace(/`([^`]+)`/g, "$1").replace(/[ \t]+$/gm, ""), hiddenCommands);
 }
 function stripAnsi3(value) {
   const sgrPattern = new RegExp(`${String.fromCharCode(27)}\\[[0-9;]*m`, "g");
   return value.replace(sgrPattern, "");
 }
-function normalizeCommandRows(value) {
+function filterUsageCommandChoices(line, hiddenCommands) {
+  const match = /^(\s*USAGE\s+\S+\s+)([A-Za-z0-9_-]+(?:\|[A-Za-z0-9_-]+)+)(.*)$/.exec(line);
+  if (!match) {
+    return line;
+  }
+  const [, prefix, choices, suffix] = match;
+  const visibleChoices = choices.split("|").filter((choice) => !hiddenCommands.has(choice));
+  return `${prefix}${visibleChoices.join("|")}${suffix}`;
+}
+function normalizeCommandRows(value, hiddenCommands) {
   const lines = value.split(`
 `);
   const normalized = [];
@@ -6499,26 +7262,27 @@ function normalizeCommandRows(value) {
     if (pendingRows.length === 0) {
       return;
     }
-    const visibleRows = pendingRows.filter((row) => row.name !== "__complete");
+    const visibleRows = pendingRows.filter((row) => row.name !== "__complete" && !hiddenCommands.has(row.name));
     if (visibleRows.length === 0) {
       pendingRows = [];
       return;
     }
     const width = Math.max(...visibleRows.map((row) => row.name.length));
     for (const row of visibleRows) {
-      normalized.push(`  ${import_picocolors5.default.bold(import_picocolors5.default.cyan(row.name.padEnd(width + 2)))}${row.description}`);
+      normalized.push(`  ${import_picocolors7.default.bold(import_picocolors7.default.cyan(row.name.padEnd(width + 2)))}${row.description}`);
     }
     pendingRows = [];
   };
   for (const line of lines) {
-    const plain = stripAnsi3(line).trim();
+    const visibleLine = filterUsageCommandChoices(line, hiddenCommands);
+    const plain = stripAnsi3(visibleLine).trim();
     if (plain === "COMMANDS") {
       flushRows();
       inCommands = true;
-      normalized.push(line);
+      normalized.push(visibleLine);
       continue;
     }
-    const commandRow = inCommands ? stripAnsi3(line).match(/^\s{2,}([A-Za-z0-9_-]+)\s{2,}(.+)$/) : null;
+    const commandRow = inCommands ? stripAnsi3(visibleLine).match(/^\s{2,}([A-Za-z0-9_-]+)\s{2,}(.+)$/) : null;
     if (commandRow) {
       pendingRows.push({
         name: commandRow[1],
@@ -6530,23 +7294,22 @@ function normalizeCommandRows(value) {
     if (inCommands && plain.length > 0) {
       inCommands = false;
     }
-    normalized.push(line);
+    normalized.push(visibleLine);
   }
   flushRows();
   return normalized.join(`
 `);
 }
 async function showNativeUsage(command, parent) {
-  process.stdout.write(`${formatUsageForStdout(await renderUsage(command, parent))}
+  const hiddenCommands = new Set(getCommandRegistrations(command)?.filter((registration) => registration.visibility !== "public").map((registration) => registration.name) ?? []);
+  const appendix = await getCommandHelpAppendixProvider(command)?.();
+  const rendered = formatUsageForStdout(await renderUsage(command, parent), hiddenCommands);
+  process.stdout.write(`${rendered}${appendix ? `
+
+${appendix}` : ""}
 `);
 }
-async function resolveValue3(value) {
-  if (typeof value === "function") {
-    return await value();
-  }
-  return await value;
-}
-async function resolveOmittedTopLevelCommand(rawArgs) {
+async function resolveBareTopLevelHelpCommand(rawArgs) {
   if (rawArgs.length !== 1) {
     return;
   }
@@ -6554,14 +7317,11 @@ async function resolveOmittedTopLevelCommand(rawArgs) {
   if (!name || name.startsWith("-") || name === "__complete") {
     return;
   }
-  if (!new Set(["codex", "scripts", "completion"]).has(name)) {
-    return;
-  }
-  const subCommands = await resolveValue3(rootCommand.subCommands);
-  return await resolveValue3(subCommands?.[name]);
+  const registration = getCommandRegistration(rootCommand, name);
+  return registration?.bareBehavior === "help" ? registration.command : undefined;
 }
-var rawArgs = process.argv.slice(2);
-var omittedTopLevelCommand = await resolveOmittedTopLevelCommand(rawArgs);
+var rawArgs = normalizeRegisteredArgs(rootCommand, process.argv.slice(2));
+var bareTopLevelHelpCommand = await resolveBareTopLevelHelpCommand(rawArgs);
 if (rawArgs.length === 1 && rawArgs[0] === "--version") {
   process.stdout.write(`chc ${getCliVersion()}
 `);
@@ -6569,11 +7329,11 @@ if (rawArgs.length === 1 && rawArgs[0] === "--version") {
 } else if (rawArgs.length === 0) {
   await showNativeUsage(rootCommand);
   process.exitCode = 0;
-} else if (omittedTopLevelCommand) {
-  await showNativeUsage(omittedTopLevelCommand, rootCommand);
+} else if (bareTopLevelHelpCommand) {
+  await showNativeUsage(bareTopLevelHelpCommand, rootCommand);
   process.exitCode = 0;
 } else {
-  await runMain(rootCommand, { showUsage: showNativeUsage }).catch(() => {
+  await runMain(rootCommand, { rawArgs, showUsage: showNativeUsage }).catch(() => {
     process.exitCode = 1;
   });
 }

--- a/apps/cli/dist/index.js
+++ b/apps/cli/dist/index.js
@@ -6869,6 +6869,7 @@ function identity(value) {
 function createSelfUpdateRenderer(context, options, deps = defaultDeps2) {
   const human = !context.json && !context.quiet;
   const interactiveOutput = human && context.isTty && deps.isOutputTty();
+  const colors2 = import_picocolors5.default.createColors(interactiveOutput);
   let activeSpinner;
   let activePhase;
   let headerWritten = false;
@@ -6876,7 +6877,7 @@ function createSelfUpdateRenderer(context, options, deps = defaultDeps2) {
     if (!human || headerWritten)
       return;
     headerWritten = true;
-    deps.output.stdout.write(`${import_picocolors5.default.cyan("CthuTool update")}
+    deps.output.stdout.write(`${colors2.cyan("CthuTool update")}
 `);
   };
   const stopSpinner = (message, code) => {
@@ -6919,11 +6920,11 @@ function createSelfUpdateRenderer(context, options, deps = defaultDeps2) {
     if (!options.verbose)
       return;
     const cwd = event.cwd ? ` (cwd: ${event.cwd})` : "";
-    deps.output.stderr.write(`${import_picocolors5.default.dim(`$ ${event.command} ${event.args.join(" ")}${cwd}`)}
+    deps.output.stderr.write(`${colors2.dim(`$ ${event.command} ${event.args.join(" ")}${cwd}`)}
 `);
     for (const detail of [event.stderr, event.stdout]) {
       if (detail)
-        deps.output.stderr.write(`${import_picocolors5.default.dim(detail)}
+        deps.output.stderr.write(`${colors2.dim(detail)}
 `);
     }
   };
@@ -6963,7 +6964,7 @@ function createSelfUpdateRenderer(context, options, deps = defaultDeps2) {
       if (interactiveOutput) {
         stopSpinner(`${label} complete`);
       } else {
-        deps.output.stdout.write(`${import_picocolors5.default.green("✓")} ${label}
+        deps.output.stdout.write(`${colors2.green("✓")} ${label}
 `);
       }
     },
@@ -6971,13 +6972,13 @@ function createSelfUpdateRenderer(context, options, deps = defaultDeps2) {
       if (!human)
         return;
       if (plan.status === "up_to_date" && plan.target) {
-        deps.output.stdout.write(`${import_picocolors5.default.green("✓")} chc is already up to date · ${identity(plan.target)}
+        deps.output.stdout.write(`${colors2.green("✓")} chc is already up to date · ${identity(plan.target)}
 `);
       } else if (plan.status === "update_available" && plan.target) {
-        deps.output.stdout.write(`${import_picocolors5.default.cyan("Update available")} · ${identity(plan.target)}
+        deps.output.stdout.write(`${colors2.cyan("Update available")} · ${identity(plan.target)}
 `);
       } else if (plan.status === "install_required") {
-        deps.output.stdout.write(`${import_picocolors5.default.yellow("Managed installation required")} · run chc update
+        deps.output.stdout.write(`${colors2.yellow("Managed installation required")} · run chc update
 `);
       }
     },
@@ -6986,14 +6987,14 @@ function createSelfUpdateRenderer(context, options, deps = defaultDeps2) {
         return;
       const after = result.after ?? result.target;
       if (result.status === "up_to_date" && after) {
-        deps.output.stdout.write(`${import_picocolors5.default.green("✓")} chc is already up to date · ${identity(after)}
+        deps.output.stdout.write(`${colors2.green("✓")} chc is already up to date · ${identity(after)}
 `);
         return;
       }
       const before = result.before ? `${identity(result.before)} → ` : "";
       const target = after ? identity(after) : result.ref;
       const verb = result.status === "installed" ? "Installed" : "Updated";
-      deps.output.stdout.write(`${import_picocolors5.default.green("✓")} ${verb} chc successfully · ${before}${target}
+      deps.output.stdout.write(`${colors2.green("✓")} ${verb} chc successfully · ${before}${target}
 `);
       deps.output.stdout.write("  Run `chc status` for installation details.\n");
     },

--- a/apps/cli/dist/index.js
+++ b/apps/cli/dist/index.js
@@ -2331,6 +2331,19 @@ async function runMain(cmd, opts = {}) {
 var import_picocolors7 = __toESM(require_picocolors(), 1);
 
 // src/command/command-discovery.ts
+function stripAnsi3(value) {
+  const sgrPattern = new RegExp(`${String.fromCharCode(27)}\\[[0-9;]*m`, "g");
+  return value.replace(sgrPattern, "");
+}
+function filterUsageCommandChoices(line, hiddenCommands) {
+  const match = /^(\s*USAGE\s+\S+\s+)([A-Za-z0-9_-]+(?:\|[A-Za-z0-9_-]+)+)(.*)$/.exec(stripAnsi3(line));
+  if (!match) {
+    return line;
+  }
+  const [, prefix, choices, suffix] = match;
+  const visibleChoices = choices.split("|").filter((choice) => !hiddenCommands.has(choice));
+  return `${prefix}${visibleChoices.join("|")}${suffix}`;
+}
 var registrationsByCommand = new WeakMap;
 var positionalCandidatesByCommand = new WeakMap;
 var helpAppendixByCommand = new WeakMap;
@@ -7239,19 +7252,6 @@ rootCommand = registerCommandGroup(defineCommand({
 // src/index.ts
 function formatUsageForStdout(value, hiddenCommands = new Set) {
   return normalizeCommandRows(value.replace(/`([^`]+)`/g, "$1").replace(/[ \t]+$/gm, ""), hiddenCommands);
-}
-function stripAnsi3(value) {
-  const sgrPattern = new RegExp(`${String.fromCharCode(27)}\\[[0-9;]*m`, "g");
-  return value.replace(sgrPattern, "");
-}
-function filterUsageCommandChoices(line, hiddenCommands) {
-  const match = /^(\s*USAGE\s+\S+\s+)([A-Za-z0-9_-]+(?:\|[A-Za-z0-9_-]+)+)(.*)$/.exec(line);
-  if (!match) {
-    return line;
-  }
-  const [, prefix, choices, suffix] = match;
-  const visibleChoices = choices.split("|").filter((choice) => !hiddenCommands.has(choice));
-  return `${prefix}${visibleChoices.join("|")}${suffix}`;
 }
 function normalizeCommandRows(value, hiddenCommands) {
   const lines = value.split(`

--- a/apps/cli/src/command/command-discovery.ts
+++ b/apps/cli/src/command/command-discovery.ts
@@ -1,0 +1,120 @@
+import type { CommandDef } from 'citty';
+
+// biome-ignore lint/suspicious/noExplicitAny: Citty's CommandDef is invariant in its argument schema; the registry intentionally stores heterogeneous commands.
+export type AnyCommandDef = CommandDef<any>;
+
+export type CommandVisibility = 'public' | 'compat' | 'internal';
+export type BareCommandBehavior = 'help' | 'run';
+
+export type CliCommandRegistration = {
+  readonly name: string;
+  readonly command: AnyCommandDef;
+  readonly visibility: CommandVisibility;
+  readonly bareBehavior: BareCommandBehavior;
+  readonly normalizeArgs?: (args: readonly string[]) => readonly string[];
+};
+
+export type CandidateProviderContext = {
+  readonly currentWord: string;
+  readonly completedWords: readonly string[];
+  readonly path: readonly string[];
+};
+
+export type PositionalCandidateProvider = (
+  context: CandidateProviderContext,
+) => Promise<readonly string[]> | readonly string[];
+
+export type CommandHelpAppendixProvider = () =>
+  | Promise<string | undefined>
+  | string
+  | undefined;
+
+const registrationsByCommand = new WeakMap<
+  AnyCommandDef,
+  readonly CliCommandRegistration[]
+>();
+const positionalCandidatesByCommand = new WeakMap<
+  AnyCommandDef,
+  PositionalCandidateProvider
+>();
+const helpAppendixByCommand = new WeakMap<
+  AnyCommandDef,
+  CommandHelpAppendixProvider
+>();
+
+export function buildRegisteredSubCommands(
+  registrations: readonly CliCommandRegistration[],
+): Record<string, AnyCommandDef> {
+  return Object.fromEntries(
+    registrations.map((registration) => [
+      registration.name,
+      registration.command,
+    ]),
+  );
+}
+
+export function registerCommandGroup<T extends AnyCommandDef>(
+  command: T,
+  registrations: readonly CliCommandRegistration[],
+): T {
+  registrationsByCommand.set(command, registrations);
+  return command;
+}
+
+export function getCommandRegistrations(
+  command: AnyCommandDef,
+): readonly CliCommandRegistration[] | undefined {
+  return registrationsByCommand.get(command);
+}
+
+export function getCommandRegistration(
+  command: AnyCommandDef,
+  name: string,
+): CliCommandRegistration | undefined {
+  return getCommandRegistrations(command)?.find(
+    (registration) => registration.name === name,
+  );
+}
+
+export function normalizeRegisteredArgs(
+  rootCommand: AnyCommandDef,
+  rawArgs: readonly string[],
+): string[] {
+  const [name, ...commandArgs] = rawArgs;
+  if (!name) {
+    return [...rawArgs];
+  }
+  const registration = getCommandRegistration(rootCommand, name);
+  if (!registration?.normalizeArgs) {
+    return [...rawArgs];
+  }
+  return [name, ...registration.normalizeArgs(commandArgs)];
+}
+
+export function registerPositionalCandidates<T extends AnyCommandDef>(
+  command: T,
+  provider: PositionalCandidateProvider,
+): T {
+  positionalCandidatesByCommand.set(command, provider);
+  return command;
+}
+
+export function getPositionalCandidateProvider(
+  command: AnyCommandDef,
+): PositionalCandidateProvider | undefined {
+  return positionalCandidatesByCommand.get(command);
+}
+
+export function registerCommandHelpAppendix<T extends AnyCommandDef>(
+  command: T,
+  provider: CommandHelpAppendixProvider,
+): T {
+  helpAppendixByCommand.set(command, provider);
+  return command;
+}
+
+export function getCommandHelpAppendixProvider(
+  command: AnyCommandDef,
+): CommandHelpAppendixProvider | undefined {
+  return helpAppendixByCommand.get(command);
+}

--- a/apps/cli/src/command/command-discovery.ts
+++ b/apps/cli/src/command/command-discovery.ts
@@ -29,6 +29,29 @@ export type CommandHelpAppendixProvider = () =>
   | string
   | undefined;
 
+export function stripAnsi(value: string): string {
+  const sgrPattern = new RegExp(`${String.fromCharCode(27)}\\[[0-9;]*m`, 'g');
+  return value.replace(sgrPattern, '');
+}
+
+export function filterUsageCommandChoices(
+  line: string,
+  hiddenCommands: ReadonlySet<string>,
+): string {
+  const match =
+    /^(\s*USAGE\s+\S+\s+)([A-Za-z0-9_-]+(?:\|[A-Za-z0-9_-]+)+)(.*)$/.exec(
+      stripAnsi(line),
+    );
+  if (!match) {
+    return line;
+  }
+  const [, prefix, choices, suffix] = match;
+  const visibleChoices = choices
+    .split('|')
+    .filter((choice) => !hiddenCommands.has(choice));
+  return `${prefix}${visibleChoices.join('|')}${suffix}`;
+}
+
 const registrationsByCommand = new WeakMap<
   AnyCommandDef,
   readonly CliCommandRegistration[]

--- a/apps/cli/src/command/completion.command.ts
+++ b/apps/cli/src/command/completion.command.ts
@@ -3,13 +3,22 @@ import { mkdir, readFile, writeFile } from 'node:fs/promises';
 import { homedir, platform } from 'node:os';
 import { dirname, join } from 'node:path';
 import { promisify } from 'node:util';
-import { type CommandDef, defineCommand } from 'citty';
+import { defineCommand } from 'citty';
 import { getCompletionCandidates } from '../domain/completion-candidates';
 import { createCliError } from '../runtime/cli-error';
 import { runObservedCliCommand } from '../runtime/command-diagnostics';
+import {
+  type AnyCommandDef,
+  buildRegisteredSubCommands,
+  type CliCommandRegistration,
+  registerCommandGroup,
+  registerPositionalCandidates,
+} from './command-discovery';
 
-type RootCommandResolver = () => CommandDef;
+type RootCommandResolver = () => AnyCommandDef;
 type CompletionProfileAction = 'enable' | 'disable' | 'status';
+export const supportedCompletionShells = ['powershell', 'zsh'] as const;
+type CompletionShell = (typeof supportedCompletionShells)[number];
 
 const emptyCompletionWord = '__cthutool_empty_completion_word__';
 const powershellProfileEnv = 'CHC_COMPLETION_POWERSHELL_PROFILE';
@@ -59,20 +68,13 @@ _chc_completion() {
 compdef _chc_completion chc
 `;
 
-function renderShellScript(shell: string): string | undefined {
-  if (shell === 'powershell') {
-    return powershellScript;
-  }
-  if (shell === 'zsh') {
-    return zshScript;
-  }
-  return undefined;
-}
+const completionShellScripts: Record<CompletionShell, string> = {
+  powershell: powershellScript,
+  zsh: zshScript,
+};
 
-function isCompletionProfileAction(
-  value: string,
-): value is CompletionProfileAction {
-  return value === 'enable' || value === 'disable' || value === 'status';
+function isCompletionShell(value: string): value is CompletionShell {
+  return supportedCompletionShells.some((shell) => shell === value);
 }
 
 function escapeRegExp(value: string): string {
@@ -262,74 +264,103 @@ async function handleZshProfileAction(
   process.exitCode = 0;
 }
 
-export function createCompletionCommand() {
+function createCompletionShellCommand(shell: CompletionShell) {
   return defineCommand({
     meta: {
-      name: 'completion',
-      description: 'Print or manage shell completion setup.',
+      name: shell,
+      description: `Print the ${shell} completion adapter.`,
     },
-    args: {
-      shell: {
-        type: 'positional',
-        description:
-          'Shell to generate completion for (powershell or zsh), or action to manage persistent completion',
-        required: true,
-      },
-    },
-    async run({ args, rawArgs }) {
+    async run({ args }) {
       await runObservedCliCommand(
         args,
-        { command: 'completion' },
-        async ({ fail }) => {
-          const first = rawArgs[0] ?? '';
-          if (isCompletionProfileAction(first)) {
-            const shell = rawArgs[1] ?? '';
-            if (shell !== 'powershell' && shell !== 'zsh') {
-              const error = createCliError(
-                'invalid_option',
-                `unsupported managed completion shell: ${shell || '<missing>'}`,
-              );
-              fail(error, { details: { action: first, shell } });
-              process.stderr.write(`${error.message}\n`);
-              process.exitCode = error.exitCode;
-              return;
-            }
-            try {
-              if (shell === 'powershell') {
-                await handlePowerShellProfileAction(first);
-              } else {
-                await handleZshProfileAction(first);
-              }
-            } catch (error) {
-              const cliError = createCliError(
-                'invalid_option',
-                error instanceof Error ? error.message : String(error),
-              );
-              fail(cliError, { details: { action: first, shell } });
-              process.stderr.write(`${cliError.message}\n`);
-              process.exitCode = cliError.exitCode;
-            }
-            return;
-          }
-
-          const shell = typeof args.shell === 'string' ? args.shell : '';
-          const script = renderShellScript(shell);
-          if (!script) {
-            const error = createCliError(
-              'invalid_option',
-              `unsupported shell: ${shell}`,
-            );
-            fail(error, { details: { shell } });
-            process.stderr.write(`${error.message}\n`);
-            process.exitCode = error.exitCode;
-            return;
-          }
-          process.stdout.write(script);
+        { command: 'completion', subcommand: shell },
+        async () => {
+          process.stdout.write(completionShellScripts[shell]);
           process.exitCode = 0;
         },
       );
     },
   });
+}
+
+function createCompletionProfileCommand(action: CompletionProfileAction) {
+  const command = defineCommand({
+    meta: {
+      name: action,
+      description: `${action[0]?.toUpperCase()}${action.slice(1)} persistent shell completion.`,
+    },
+    args: {
+      shell: {
+        type: 'positional',
+        description: 'Shell profile to manage (powershell or zsh)',
+        required: true,
+      },
+    },
+    async run({ args }) {
+      await runObservedCliCommand(
+        args,
+        { command: 'completion', subcommand: action },
+        async ({ fail }) => {
+          const shell = typeof args.shell === 'string' ? args.shell : '';
+          if (!isCompletionShell(shell)) {
+            const error = createCliError(
+              'invalid_option',
+              `unsupported managed completion shell: ${shell || '<missing>'}`,
+            );
+            fail(error, { details: { action, shell } });
+            process.stderr.write(`${error.message}\n`);
+            process.exitCode = error.exitCode;
+            return;
+          }
+          try {
+            if (shell === 'powershell') {
+              await handlePowerShellProfileAction(action);
+            } else {
+              await handleZshProfileAction(action);
+            }
+          } catch (error) {
+            const cliError = createCliError(
+              'invalid_option',
+              error instanceof Error ? error.message : String(error),
+            );
+            fail(cliError, { details: { action, shell } });
+            process.stderr.write(`${cliError.message}\n`);
+            process.exitCode = cliError.exitCode;
+          }
+        },
+      );
+    },
+  });
+  return registerPositionalCandidates(command, ({ completedWords, path }) =>
+    completedWords.length === path.length ? supportedCompletionShells : [],
+  );
+}
+
+export function createCompletionCommand() {
+  const registrations: readonly CliCommandRegistration[] = [
+    ...supportedCompletionShells.map((shell) => ({
+      name: shell,
+      command: createCompletionShellCommand(shell),
+      visibility: 'public' as const,
+      bareBehavior: 'run' as const,
+    })),
+    ...(['enable', 'disable', 'status'] as const).map((action) => ({
+      name: action,
+      command: createCompletionProfileCommand(action),
+      visibility: 'public' as const,
+      bareBehavior: 'run' as const,
+    })),
+  ];
+  return registerCommandGroup(
+    defineCommand({
+      meta: {
+        name: 'completion',
+        description: 'Print or manage shell completion setup.',
+      },
+      subCommands: buildRegisteredSubCommands(registrations),
+    }),
+    registrations,
+  );
 }
 
 export function createInternalCompleteCommand(

--- a/apps/cli/src/command/root.command.ts
+++ b/apps/cli/src/command/root.command.ts
@@ -1,32 +1,79 @@
-import { type CommandDef, defineCommand } from 'citty';
+import { defineCommand } from 'citty';
 import { codexCommand } from './codex.command';
+import {
+  type AnyCommandDef,
+  buildRegisteredSubCommands,
+  type CliCommandRegistration,
+  registerCommandGroup,
+} from './command-discovery';
 import {
   createCompletionCommand,
   createInternalCompleteCommand,
 } from './completion.command';
-import { scriptsCommand } from './run-scripts.command';
+import { normalizeScriptsArgs, scriptsCommand } from './run-scripts.command';
 import {
   statusCommand,
   updateCommand,
   versionCommand,
 } from './self-update.command';
 
-let rootCommand: CommandDef;
+let rootCommand: AnyCommandDef;
 
-rootCommand = defineCommand({
-  meta: {
-    name: 'chc',
-    description: 'CthuTool monorepo CLI',
+const rootCommandRegistrations: readonly CliCommandRegistration[] = [
+  {
+    name: 'codex',
+    command: codexCommand,
+    visibility: 'public',
+    bareBehavior: 'help',
   },
-  subCommands: {
-    codex: codexCommand,
-    version: versionCommand,
-    status: statusCommand,
-    update: updateCommand,
-    completion: createCompletionCommand(),
-    __complete: createInternalCompleteCommand(() => rootCommand),
-    scripts: scriptsCommand,
+  {
+    name: 'version',
+    command: versionCommand,
+    visibility: 'compat',
+    bareBehavior: 'run',
   },
-});
+  {
+    name: 'status',
+    command: statusCommand,
+    visibility: 'public',
+    bareBehavior: 'run',
+  },
+  {
+    name: 'update',
+    command: updateCommand,
+    visibility: 'public',
+    bareBehavior: 'run',
+  },
+  {
+    name: 'completion',
+    command: createCompletionCommand(),
+    visibility: 'public',
+    bareBehavior: 'help',
+  },
+  {
+    name: '__complete',
+    command: createInternalCompleteCommand(() => rootCommand),
+    visibility: 'internal',
+    bareBehavior: 'run',
+  },
+  {
+    name: 'scripts',
+    command: scriptsCommand,
+    visibility: 'public',
+    bareBehavior: 'help',
+    normalizeArgs: normalizeScriptsArgs,
+  },
+];
 
-export { rootCommand };
+rootCommand = registerCommandGroup(
+  defineCommand({
+    meta: {
+      name: 'chc',
+      description: 'CthuTool monorepo CLI',
+    },
+    subCommands: buildRegisteredSubCommands(rootCommandRegistrations),
+  }),
+  rootCommandRegistrations,
+);
+
+export { rootCommand, rootCommandRegistrations };

--- a/apps/cli/src/command/run-scripts.command.ts
+++ b/apps/cli/src/command/run-scripts.command.ts
@@ -3,10 +3,17 @@ import { defineCommand } from 'citty';
 import pc from 'picocolors';
 import { listSelectable, resolvePackage } from '../domain/script-catalog';
 import { runBundledScript } from '../flow/run-bundled-script';
+import {
+  formatBundledScriptCatalog,
+  getBundledScriptIdCandidates,
+  loadBundledScriptCatalog,
+  renderBundledScriptHelpAppendix,
+  toBundledScriptCatalogRows,
+} from '../infra/bundled-script-catalog';
 import { getBundledScriptsRoot } from '../infra/bundled-scripts-root';
-import { discoverScripts } from '../infra/discover-scripts';
 import { cliContractArgs, createCliContext } from '../runtime/cli-context';
 import { type CliError, createCliError } from '../runtime/cli-error';
+import { runObservedCliCommand } from '../runtime/command-diagnostics';
 import {
   createCliCommandDiagnostics,
   createCliDiagnostics,
@@ -15,8 +22,18 @@ import {
 import {
   processOutput,
   writeCommandError,
+  writeHumanStatus,
+  writeJsonValue,
   writeWarning,
 } from '../runtime/output';
+import {
+  buildRegisteredSubCommands,
+  type CandidateProviderContext,
+  type CliCommandRegistration,
+  registerCommandGroup,
+  registerCommandHelpAppendix,
+  registerPositionalCandidates,
+} from './command-discovery';
 
 export type SelectableRow = { readonly id: string; readonly title: string };
 
@@ -45,6 +62,21 @@ const defaultDeps: RunScriptsDeps = {
   },
 };
 
+const scriptRunnerArgs = {
+  ...cliContractArgs,
+  id: {
+    type: 'positional',
+    description: 'Script id (folder name under apps/cli/src/scripts/)',
+    required: false,
+  },
+  script: {
+    type: 'string',
+    description: 'Same as positional id (for non-interactive CI)',
+    alias: 's',
+    valueHint: 'id',
+  },
+} as const;
+
 function resolveExplicitId(args: {
   readonly id?: string;
   readonly script?: string;
@@ -70,200 +102,287 @@ function toScriptArgs(args: Record<string, unknown>): Record<string, unknown> {
   );
 }
 
-export const createScriptsCommand = (deps: RunScriptsDeps = defaultDeps) =>
-  defineCommand({
-    meta: {
-      name: 'scripts',
-      description: [
-        'Discover and run bundled scripts under apps/cli/src/scripts/<id>/ (script.json + index.ts).',
-        '',
-        'Examples:',
-        '  chc scripts hello-world',
-        '  chc scripts --script hello-world',
-        '  bun run apps/cli/src/scripts/hello-world/index.ts',
-      ].join('\n'),
-    },
-    args: {
-      ...cliContractArgs,
-      id: {
-        type: 'positional',
-        description: 'Script id (folder name under apps/cli/src/scripts/)',
-        required: false,
-      },
-      script: {
-        type: 'string',
-        description: 'Same as positional id (for non-interactive CI)',
-        alias: 's',
-        valueHint: 'id',
-      },
-    },
-    async run({ args }) {
-      const context = createCliContext(args, { isTty: deps.isInteractive });
-      const commandDiagnostics = createCliCommandDiagnostics(
-        context,
-        processOutput,
-        { command: 'scripts' },
-      );
-      const diagnostics = createCliDiagnostics(context, processOutput, {
-        command: 'scripts',
-      });
-      const fail = (error: CliError, details?: Record<string, unknown>) => {
-        commandDiagnostics.fail(error, { details });
-        writeCommandError(context, processOutput, error);
-        process.exitCode = error.exitCode;
-      };
-      const root = getBundledScriptsRoot();
-      const discovered = await discoverScripts(root);
-      if (discovered.isErr()) {
-        const error = createCliError(
-          'discovery_failed',
-          discovered.error.message,
-        );
-        fail(error, { phase: 'discovery', scriptsRoot: root });
-        return;
-      }
+function shouldOfferScriptIds({
+  completedWords,
+  path,
+}: CandidateProviderContext): boolean {
+  const tail = completedWords.slice(path.length);
+  const last = tail.at(-1);
+  if (last === '--script' || last === '-s') {
+    return true;
+  }
+  return !tail.some((word) => !word.startsWith('-'));
+}
 
-      const catalog = discovered.value;
-      diagnostics.emit({
-        level: 'debug',
-        event: 'cli.scripts_discovered',
-        phase: 'discovery',
-        details: {
-          packageCount: catalog.packages.length,
-          warningCount: catalog.warnings.length,
-        },
-      });
-      for (const w of catalog.warnings) {
-        writeWarning(processOutput, pc.yellow(`${w.path}: ${w.message}`));
-        diagnostics.emit({
-          level: 'warn',
-          event: 'cli.script_discovery_warning',
-          phase: 'discovery',
-          details: {
-            message: w.message,
-            path: w.path,
-          },
-        });
-      }
+async function scriptIdCandidates(context: CandidateProviderContext) {
+  return shouldOfferScriptIds(context)
+    ? await getBundledScriptIdCandidates()
+    : [];
+}
 
-      if (catalog.packages.length === 0) {
-        const error = createCliError(
-          'discovery_failed',
-          'no valid bundled script packages found (see apps/cli/src/scripts/)',
-        );
-        fail(error, { phase: 'discovery', scriptsRoot: root });
-        return;
-      }
+export function normalizeScriptsArgs(
+  args: readonly string[],
+): readonly string[] {
+  const [first] = args;
+  if (
+    !first ||
+    first === 'list' ||
+    first === 'run' ||
+    first === '--help' ||
+    first === '-h'
+  ) {
+    return args;
+  }
+  return ['run', ...args];
+}
 
-      const explicitId = resolveExplicitId(args);
-      let targetId = explicitId;
+async function executeBundledScript(
+  args: Record<string, unknown>,
+  deps: RunScriptsDeps,
+): Promise<void> {
+  const context = createCliContext(args, { isTty: deps.isInteractive });
+  const commandDiagnostics = createCliCommandDiagnostics(
+    context,
+    processOutput,
+    { command: 'scripts' },
+  );
+  const diagnostics = createCliDiagnostics(context, processOutput, {
+    command: 'scripts',
+  });
+  const fail = (error: CliError, details?: Record<string, unknown>) => {
+    commandDiagnostics.fail(error, { details });
+    writeCommandError(context, processOutput, error);
+    process.exitCode = error.exitCode;
+  };
+  const root = getBundledScriptsRoot();
+  const discovered = await loadBundledScriptCatalog();
+  if (discovered.isErr()) {
+    const error = createCliError('discovery_failed', discovered.error.message);
+    fail(error, { phase: 'discovery', scriptsRoot: root });
+    return;
+  }
 
-      if (!targetId) {
-        if (!context.interactive) {
-          const error = createCliError(
-            'missing_required_argument',
-            'script id is required in non-interactive mode (use: chc scripts <id> or --script <id>)',
-          );
-          fail(error, { phase: 'selection' });
-          return;
-        }
-
-        const options = listSelectable(catalog);
-        if (options.length === 1) {
-          const [only] = options;
-          targetId = only.id;
-          diagnostics.emit({
-            level: 'info',
-            event: 'cli.script_selected',
-            phase: 'selection',
-            scriptId: targetId,
-            details: { selectionMode: 'single-option' },
-          });
-        } else {
-          const choice = await deps.pickScriptId(options);
-          if (choice === undefined) {
-            const error = createCliError(
-              'invalid_option',
-              'selection cancelled',
-            );
-            fail(error, { phase: 'selection' });
-            return;
-          }
-          targetId = choice;
-          diagnostics.emit({
-            level: 'info',
-            event: 'cli.script_selected',
-            phase: 'selection',
-            scriptId: targetId,
-            details: { selectionMode: 'interactive' },
-          });
-        }
-      } else {
-        diagnostics.emit({
-          level: 'info',
-          event: 'cli.script_selected',
-          phase: 'selection',
-          scriptId: targetId,
-          details: {
-            selectionMode: explicitId === args.script ? 'flag' : 'positional',
-          },
-        });
-      }
-
-      const resolved = resolvePackage(catalog, targetId);
-      if (resolved.isErr()) {
-        const error =
-          resolved.error.kind === 'not_found'
-            ? createCliError(
-                'unknown_selection',
-                `unknown script id: ${resolved.error.id}`,
-              )
-            : createCliError(
-                'ambiguous_selection',
-                `ambiguous script id: ${resolved.error.id}`,
-              );
-        fail(error, {
-          phase: 'selection',
-          requestedScriptId: resolved.error.id,
-        });
-        return;
-      }
-
-      const executed = await runBundledScript(
-        resolved.value,
-        toScriptArgs(args),
-        {
-          cli: context,
-          diagnostics: diagnostics.child({
-            scriptId: resolved.value.id,
-          }),
-        },
-      );
-      if (executed.isErr()) {
-        const e = executed.error;
-        const error =
-          e.kind === 'load'
-            ? createCliError('script_load_failed', e.message)
-            : e.kind === 'no_default_export'
-              ? createCliError('script_load_failed', e.message)
-              : (e.cliError ??
-                createCliError('script_execution_failed', e.message));
-        fail(error, {
-          phase: e.kind,
-          scriptId: resolved.value.id,
-          scriptArgs: summarizeScriptArgs(toScriptArgs(args)),
-        });
-        return;
-      }
-
-      commandDiagnostics.complete({
-        details: {
-          scriptId: resolved.value.id,
-          scriptArgs: summarizeScriptArgs(toScriptArgs(args)),
-        },
-      });
-      process.exitCode = 0;
+  const catalog = discovered.value;
+  diagnostics.emit({
+    level: 'debug',
+    event: 'cli.scripts_discovered',
+    phase: 'discovery',
+    details: {
+      packageCount: catalog.packages.length,
+      warningCount: catalog.warnings.length,
     },
   });
+  for (const warning of catalog.warnings) {
+    writeWarning(
+      processOutput,
+      pc.yellow(`${warning.path}: ${warning.message}`),
+    );
+    diagnostics.emit({
+      level: 'warn',
+      event: 'cli.script_discovery_warning',
+      phase: 'discovery',
+      details: {
+        message: warning.message,
+        path: warning.path,
+      },
+    });
+  }
+
+  if (catalog.packages.length === 0) {
+    const error = createCliError(
+      'discovery_failed',
+      'no valid bundled script packages found (see apps/cli/src/scripts/)',
+    );
+    fail(error, { phase: 'discovery', scriptsRoot: root });
+    return;
+  }
+
+  const explicitId = resolveExplicitId(args);
+  let targetId = explicitId;
+
+  if (!targetId) {
+    if (!context.interactive) {
+      const error = createCliError(
+        'missing_required_argument',
+        'script id is required in non-interactive mode (use: chc scripts run <id>, chc scripts <id>, or --script <id>)',
+      );
+      fail(error, { phase: 'selection' });
+      return;
+    }
+
+    const options = listSelectable(catalog);
+    if (options.length === 1) {
+      const [only] = options;
+      targetId = only.id;
+      diagnostics.emit({
+        level: 'info',
+        event: 'cli.script_selected',
+        phase: 'selection',
+        scriptId: targetId,
+        details: { selectionMode: 'single-option' },
+      });
+    } else {
+      const choice = await deps.pickScriptId(options);
+      if (choice === undefined) {
+        const error = createCliError('invalid_option', 'selection cancelled');
+        fail(error, { phase: 'selection' });
+        return;
+      }
+      targetId = choice;
+      diagnostics.emit({
+        level: 'info',
+        event: 'cli.script_selected',
+        phase: 'selection',
+        scriptId: targetId,
+        details: { selectionMode: 'interactive' },
+      });
+    }
+  } else {
+    diagnostics.emit({
+      level: 'info',
+      event: 'cli.script_selected',
+      phase: 'selection',
+      scriptId: targetId,
+      details: {
+        selectionMode: explicitId === args.script ? 'flag' : 'positional',
+      },
+    });
+  }
+
+  const resolved = resolvePackage(catalog, targetId);
+  if (resolved.isErr()) {
+    const error =
+      resolved.error.kind === 'not_found'
+        ? createCliError(
+            'unknown_selection',
+            `unknown script id: ${resolved.error.id}`,
+          )
+        : createCliError(
+            'ambiguous_selection',
+            `ambiguous script id: ${resolved.error.id}`,
+          );
+    fail(error, {
+      phase: 'selection',
+      requestedScriptId: resolved.error.id,
+    });
+    return;
+  }
+
+  const executed = await runBundledScript(resolved.value, toScriptArgs(args), {
+    cli: context,
+    diagnostics: diagnostics.child({
+      scriptId: resolved.value.id,
+    }),
+  });
+  if (executed.isErr()) {
+    const error =
+      executed.error.kind === 'load' ||
+      executed.error.kind === 'no_default_export'
+        ? createCliError('script_load_failed', executed.error.message)
+        : (executed.error.cliError ??
+          createCliError('script_execution_failed', executed.error.message));
+    fail(error, {
+      phase: executed.error.kind,
+      scriptId: resolved.value.id,
+      scriptArgs: summarizeScriptArgs(toScriptArgs(args)),
+    });
+    return;
+  }
+
+  commandDiagnostics.complete({
+    details: {
+      scriptId: resolved.value.id,
+      scriptArgs: summarizeScriptArgs(toScriptArgs(args)),
+    },
+  });
+  process.exitCode = 0;
+}
+
+function createScriptListCommand() {
+  return defineCommand({
+    meta: {
+      name: 'list',
+      description: 'List discovered bundled scripts.',
+    },
+    args: cliContractArgs,
+    async run({ args }) {
+      await runObservedCliCommand(
+        args,
+        { command: 'scripts', subcommand: 'list' },
+        async ({ context, fail }) => {
+          const discovered = await loadBundledScriptCatalog();
+          if (discovered.isErr()) {
+            const error = createCliError(
+              'discovery_failed',
+              discovered.error.message,
+            );
+            fail(error, { details: { phase: 'discovery' } });
+            writeCommandError(context, processOutput, error);
+            process.exitCode = error.exitCode;
+            return;
+          }
+          if (context.json) {
+            writeJsonValue(processOutput, {
+              ok: true,
+              command: 'scripts list',
+              scripts: toBundledScriptCatalogRows(discovered.value),
+            });
+          } else {
+            writeHumanStatus(
+              context,
+              processOutput,
+              formatBundledScriptCatalog(discovered.value),
+            );
+          }
+          process.exitCode = 0;
+        },
+      );
+    },
+  });
+}
+
+function createScriptRunCommand(deps: RunScriptsDeps) {
+  const command = defineCommand({
+    meta: {
+      name: 'run',
+      description: 'Run a discovered bundled script.',
+    },
+    args: scriptRunnerArgs,
+    async run({ args }) {
+      await executeBundledScript(args, deps);
+    },
+  });
+  return registerPositionalCandidates(command, scriptIdCandidates);
+}
+
+export const createScriptsCommand = (deps: RunScriptsDeps = defaultDeps) => {
+  const registrations: readonly CliCommandRegistration[] = [
+    {
+      name: 'list',
+      command: createScriptListCommand(),
+      visibility: 'public',
+      bareBehavior: 'run',
+    },
+    {
+      name: 'run',
+      command: createScriptRunCommand(deps),
+      visibility: 'public',
+      bareBehavior: 'run',
+    },
+  ];
+  const command = registerCommandGroup(
+    defineCommand({
+      meta: {
+        name: 'scripts',
+        description:
+          'Discover, list, and run bundled scripts under apps/cli/src/scripts/<id>/.',
+      },
+      subCommands: buildRegisteredSubCommands(registrations),
+    }),
+    registrations,
+  );
+  registerPositionalCandidates(command, scriptIdCandidates);
+  return registerCommandHelpAppendix(command, renderBundledScriptHelpAppendix);
+};
 
 export const scriptsCommand = createScriptsCommand();

--- a/apps/cli/src/command/self-update-output.ts
+++ b/apps/cli/src/command/self-update-output.ts
@@ -55,6 +55,7 @@ export function createSelfUpdateRenderer(
 ): SelfUpdateRenderer {
   const human = !context.json && !context.quiet;
   const interactiveOutput = human && context.isTty && deps.isOutputTty();
+  const colors = pc.createColors(interactiveOutput);
   let activeSpinner: SpinnerLike | undefined;
   let activePhase: SelfUpdatePhase | undefined;
   let headerWritten = false;
@@ -62,7 +63,7 @@ export function createSelfUpdateRenderer(
   const writeHeader = () => {
     if (!human || headerWritten) return;
     headerWritten = true;
-    deps.output.stdout.write(`${pc.cyan('CthuTool update')}\n`);
+    deps.output.stdout.write(`${colors.cyan('CthuTool update')}\n`);
   };
 
   const stopSpinner = (message: string, code?: number) => {
@@ -102,10 +103,10 @@ export function createSelfUpdateRenderer(
     if (!options.verbose) return;
     const cwd = event.cwd ? ` (cwd: ${event.cwd})` : '';
     deps.output.stderr.write(
-      `${pc.dim(`$ ${event.command} ${event.args.join(' ')}${cwd}`)}\n`,
+      `${colors.dim(`$ ${event.command} ${event.args.join(' ')}${cwd}`)}\n`,
     );
     for (const detail of [event.stderr, event.stdout]) {
-      if (detail) deps.output.stderr.write(`${pc.dim(detail)}\n`);
+      if (detail) deps.output.stderr.write(`${colors.dim(detail)}\n`);
     }
   };
 
@@ -143,22 +144,22 @@ export function createSelfUpdateRenderer(
       if (interactiveOutput) {
         stopSpinner(`${label} complete`);
       } else {
-        deps.output.stdout.write(`${pc.green('✓')} ${label}\n`);
+        deps.output.stdout.write(`${colors.green('✓')} ${label}\n`);
       }
     },
     renderCheckResult(plan) {
       if (!human) return;
       if (plan.status === 'up_to_date' && plan.target) {
         deps.output.stdout.write(
-          `${pc.green('✓')} chc is already up to date · ${identity(plan.target)}\n`,
+          `${colors.green('✓')} chc is already up to date · ${identity(plan.target)}\n`,
         );
       } else if (plan.status === 'update_available' && plan.target) {
         deps.output.stdout.write(
-          `${pc.cyan('Update available')} · ${identity(plan.target)}\n`,
+          `${colors.cyan('Update available')} · ${identity(plan.target)}\n`,
         );
       } else if (plan.status === 'install_required') {
         deps.output.stdout.write(
-          `${pc.yellow('Managed installation required')} · run chc update\n`,
+          `${colors.yellow('Managed installation required')} · run chc update\n`,
         );
       }
     },
@@ -167,7 +168,7 @@ export function createSelfUpdateRenderer(
       const after = result.after ?? result.target;
       if (result.status === 'up_to_date' && after) {
         deps.output.stdout.write(
-          `${pc.green('✓')} chc is already up to date · ${identity(after)}\n`,
+          `${colors.green('✓')} chc is already up to date · ${identity(after)}\n`,
         );
         return;
       }
@@ -175,7 +176,7 @@ export function createSelfUpdateRenderer(
       const target = after ? identity(after) : result.ref;
       const verb = result.status === 'installed' ? 'Installed' : 'Updated';
       deps.output.stdout.write(
-        `${pc.green('✓')} ${verb} chc successfully · ${before}${target}\n`,
+        `${colors.green('✓')} ${verb} chc successfully · ${before}${target}\n`,
       );
       deps.output.stdout.write(
         '  Run `chc status` for installation details.\n',

--- a/apps/cli/src/command/self-update-output.ts
+++ b/apps/cli/src/command/self-update-output.ts
@@ -1,0 +1,193 @@
+import { spinner } from '@clack/prompts';
+import pc from 'picocolors';
+import type {
+  SelfUpdateError,
+  SelfUpdateEvent,
+  SelfUpdatePhase,
+  SelfUpdatePlan,
+  SelfUpdateResult,
+} from '../domain/self-update-manager';
+import type { CliContext } from '../runtime/cli-context';
+import { type CliOutput, processOutput } from '../runtime/output';
+
+type SpinnerLike = ReturnType<typeof spinner>;
+
+export type SelfUpdateRenderer = {
+  readonly onEvent: (event: SelfUpdateEvent) => void;
+  readonly renderCheckResult: (plan: SelfUpdatePlan) => void;
+  readonly renderApplyResult: (result: SelfUpdateResult) => void;
+  readonly stopForError: (error: unknown) => void;
+};
+
+export type SelfUpdateRendererDeps = {
+  readonly output: CliOutput;
+  readonly isOutputTty: () => boolean;
+  readonly createSpinner: () => SpinnerLike;
+};
+
+const defaultDeps: SelfUpdateRendererDeps = {
+  output: processOutput,
+  isOutputTty: () => process.stdout.isTTY === true,
+  createSpinner: spinner,
+};
+
+const phaseLabels: Record<SelfUpdatePhase, string> = {
+  preflight: 'Checking local update state',
+  check_remote: 'Checking the selected remote ref',
+  clone: 'Cloning the managed source checkout',
+  fetch: 'Fetching repository updates',
+  checkout: 'Checking out the selected ref',
+  verify_bundle: 'Verifying the committed CLI bundle',
+  install_global: 'Installing the global command',
+};
+
+function identity(value: {
+  readonly ref: string;
+  readonly shortCommit: string;
+}) {
+  return `${value.ref}@${value.shortCommit}`;
+}
+
+export function createSelfUpdateRenderer(
+  context: CliContext,
+  options: { readonly verbose: boolean },
+  deps: SelfUpdateRendererDeps = defaultDeps,
+): SelfUpdateRenderer {
+  const human = !context.json && !context.quiet;
+  const interactiveOutput = human && context.isTty && deps.isOutputTty();
+  let activeSpinner: SpinnerLike | undefined;
+  let activePhase: SelfUpdatePhase | undefined;
+  let headerWritten = false;
+
+  const writeHeader = () => {
+    if (!human || headerWritten) return;
+    headerWritten = true;
+    deps.output.stdout.write(`${pc.cyan('CthuTool update')}\n`);
+  };
+
+  const stopSpinner = (message: string, code?: number) => {
+    if (!activeSpinner) return;
+    activeSpinner.stop(message, code);
+    activeSpinner = undefined;
+    activePhase = undefined;
+  };
+
+  const renderPlan = (plan: SelfUpdatePlan) => {
+    if (!human) return;
+    writeHeader();
+    deps.output.stdout.write(`source: ${plan.installDir}\n`);
+    deps.output.stdout.write(`target: ${plan.repo}#${plan.ref}\n`);
+    if (plan.before) {
+      deps.output.stdout.write(`current: ${identity(plan.before)}\n`);
+    }
+    if (plan.target) {
+      deps.output.stdout.write(`latest:  ${identity(plan.target)}\n`);
+    }
+    if (plan.changes && plan.changes.count > 0) {
+      deps.output.stdout.write(`changes: ${plan.changes.count} commit(s)\n`);
+      for (const change of plan.changes.highlights) {
+        deps.output.stdout.write(`  ${change.commit}  ${change.subject}\n`);
+      }
+      if (plan.changes.omitted > 0) {
+        deps.output.stdout.write(
+          `  … ${plan.changes.omitted} more commit(s)\n`,
+        );
+      }
+    }
+  };
+
+  const renderVerboseCommand = (
+    event: Extract<SelfUpdateEvent, { readonly type: 'command' }>,
+  ) => {
+    if (!options.verbose) return;
+    const cwd = event.cwd ? ` (cwd: ${event.cwd})` : '';
+    deps.output.stderr.write(
+      `${pc.dim(`$ ${event.command} ${event.args.join(' ')}${cwd}`)}\n`,
+    );
+    for (const detail of [event.stderr, event.stdout]) {
+      if (detail) deps.output.stderr.write(`${pc.dim(detail)}\n`);
+    }
+  };
+
+  return {
+    onEvent(event) {
+      if (event.type === 'command') {
+        renderVerboseCommand(event);
+        return;
+      }
+      if (event.type === 'plan') {
+        renderPlan(event.plan);
+        return;
+      }
+      if (event.type === 'failure') {
+        if (activeSpinner) {
+          stopSpinner(`${phaseLabels[event.phase]} failed`, 1);
+        }
+        return;
+      }
+      if (!human) return;
+      writeHeader();
+      const label = phaseLabels[event.phase];
+      if (event.type === 'phase_started') {
+        if (interactiveOutput) {
+          if (activeSpinner)
+            stopSpinner(phaseLabels[activePhase ?? event.phase]);
+          activeSpinner = deps.createSpinner();
+          activePhase = event.phase;
+          activeSpinner.start(label);
+        } else {
+          deps.output.stdout.write(`- ${label}\n`);
+        }
+        return;
+      }
+      if (interactiveOutput) {
+        stopSpinner(`${label} complete`);
+      } else {
+        deps.output.stdout.write(`${pc.green('✓')} ${label}\n`);
+      }
+    },
+    renderCheckResult(plan) {
+      if (!human) return;
+      if (plan.status === 'up_to_date' && plan.target) {
+        deps.output.stdout.write(
+          `${pc.green('✓')} chc is already up to date · ${identity(plan.target)}\n`,
+        );
+      } else if (plan.status === 'update_available' && plan.target) {
+        deps.output.stdout.write(
+          `${pc.cyan('Update available')} · ${identity(plan.target)}\n`,
+        );
+      } else if (plan.status === 'install_required') {
+        deps.output.stdout.write(
+          `${pc.yellow('Managed installation required')} · run chc update\n`,
+        );
+      }
+    },
+    renderApplyResult(result) {
+      if (!human) return;
+      const after = result.after ?? result.target;
+      if (result.status === 'up_to_date' && after) {
+        deps.output.stdout.write(
+          `${pc.green('✓')} chc is already up to date · ${identity(after)}\n`,
+        );
+        return;
+      }
+      const before = result.before ? `${identity(result.before)} → ` : '';
+      const target = after ? identity(after) : result.ref;
+      const verb = result.status === 'installed' ? 'Installed' : 'Updated';
+      deps.output.stdout.write(
+        `${pc.green('✓')} ${verb} chc successfully · ${before}${target}\n`,
+      );
+      deps.output.stdout.write(
+        '  Run `chc status` for installation details.\n',
+      );
+    },
+    stopForError(error) {
+      if (!activeSpinner) return;
+      const phase =
+        error && typeof error === 'object' && 'phase' in error
+          ? (error as SelfUpdateError).phase
+          : activePhase;
+      stopSpinner(phase ? `${phaseLabels[phase]} failed` : 'Update failed', 1);
+    },
+  };
+}

--- a/apps/cli/src/command/self-update.command.ts
+++ b/apps/cli/src/command/self-update.command.ts
@@ -1,15 +1,13 @@
 import { defineCommand } from 'citty';
 import pc from 'picocolors';
 import {
+  assertSelfUpdatePlanReady,
   createSelfUpdateDeps,
-  defaultSelfUpdateRef,
-  defaultSelfUpdateRepo,
   getCliInstallationStatus,
   getCliVersion,
-  getDefaultSelfUpdateInstallDir,
+  planSelfUpdate,
   runSelfUpdate,
   SelfUpdateError,
-  type SelfUpdateStep,
 } from '../domain/self-update-manager';
 import { type CliContext, cliContractArgs } from '../runtime/cli-context';
 import { type CliError, createCliError } from '../runtime/cli-error';
@@ -20,9 +18,9 @@ import {
   writeHumanStatus,
   writeJsonValue,
 } from '../runtime/output';
+import { createSelfUpdateRenderer } from './self-update-output';
 
-const selfUpdateArgs = {
-  ...cliContractArgs,
+const selfUpdateSourceArgs = {
   repo: {
     type: 'string',
     description: 'Git repository URL to install from',
@@ -37,27 +35,23 @@ const selfUpdateArgs = {
   },
 } as const;
 
+const selfUpdateArgs = {
+  ...cliContractArgs,
+  ...selfUpdateSourceArgs,
+  check: {
+    type: 'boolean',
+    description: 'Check update availability without applying changes',
+  },
+  verbose: {
+    type: 'boolean',
+    description: 'Show bounded Git and npm command details',
+  },
+} as const;
+
 function getStringArg(value: unknown): string | undefined {
   return typeof value === 'string' && value.trim().length > 0
     ? value.trim()
     : undefined;
-}
-
-function formatStep(step: SelfUpdateStep): string {
-  switch (step) {
-    case 'clone':
-      return 'cloning repository';
-    case 'fetch':
-      return 'fetching repository';
-    case 'checkout':
-      return 'checking out ref';
-    case 'pull':
-      return 'fast-forwarding branch';
-    case 'verify-bundle':
-      return 'verifying committed CLI bundle';
-    case 'install-global':
-      return 'installing global command';
-  }
 }
 
 function toUpdateCliError(error: unknown): CliError {
@@ -69,8 +63,25 @@ function toUpdateCliError(error: unknown): CliError {
       );
 }
 
-function writeFailure(context: CliContext, cliError: CliError): void {
-  writeCommandError(context, processOutput, cliError);
+function writeFailure(
+  context: CliContext,
+  cliError: CliError,
+  error: unknown,
+): void {
+  if (context.json && error instanceof SelfUpdateError) {
+    writeJsonValue(processOutput, {
+      ok: false,
+      error: {
+        code: cliError.code,
+        message: error.summary,
+        phase: error.phase,
+        cause: error.causeText,
+        hint: error.hint,
+      },
+    });
+  } else {
+    writeCommandError(context, processOutput, cliError);
+  }
   process.exitCode = cliError.exitCode;
 }
 
@@ -90,34 +101,33 @@ function createUpdateCommand() {
           const repo = getStringArg(args.repo);
           const ref = getStringArg(args.ref);
           const installDir = getStringArg(args['install-dir']);
-
-          writeHumanStatus(context, processOutput, pc.cyan('CthuTool update'));
-          writeHumanStatus(
-            context,
-            processOutput,
-            `repo: ${repo ?? defaultSelfUpdateRepo}`,
-          );
-          writeHumanStatus(
-            context,
-            processOutput,
-            `ref:  ${ref ?? defaultSelfUpdateRef}`,
-          );
-          writeHumanStatus(
-            context,
-            processOutput,
-            `dir:  ${installDir ?? getDefaultSelfUpdateInstallDir()}`,
-          );
+          const renderer = createSelfUpdateRenderer(context, {
+            verbose: args.verbose === true,
+          });
+          const managerDeps = createSelfUpdateDeps(renderer.onEvent);
 
           try {
+            if (args.check === true) {
+              const result = await planSelfUpdate(
+                { repo, ref, installDir },
+                managerDeps,
+              );
+              assertSelfUpdatePlanReady(result);
+              if (context.json) {
+                writeJsonValue(processOutput, {
+                  ok: true,
+                  command: 'update',
+                  result,
+                });
+              } else {
+                renderer.renderCheckResult(result);
+              }
+              process.exitCode = 0;
+              return;
+            }
             const result = await runSelfUpdate(
               { repo, ref, installDir },
-              createSelfUpdateDeps((step) => {
-                writeHumanStatus(
-                  context,
-                  processOutput,
-                  `- ${formatStep(step)}`,
-                );
-              }),
+              managerDeps,
             );
             if (context.json) {
               writeJsonValue(processOutput, {
@@ -126,13 +136,22 @@ function createUpdateCommand() {
                 result,
               });
             } else {
-              writeHumanStatus(context, processOutput, pc.green('updated'));
+              renderer.renderApplyResult(result);
             }
             process.exitCode = 0;
           } catch (error) {
+            renderer.stopForError(error);
             const cliError = toUpdateCliError(error);
-            fail(cliError, { details: { installDir, ref, repo } });
-            writeFailure(context, cliError);
+            fail(cliError, {
+              details: {
+                installDir,
+                ref,
+                repo,
+                phase:
+                  error instanceof SelfUpdateError ? error.phase : undefined,
+              },
+            });
+            writeFailure(context, cliError, error);
           }
         },
       );
@@ -168,7 +187,7 @@ export const statusCommand = defineCommand({
     name: 'status',
     description: 'Show chc CLI installation status.',
   },
-  args: selfUpdateArgs,
+  args: { ...cliContractArgs, ...selfUpdateSourceArgs },
   async run({ args }) {
     await runObservedCliCommand(
       args,
@@ -232,7 +251,7 @@ export const statusCommand = defineCommand({
         } catch (error) {
           const cliError = toUpdateCliError(error);
           fail(cliError);
-          writeFailure(context, cliError);
+          writeFailure(context, cliError, error);
         }
       },
     );

--- a/apps/cli/src/domain/completion-candidates.ts
+++ b/apps/cli/src/domain/completion-candidates.ts
@@ -1,15 +1,17 @@
-import type { ArgDef, ArgsDef, CommandDef, Resolvable } from 'citty';
-import { getBundledScriptsRoot } from '../infra/bundled-scripts-root';
-import { discoverScripts } from '../infra/discover-scripts';
-import { listSelectable } from './script-catalog';
+import type { ArgDef, ArgsDef, Resolvable } from 'citty';
+import {
+  type AnyCommandDef,
+  getCommandRegistrations,
+  getPositionalCandidateProvider,
+} from '../command/command-discovery';
 
 export type CompletionCandidateInput = {
-  readonly rootCommand: CommandDef;
+  readonly rootCommand: AnyCommandDef;
   readonly words: readonly string[];
 };
 
 type CompletionState = {
-  readonly command: CommandDef;
+  readonly command: AnyCommandDef;
   readonly path: readonly string[];
 };
 
@@ -27,23 +29,34 @@ function toKebabCase(value: string): string {
 }
 
 async function getSubCommands(
-  command: CommandDef,
-): Promise<Record<string, CommandDef>> {
+  command: AnyCommandDef,
+): Promise<Record<string, AnyCommandDef>> {
   const subCommands = await resolveValue(command.subCommands);
   if (!subCommands) {
     return {};
   }
 
   const entries = await Promise.all(
-    Object.entries(subCommands).map(async ([name, value]) => [
-      name,
-      (await resolveValue(value)) as CommandDef,
-    ]),
+    Object.entries(subCommands).map(
+      async ([name, value]): Promise<[string, AnyCommandDef]> => [
+        name,
+        (await resolveValue(value)) as AnyCommandDef,
+      ],
+    ),
   );
-  return Object.fromEntries(entries);
+  const publicNames = new Set(
+    getCommandRegistrations(command)
+      ?.filter((registration) => registration.visibility === 'public')
+      .map((registration) => registration.name),
+  );
+  return Object.fromEntries(
+    publicNames.size === 0
+      ? entries
+      : entries.filter(([name]) => publicNames.has(name)),
+  );
 }
 
-async function getArgs(command: CommandDef): Promise<ArgsDef> {
+async function getArgs(command: AnyCommandDef): Promise<ArgsDef> {
   return (await resolveValue(command.args)) ?? {};
 }
 
@@ -60,7 +73,7 @@ function flagName(name: string, _arg: ArgDef): string {
 }
 
 async function traverseCommand(
-  rootCommand: CommandDef,
+  rootCommand: AnyCommandDef,
   completedWords: readonly string[],
 ): Promise<CompletionState | undefined> {
   let command = rootCommand;
@@ -103,7 +116,7 @@ function filterByPrefix(
 }
 
 async function getFlagCandidates(
-  command: CommandDef,
+  command: AnyCommandDef,
   completedWords: readonly string[],
   prefix: string,
 ): Promise<string[]> {
@@ -114,53 +127,6 @@ async function getFlagCandidates(
     .map(([name, arg]) => flagName(name, arg))
     .filter((candidate) => !used.has(candidate));
   return filterByPrefix(candidates, prefix);
-}
-
-async function getScriptCandidates(prefix: string): Promise<string[]> {
-  const discovered = await discoverScripts(getBundledScriptsRoot());
-  if (discovered.isErr()) {
-    return [];
-  }
-  return filterByPrefix(
-    listSelectable(discovered.value).map((row) => row.id),
-    prefix,
-  );
-}
-
-function shouldCompleteScriptId(
-  path: readonly string[],
-  completedWords: readonly string[],
-): boolean {
-  if (path.join(' ') !== 'scripts') {
-    return false;
-  }
-  const hasScriptFlag = completedWords.at(-1) === '--script';
-  const hasExplicitId = completedWords.some((word, index) => {
-    if (index === 0 || isFlag(word)) {
-      return false;
-    }
-    const previous = completedWords[index - 1];
-    return previous !== '--script';
-  });
-  return hasScriptFlag || !hasExplicitId;
-}
-
-function shouldCompleteShellName(
-  path: readonly string[],
-  completedWords: readonly string[],
-): boolean {
-  return path.join(' ') === 'completion' && completedWords.length === 1;
-}
-
-function shouldCompleteManagedShellName(
-  path: readonly string[],
-  completedWords: readonly string[],
-): boolean {
-  return (
-    path.join(' ') === 'completion' &&
-    completedWords.length === 2 &&
-    ['disable', 'enable', 'status'].includes(completedWords[1])
-  );
 }
 
 export async function getCompletionCandidates({
@@ -178,24 +144,19 @@ export async function getCompletionCandidates({
     return getFlagCandidates(state.command, completedWords, currentWord);
   }
 
-  if (shouldCompleteScriptId(state.path, completedWords)) {
-    return getScriptCandidates(currentWord);
-  }
-
-  if (shouldCompleteShellName(state.path, completedWords)) {
-    return filterByPrefix(
-      ['disable', 'enable', 'powershell', 'status', 'zsh'],
-      currentWord,
-    );
-  }
-
-  if (shouldCompleteManagedShellName(state.path, completedWords)) {
-    return filterByPrefix(['powershell', 'zsh'], currentWord);
-  }
-
+  const positionalCandidates = getPositionalCandidateProvider(state.command);
   const subCommands = await getSubCommands(state.command);
+  const dynamicCandidates = positionalCandidates
+    ? await positionalCandidates({
+        currentWord,
+        completedWords,
+        path: state.path,
+      })
+    : [];
+  const staticCandidates =
+    completedWords.length === state.path.length ? Object.keys(subCommands) : [];
   return filterByPrefix(
-    Object.keys(subCommands).filter((candidate) => candidate !== '__complete'),
+    [...staticCandidates, ...dynamicCandidates],
     currentWord,
   );
 }

--- a/apps/cli/src/domain/script-catalog.ts
+++ b/apps/cli/src/domain/script-catalog.ts
@@ -22,6 +22,12 @@ export type CatalogResolveError =
   | { readonly kind: 'not_found'; readonly id: string }
   | { readonly kind: 'ambiguous'; readonly id: string };
 
+export type ScriptCatalogRow = {
+  readonly id: string;
+  readonly title: string;
+  readonly description?: string;
+};
+
 /**
  * Sorted selectable rows for prompts and listings.
  *
@@ -30,10 +36,14 @@ export type CatalogResolveError =
  */
 export const listSelectable = (
   catalog: ScriptCatalog,
-): ReadonlyArray<{ readonly id: string; readonly title: string }> =>
+): ReadonlyArray<ScriptCatalogRow> =>
   [...catalog.packages]
     .sort((a, b) => a.id.localeCompare(b.id))
-    .map((p) => ({ id: p.id, title: p.manifest.title }));
+    .map((p) => ({
+      id: p.id,
+      title: p.manifest.title,
+      description: p.manifest.description,
+    }));
 
 /**
  * Resolves a package by id from a catalog.

--- a/apps/cli/src/domain/self-update-manager.ts
+++ b/apps/cli/src/domain/self-update-manager.ts
@@ -10,11 +10,33 @@ export const defaultSelfUpdateRepo =
 export const defaultSelfUpdateRef = 'main';
 export const committedCliBundlePath = 'apps/cli/dist/index.js';
 
+const maxChangeHighlights = 5;
+const maxSubjectLength = 120;
+const maxDetailLines = 8;
+const maxDetailLineLength = 240;
+
 export type SelfUpdateOptions = {
   readonly repo?: string;
   readonly ref?: string;
   readonly installDir?: string;
 };
+
+export type SelfUpdatePlanStatus =
+  | 'install_required'
+  | 'update_available'
+  | 'up_to_date'
+  | 'blocked';
+
+export type SelfUpdateApplyStatus = 'installed' | 'updated' | 'up_to_date';
+
+export type SelfUpdatePhase =
+  | 'preflight'
+  | 'check_remote'
+  | 'clone'
+  | 'fetch'
+  | 'checkout'
+  | 'verify_bundle'
+  | 'install_global';
 
 export type SelfUpdateStep =
   | 'clone'
@@ -23,6 +45,41 @@ export type SelfUpdateStep =
   | 'pull'
   | 'verify-bundle'
   | 'install-global';
+
+export type SelfUpdateIdentity = {
+  readonly ref: string;
+  readonly commit: string;
+  readonly shortCommit: string;
+};
+
+export type SelfUpdateChange = {
+  readonly commit: string;
+  readonly subject: string;
+};
+
+export type SelfUpdateChangeSummary = {
+  readonly count: number;
+  readonly highlights: readonly SelfUpdateChange[];
+  readonly omitted: number;
+};
+
+export type SelfUpdateBlock = {
+  readonly kind: 'dirty_checkout' | 'diverged_branch';
+  readonly message: string;
+  readonly hint: string;
+};
+
+export type SelfUpdatePlan = {
+  readonly status: SelfUpdatePlanStatus;
+  readonly repo: string;
+  readonly ref: string;
+  readonly installDir: string;
+  readonly before?: SelfUpdateIdentity;
+  readonly target?: SelfUpdateIdentity;
+  readonly changes?: SelfUpdateChangeSummary;
+  readonly block?: SelfUpdateBlock;
+  readonly phases: readonly SelfUpdatePhase[];
+};
 
 export type SelfUpdateCommandResult = {
   readonly command: string;
@@ -33,10 +90,41 @@ export type SelfUpdateCommandResult = {
   readonly stderr: string;
 };
 
+export type SelfUpdateEvent =
+  | {
+      readonly type: 'phase_started' | 'phase_completed';
+      readonly phase: SelfUpdatePhase;
+    }
+  | { readonly type: 'plan'; readonly plan: SelfUpdatePlan }
+  | {
+      readonly type: 'command';
+      readonly phase: SelfUpdatePhase;
+      readonly command: string;
+      readonly args: readonly string[];
+      readonly cwd?: string;
+      readonly code: number;
+      readonly stdout?: string;
+      readonly stderr?: string;
+    }
+  | {
+      readonly type: 'failure';
+      readonly phase: SelfUpdatePhase;
+      readonly summary: string;
+      readonly cause?: string;
+      readonly hint: string;
+    };
+
 export type SelfUpdateResult = {
+  readonly status: SelfUpdateApplyStatus;
   readonly repo: string;
   readonly ref: string;
   readonly installDir: string;
+  readonly before?: SelfUpdateIdentity;
+  readonly target?: SelfUpdateIdentity;
+  readonly after?: SelfUpdateIdentity;
+  readonly changes?: SelfUpdateChangeSummary;
+  readonly phases: readonly SelfUpdatePhase[];
+  /** Compatibility detail retained for existing JSON consumers. */
   readonly steps: readonly SelfUpdateStep[];
 };
 
@@ -61,16 +149,31 @@ export type SelfUpdateDeps = {
   ) => Promise<SelfUpdateCommandResult>;
   readonly env: Record<string, string | undefined>;
   readonly home: () => string;
-  readonly onStep?: (step: SelfUpdateStep) => void;
+  readonly onEvent?: (event: SelfUpdateEvent) => void;
 };
 
 export class SelfUpdateError extends Error {
-  readonly result: SelfUpdateCommandResult;
+  readonly phase: SelfUpdatePhase;
+  readonly summary: string;
+  readonly causeText?: string;
+  readonly hint: string;
+  readonly result?: SelfUpdateCommandResult;
 
-  constructor(result: SelfUpdateCommandResult) {
-    super(formatFailedCommand(result));
+  constructor(options: {
+    readonly phase: SelfUpdatePhase;
+    readonly summary: string;
+    readonly cause?: string;
+    readonly hint: string;
+    readonly result?: SelfUpdateCommandResult;
+  }) {
+    const cause = options.cause ? `\nCause: ${options.cause}` : '';
+    super(`${options.summary}${cause}\nNext: ${options.hint}`);
     this.name = 'SelfUpdateError';
-    this.result = result;
+    this.phase = options.phase;
+    this.summary = options.summary;
+    this.causeText = options.cause;
+    this.hint = options.hint;
+    this.result = options.result;
   }
 }
 
@@ -79,7 +182,7 @@ export function getDefaultSelfUpdateInstallDir(home = homedir()): string {
 }
 
 export function createSelfUpdateDeps(
-  onStep?: (step: SelfUpdateStep) => void,
+  onEvent?: (event: SelfUpdateEvent) => void,
 ): SelfUpdateDeps {
   return {
     exists: existsSync,
@@ -89,7 +192,7 @@ export function createSelfUpdateDeps(
     run: runCommand,
     env: process.env,
     home: homedir,
-    onStep,
+    onEvent,
   };
 }
 
@@ -116,36 +219,368 @@ export function resolveSelfUpdateOptions(
   };
 }
 
-function emitStep(deps: SelfUpdateDeps, step: SelfUpdateStep): void {
-  deps.onStep?.(step);
+function emit(deps: SelfUpdateDeps, event: SelfUpdateEvent): void {
+  deps.onEvent?.(event);
 }
 
-function ensureOk(result: SelfUpdateCommandResult): void {
-  if (result.code !== 0) {
-    throw new SelfUpdateError(result);
+async function runPhase<T>(
+  deps: SelfUpdateDeps,
+  phase: SelfUpdatePhase,
+  action: () => Promise<T>,
+): Promise<T> {
+  emit(deps, { type: 'phase_started', phase });
+  try {
+    const value = await action();
+    emit(deps, { type: 'phase_completed', phase });
+    return value;
+  } catch (error) {
+    const failure = toPhaseError(error, phase);
+    emit(deps, {
+      type: 'failure',
+      phase: failure.phase,
+      summary: failure.summary,
+      cause: failure.causeText,
+      hint: failure.hint,
+    });
+    throw failure;
   }
 }
 
-async function runRequired(
-  deps: SelfUpdateDeps,
-  command: string,
-  args: readonly string[],
-  options?: { readonly cwd?: string },
-): Promise<void> {
-  ensureOk(await deps.run(command, args, options));
+function phaseHint(phase: SelfUpdatePhase): string {
+  switch (phase) {
+    case 'preflight':
+      return 'Check the selected directory and local Git state, then retry.';
+    case 'check_remote':
+      return 'Check the repository URL, ref, network access, and Git credentials.';
+    case 'clone':
+      return 'Check repository access and permissions for the managed source directory.';
+    case 'fetch':
+      return 'Check network access and the configured origin, then retry.';
+    case 'checkout':
+      return 'Inspect the checkout state and selected ref before retrying.';
+    case 'verify_bundle':
+      return `Select a ref containing ${committedCliBundlePath}.`;
+    case 'install_global':
+      return 'Check npm global-install permissions, then retry the update.';
+  }
 }
 
-async function remoteRefExists(
+function toPhaseError(error: unknown, phase: SelfUpdatePhase): SelfUpdateError {
+  if (error instanceof SelfUpdateError) {
+    return error;
+  }
+  return new SelfUpdateError({
+    phase,
+    summary: `Update failed during ${formatPhase(phase)}.`,
+    cause: boundedText(error instanceof Error ? error.message : String(error)),
+    hint: phaseHint(phase),
+  });
+}
+
+function commandFailure(
+  phase: SelfUpdatePhase,
+  result: SelfUpdateCommandResult,
+): SelfUpdateError {
+  return new SelfUpdateError({
+    phase,
+    summary: `Update failed during ${formatPhase(phase)}.`,
+    cause:
+      boundedCommandOutput(result) ||
+      `Command exited with code ${result.code}.`,
+    hint: phaseHint(phase),
+    result,
+  });
+}
+
+async function execute(
   deps: SelfUpdateDeps,
-  installDir: string,
-  ref: string,
-): Promise<boolean> {
-  const result = await deps.run(
-    'git',
-    ['rev-parse', '--verify', `origin/${ref}`],
-    { cwd: installDir, allowFailure: true },
+  phase: SelfUpdatePhase,
+  command: string,
+  args: readonly string[],
+  options: { readonly cwd?: string; readonly allowFailure?: boolean } = {},
+): Promise<SelfUpdateCommandResult> {
+  let result: SelfUpdateCommandResult;
+  try {
+    result = await deps.run(command, args, options);
+  } catch (error) {
+    throw new SelfUpdateError({
+      phase,
+      summary: `Unable to start ${command} during ${formatPhase(phase)}.`,
+      cause: boundedText(
+        error instanceof Error ? error.message : String(error),
+      ),
+      hint: phaseHint(phase),
+    });
+  }
+  emit(deps, {
+    type: 'command',
+    phase,
+    command,
+    args: redactArgs(args),
+    cwd: options.cwd,
+    code: result.code,
+    stdout: boundedText(result.stdout),
+    stderr: boundedText(result.stderr),
+  });
+  if (result.code !== 0 && options.allowFailure !== true) {
+    throw commandFailure(phase, result);
+  }
+  return result;
+}
+
+async function requiredOutput(
+  deps: SelfUpdateDeps,
+  phase: SelfUpdatePhase,
+  args: readonly string[],
+  cwd: string,
+): Promise<string> {
+  const result = await execute(deps, phase, 'git', args, { cwd });
+  const value = result.stdout.trim();
+  if (value.length === 0) {
+    throw new SelfUpdateError({
+      phase,
+      summary: `Git returned no identity during ${formatPhase(phase)}.`,
+      hint: phaseHint(phase),
+    });
+  }
+  return value;
+}
+
+async function readIdentity(
+  deps: SelfUpdateDeps,
+  phase: SelfUpdatePhase,
+  cwd: string,
+  fallbackRef: string,
+  revision = 'HEAD',
+): Promise<SelfUpdateIdentity> {
+  const commit = await requiredOutput(
+    deps,
+    phase,
+    ['rev-parse', '--verify', `${revision}^{commit}`],
+    cwd,
   );
-  return result.code === 0;
+  const refResult =
+    revision === 'HEAD'
+      ? await execute(
+          deps,
+          phase,
+          'git',
+          ['symbolic-ref', '--quiet', '--short', 'HEAD'],
+          { cwd, allowFailure: true },
+        )
+      : undefined;
+  return {
+    ref:
+      refResult?.code === 0
+        ? refResult.stdout.trim() || fallbackRef
+        : fallbackRef,
+    commit,
+    shortCommit: commit.slice(0, 7),
+  };
+}
+
+function finishPlan(
+  deps: SelfUpdateDeps,
+  plan: SelfUpdatePlan,
+): SelfUpdatePlan {
+  emit(deps, { type: 'plan', plan });
+  return plan;
+}
+
+export async function planSelfUpdate(
+  options: SelfUpdateOptions = {},
+  deps = createSelfUpdateDeps(),
+): Promise<SelfUpdatePlan> {
+  const resolved = resolveSelfUpdateOptions(options, deps);
+  const publicResolved = {
+    ...resolved,
+    repo: redactValue(resolved.repo),
+  };
+  const phases: SelfUpdatePhase[] = [];
+  const gitRoot = join(resolved.installDir, '.git');
+
+  const initial = await runPhase(deps, 'preflight', async () => {
+    if (!deps.exists(gitRoot)) {
+      return undefined;
+    }
+    const status = await execute(
+      deps,
+      'preflight',
+      'git',
+      ['status', '--porcelain', '--untracked-files=normal'],
+      { cwd: resolved.installDir },
+    );
+    if (status.stdout.trim().length > 0) {
+      return 'dirty' as const;
+    }
+    return readIdentity(deps, 'preflight', resolved.installDir, resolved.ref);
+  });
+  phases.push('preflight');
+
+  if (initial === undefined) {
+    return finishPlan(deps, {
+      status: 'install_required',
+      ...publicResolved,
+      phases,
+    });
+  }
+  if (initial === 'dirty') {
+    return finishPlan(deps, {
+      status: 'blocked',
+      ...publicResolved,
+      block: {
+        kind: 'dirty_checkout',
+        message: 'The selected checkout has uncommitted or untracked changes.',
+        hint: 'Commit, stash, or remove the local changes, then retry.',
+      },
+      phases,
+    });
+  }
+
+  const remote = await runPhase(deps, 'check_remote', async () => {
+    await execute(
+      deps,
+      'check_remote',
+      'git',
+      ['fetch', '--no-tags', resolved.repo, resolved.ref],
+      { cwd: resolved.installDir },
+    );
+    const target = await readIdentity(
+      deps,
+      'check_remote',
+      resolved.installDir,
+      resolved.ref,
+      'FETCH_HEAD',
+    );
+    const branch = await execute(
+      deps,
+      'check_remote',
+      'git',
+      ['ls-remote', '--exit-code', '--heads', resolved.repo, resolved.ref],
+      { cwd: resolved.installDir, allowFailure: true },
+    );
+    return {
+      target,
+      isBranch: branch.code === 0 && branch.stdout.trim().length > 0,
+    };
+  });
+  phases.push('check_remote');
+
+  if (initial.commit === remote.target.commit) {
+    return finishPlan(deps, {
+      status: 'up_to_date',
+      ...publicResolved,
+      before: initial,
+      target: remote.target,
+      phases,
+    });
+  }
+
+  if (remote.isBranch) {
+    const ancestor = await execute(
+      deps,
+      'check_remote',
+      'git',
+      ['merge-base', '--is-ancestor', initial.commit, remote.target.commit],
+      { cwd: resolved.installDir, allowFailure: true },
+    );
+    if (ancestor.code === 1) {
+      return finishPlan(deps, {
+        status: 'blocked',
+        ...publicResolved,
+        before: initial,
+        target: remote.target,
+        block: {
+          kind: 'diverged_branch',
+          message:
+            'The selected checkout cannot fast-forward to the remote branch.',
+          hint: 'Reconcile the local branch manually, then retry.',
+        },
+        phases,
+      });
+    }
+    if (ancestor.code !== 0) {
+      throw commandFailure('check_remote', ancestor);
+    }
+  }
+
+  const changes = await loadChangeSummary(
+    deps,
+    resolved.installDir,
+    initial.commit,
+    remote.target.commit,
+  );
+  return finishPlan(deps, {
+    status: 'update_available',
+    ...publicResolved,
+    before: initial,
+    target: remote.target,
+    changes,
+    phases,
+  });
+}
+
+async function loadChangeSummary(
+  deps: SelfUpdateDeps,
+  cwd: string,
+  before: string,
+  target: string,
+): Promise<SelfUpdateChangeSummary> {
+  const countResult = await execute(
+    deps,
+    'check_remote',
+    'git',
+    ['rev-list', '--count', `${before}..${target}`],
+    { cwd, allowFailure: true },
+  );
+  const parsedCount = Number.parseInt(countResult.stdout.trim(), 10);
+  const count =
+    countResult.code === 0 && Number.isFinite(parsedCount) ? parsedCount : 0;
+  const logResult = await execute(
+    deps,
+    'check_remote',
+    'git',
+    [
+      'log',
+      `--max-count=${maxChangeHighlights}`,
+      '--format=%h%x09%s',
+      `${before}..${target}`,
+    ],
+    { cwd, allowFailure: true },
+  );
+  const highlights =
+    logResult.code === 0
+      ? logResult.stdout
+          .split(/\r?\n/)
+          .filter(Boolean)
+          .slice(0, maxChangeHighlights)
+          .map((line) => {
+            const [commit = '', ...subject] = line.split('\t');
+            return {
+              commit: commit.slice(0, 12),
+              subject: boundedLine(subject.join('\t'), maxSubjectLength),
+            };
+          })
+      : [];
+  return {
+    count: Math.max(count, highlights.length),
+    highlights,
+    omitted: Math.max(0, count - highlights.length),
+  };
+}
+
+function blockedError(plan: SelfUpdatePlan): SelfUpdateError {
+  return new SelfUpdateError({
+    phase: 'preflight',
+    summary: `Update blocked: ${plan.block?.message ?? 'The selected checkout is not safe to update.'}`,
+    hint: plan.block?.hint ?? phaseHint('preflight'),
+  });
+}
+
+export function assertSelfUpdatePlanReady(plan: SelfUpdatePlan): void {
+  if (plan.status === 'blocked') {
+    throw blockedError(plan);
+  }
 }
 
 export async function runSelfUpdate(
@@ -153,68 +588,127 @@ export async function runSelfUpdate(
   deps = createSelfUpdateDeps(),
 ): Promise<SelfUpdateResult> {
   const resolved = resolveSelfUpdateOptions(options, deps);
-  const completedSteps: SelfUpdateStep[] = [];
-  const recordStep = (step: SelfUpdateStep) => {
-    completedSteps.push(step);
-    emitStep(deps, step);
-  };
+  const plan = await planSelfUpdate(options, deps);
+  assertSelfUpdatePlanReady(plan);
+  if (plan.status === 'up_to_date') {
+    return {
+      status: 'up_to_date',
+      repo: plan.repo,
+      ref: plan.ref,
+      installDir: plan.installDir,
+      before: plan.before,
+      target: plan.target,
+      after: plan.before,
+      phases: plan.phases,
+      steps: [],
+    };
+  }
 
-  if (deps.exists(join(resolved.installDir, '.git'))) {
-    recordStep('fetch');
-    await runRequired(
-      deps,
-      'git',
-      ['remote', 'set-url', 'origin', resolved.repo],
-      {
-        cwd: resolved.installDir,
-      },
-    );
-    await runRequired(deps, 'git', ['fetch', '--tags', 'origin'], {
-      cwd: resolved.installDir,
+  const phases = [...plan.phases];
+  const steps: SelfUpdateStep[] = [];
+  const isInstall = plan.status === 'install_required';
+
+  if (isInstall) {
+    await runPhase(deps, 'clone', async () => {
+      await deps.mkdir(dirname(plan.installDir));
+      await execute(deps, 'clone', 'git', [
+        'clone',
+        resolved.repo,
+        plan.installDir,
+      ]);
     });
+    phases.push('clone');
+    steps.push('clone');
   } else {
-    recordStep('clone');
-    await deps.mkdir(dirname(resolved.installDir));
-    await runRequired(deps, 'git', [
-      'clone',
-      resolved.repo,
-      resolved.installDir,
-    ]);
+    await runPhase(deps, 'preflight', async () => {
+      const status = await execute(
+        deps,
+        'preflight',
+        'git',
+        ['status', '--porcelain', '--untracked-files=normal'],
+        { cwd: plan.installDir },
+      );
+      if (status.stdout.trim().length > 0) {
+        throw new SelfUpdateError({
+          phase: 'preflight',
+          summary: 'Update blocked: the checkout changed after preflight.',
+          hint: 'Preserve the new local changes, then retry.',
+        });
+      }
+    });
   }
 
-  recordStep('checkout');
-  await runRequired(deps, 'git', ['checkout', resolved.ref], {
-    cwd: resolved.installDir,
-  });
+  if (!isInstall) {
+    await runPhase(deps, 'fetch', async () => {
+      await execute(
+        deps,
+        'fetch',
+        'git',
+        ['remote', 'set-url', 'origin', resolved.repo],
+        { cwd: plan.installDir },
+      );
+      await execute(deps, 'fetch', 'git', ['fetch', '--tags', 'origin'], {
+        cwd: plan.installDir,
+      });
+    });
+    phases.push('fetch');
+    steps.push('fetch');
+  }
 
-  if (await remoteRefExists(deps, resolved.installDir, resolved.ref)) {
-    recordStep('pull');
-    await runRequired(
+  await runPhase(deps, 'checkout', async () => {
+    await execute(deps, 'checkout', 'git', ['checkout', plan.ref], {
+      cwd: plan.installDir,
+    });
+    steps.push('checkout');
+    const remoteBranch = await execute(
       deps,
+      'checkout',
       'git',
-      ['pull', '--ff-only', 'origin', resolved.ref],
-      {
-        cwd: resolved.installDir,
-      },
+      ['rev-parse', '--verify', `origin/${plan.ref}`],
+      { cwd: plan.installDir, allowFailure: true },
     );
-  }
+    if (remoteBranch.code === 0) {
+      await execute(
+        deps,
+        'checkout',
+        'git',
+        ['pull', '--ff-only', 'origin', plan.ref],
+        { cwd: plan.installDir },
+      );
+      steps.push('pull');
+    }
+  });
+  phases.push('checkout');
 
-  recordStep('verify-bundle');
-  verifyCommittedBundle(deps, resolved.installDir);
+  await runPhase(deps, 'verify_bundle', async () => {
+    verifyCommittedBundle(deps, plan.installDir);
+  });
+  phases.push('verify_bundle');
+  steps.push('verify-bundle');
 
-  recordStep('install-global');
-  await runRequired(deps, 'npm', [
-    'install',
-    '-g',
-    '--ignore-scripts',
-    resolved.installDir,
-  ]);
+  await runPhase(deps, 'install_global', async () => {
+    await execute(deps, 'install_global', 'npm', [
+      'install',
+      '-g',
+      '--ignore-scripts',
+      plan.installDir,
+    ]);
+  });
+  phases.push('install_global');
+  steps.push('install-global');
 
+  const after = await readIdentity(deps, 'checkout', plan.installDir, plan.ref);
   return {
-    repo: resolved.repo,
-    ref: resolved.ref,
-    installDir: resolved.installDir,
-    steps: completedSteps,
+    status: isInstall ? 'installed' : 'updated',
+    repo: plan.repo,
+    ref: plan.ref,
+    installDir: plan.installDir,
+    before: plan.before,
+    target: plan.target ?? after,
+    after,
+    changes: plan.changes,
+    phases,
+    steps,
   };
 }
 
@@ -279,17 +773,47 @@ async function runOptional(
 function verifyCommittedBundle(deps: SelfUpdateDeps, installDir: string): void {
   const bundlePath = join(installDir, committedCliBundlePath);
   if (!deps.exists(bundlePath)) {
-    throw new Error(
-      `missing committed CLI bundle: ${bundlePath}; the selected ref must include ${committedCliBundlePath}`,
-    );
+    throw new SelfUpdateError({
+      phase: 'verify_bundle',
+      summary: 'The selected ref does not contain the committed CLI bundle.',
+      cause: `Missing ${bundlePath}.`,
+      hint: phaseHint('verify_bundle'),
+    });
   }
 }
 
-function formatFailedCommand(result: SelfUpdateCommandResult): string {
-  const cwd = result.cwd ? ` (cwd: ${result.cwd})` : '';
-  const output = `${result.stderr}\n${result.stdout}`.trim();
-  const suffix = output.length > 0 ? `\n${output}` : '';
-  return `command failed: ${result.command} ${result.args.join(' ')}${cwd}${suffix}`;
+function formatPhase(phase: SelfUpdatePhase): string {
+  return phase.replaceAll('_', ' ');
+}
+
+function boundedLine(value: string, maxLength: number): string {
+  const normalized = value.replaceAll(/\s+/g, ' ').trim();
+  return normalized.length <= maxLength
+    ? normalized
+    : `${normalized.slice(0, maxLength - 1)}…`;
+}
+
+function boundedText(value: string): string | undefined {
+  const lines = value
+    .split(/\r?\n/)
+    .map((line) => boundedLine(line, maxDetailLineLength))
+    .filter(Boolean)
+    .slice(0, maxDetailLines);
+  return lines.length > 0 ? lines.join('\n') : undefined;
+}
+
+function boundedCommandOutput(
+  result: SelfUpdateCommandResult,
+): string | undefined {
+  return boundedText(`${result.stderr}\n${result.stdout}`);
+}
+
+function redactArgs(args: readonly string[]): readonly string[] {
+  return args.map(redactValue);
+}
+
+function redactValue(value: string): string {
+  return value.replace(/:\/\/[^/@\s]+@/g, '://***@');
 }
 
 function runCommand(
@@ -297,7 +821,7 @@ function runCommand(
   args: readonly string[],
   options: { readonly cwd?: string; readonly allowFailure?: boolean } = {},
 ): Promise<SelfUpdateCommandResult> {
-  return new Promise((resolve, reject) => {
+  return new Promise((resolvePromise, reject) => {
     const child = spawn(command, [...args], {
       cwd: options.cwd,
       stdio: ['ignore', 'pipe', 'pipe'],
@@ -317,7 +841,7 @@ function runCommand(
       reject(error);
     });
     child.on('close', (code) => {
-      resolve({
+      resolvePromise({
         command,
         args,
         cwd: options.cwd,

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -2,10 +2,12 @@ import { type ArgsDef, type CommandDef, renderUsage, runMain } from 'citty';
 import pc from 'picocolors';
 import {
   type AnyCommandDef,
+  filterUsageCommandChoices,
   getCommandHelpAppendixProvider,
   getCommandRegistration,
   getCommandRegistrations,
   normalizeRegisteredArgs,
+  stripAnsi,
 } from './command/command-discovery';
 import { rootCommand } from './command/root.command';
 import { getCliVersion } from './domain/self-update-manager';
@@ -18,27 +20,6 @@ function formatUsageForStdout(
     value.replace(/`([^`]+)`/g, '$1').replace(/[ \t]+$/gm, ''),
     hiddenCommands,
   );
-}
-
-function stripAnsi(value: string): string {
-  const sgrPattern = new RegExp(`${String.fromCharCode(27)}\\[[0-9;]*m`, 'g');
-  return value.replace(sgrPattern, '');
-}
-
-function filterUsageCommandChoices(
-  line: string,
-  hiddenCommands: ReadonlySet<string>,
-): string {
-  const match =
-    /^(\s*USAGE\s+\S+\s+)([A-Za-z0-9_-]+(?:\|[A-Za-z0-9_-]+)+)(.*)$/.exec(line);
-  if (!match) {
-    return line;
-  }
-  const [, prefix, choices, suffix] = match;
-  const visibleChoices = choices
-    .split('|')
-    .filter((choice) => !hiddenCommands.has(choice));
-  return `${prefix}${visibleChoices.join('|')}${suffix}`;
 }
 
 function normalizeCommandRows(

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -1,17 +1,22 @@
-import {
-  type ArgsDef,
-  type CommandDef,
-  type Resolvable,
-  renderUsage,
-  runMain,
-} from 'citty';
+import { type ArgsDef, type CommandDef, renderUsage, runMain } from 'citty';
 import pc from 'picocolors';
+import {
+  type AnyCommandDef,
+  getCommandHelpAppendixProvider,
+  getCommandRegistration,
+  getCommandRegistrations,
+  normalizeRegisteredArgs,
+} from './command/command-discovery';
 import { rootCommand } from './command/root.command';
 import { getCliVersion } from './domain/self-update-manager';
 
-function formatUsageForStdout(value: string): string {
+function formatUsageForStdout(
+  value: string,
+  hiddenCommands: ReadonlySet<string> = new Set(),
+): string {
   return normalizeCommandRows(
     value.replace(/`([^`]+)`/g, '$1').replace(/[ \t]+$/gm, ''),
+    hiddenCommands,
   );
 }
 
@@ -20,7 +25,26 @@ function stripAnsi(value: string): string {
   return value.replace(sgrPattern, '');
 }
 
-function normalizeCommandRows(value: string): string {
+function filterUsageCommandChoices(
+  line: string,
+  hiddenCommands: ReadonlySet<string>,
+): string {
+  const match =
+    /^(\s*USAGE\s+\S+\s+)([A-Za-z0-9_-]+(?:\|[A-Za-z0-9_-]+)+)(.*)$/.exec(line);
+  if (!match) {
+    return line;
+  }
+  const [, prefix, choices, suffix] = match;
+  const visibleChoices = choices
+    .split('|')
+    .filter((choice) => !hiddenCommands.has(choice));
+  return `${prefix}${visibleChoices.join('|')}${suffix}`;
+}
+
+function normalizeCommandRows(
+  value: string,
+  hiddenCommands: ReadonlySet<string>,
+): string {
   const lines = value.split('\n');
   const normalized: string[] = [];
   let inCommands = false;
@@ -33,7 +57,9 @@ function normalizeCommandRows(value: string): string {
     if (pendingRows.length === 0) {
       return;
     }
-    const visibleRows = pendingRows.filter((row) => row.name !== '__complete');
+    const visibleRows = pendingRows.filter(
+      (row) => row.name !== '__complete' && !hiddenCommands.has(row.name),
+    );
     if (visibleRows.length === 0) {
       pendingRows = [];
       return;
@@ -48,16 +74,17 @@ function normalizeCommandRows(value: string): string {
   };
 
   for (const line of lines) {
-    const plain = stripAnsi(line).trim();
+    const visibleLine = filterUsageCommandChoices(line, hiddenCommands);
+    const plain = stripAnsi(visibleLine).trim();
     if (plain === 'COMMANDS') {
       flushRows();
       inCommands = true;
-      normalized.push(line);
+      normalized.push(visibleLine);
       continue;
     }
 
     const commandRow = inCommands
-      ? stripAnsi(line).match(/^\s{2,}([A-Za-z0-9_-]+)\s{2,}(.+)$/)
+      ? stripAnsi(visibleLine).match(/^\s{2,}([A-Za-z0-9_-]+)\s{2,}(.+)$/)
       : null;
     if (commandRow) {
       pendingRows.push({
@@ -71,7 +98,7 @@ function normalizeCommandRows(value: string): string {
     if (inCommands && plain.length > 0) {
       inCommands = false;
     }
-    normalized.push(line);
+    normalized.push(visibleLine);
   }
 
   flushRows();
@@ -82,21 +109,22 @@ async function showNativeUsage<T extends ArgsDef = ArgsDef>(
   command: CommandDef<T>,
   parent?: CommandDef<T>,
 ): Promise<void> {
-  process.stdout.write(
-    `${formatUsageForStdout(await renderUsage(command, parent))}\n`,
+  const hiddenCommands = new Set(
+    getCommandRegistrations(command as AnyCommandDef)
+      ?.filter((registration) => registration.visibility !== 'public')
+      .map((registration) => registration.name) ?? [],
   );
+  const appendix = await getCommandHelpAppendixProvider(
+    command as AnyCommandDef,
+  )?.();
+  const rendered = formatUsageForStdout(
+    await renderUsage(command, parent),
+    hiddenCommands,
+  );
+  process.stdout.write(`${rendered}${appendix ? `\n\n${appendix}` : ''}\n`);
 }
 
-async function resolveValue<T>(
-  value: Resolvable<T> | undefined,
-): Promise<T | undefined> {
-  if (typeof value === 'function') {
-    return await (value as () => T | Promise<T>)();
-  }
-  return await value;
-}
-
-async function resolveOmittedTopLevelCommand(
+async function resolveBareTopLevelHelpCommand(
   rawArgs: readonly string[],
 ): Promise<CommandDef | undefined> {
   if (rawArgs.length !== 1) {
@@ -107,27 +135,27 @@ async function resolveOmittedTopLevelCommand(
   if (!name || name.startsWith('-') || name === '__complete') {
     return undefined;
   }
-  if (!new Set(['codex', 'scripts', 'completion']).has(name)) {
-    return undefined;
-  }
-
-  const subCommands = await resolveValue(rootCommand.subCommands);
-  return await resolveValue(subCommands?.[name]);
+  const registration = getCommandRegistration(rootCommand, name);
+  return registration?.bareBehavior === 'help'
+    ? registration.command
+    : undefined;
 }
 
-const rawArgs = process.argv.slice(2);
-const omittedTopLevelCommand = await resolveOmittedTopLevelCommand(rawArgs);
+const rawArgs = normalizeRegisteredArgs(rootCommand, process.argv.slice(2));
+const bareTopLevelHelpCommand = await resolveBareTopLevelHelpCommand(rawArgs);
 if (rawArgs.length === 1 && rawArgs[0] === '--version') {
   process.stdout.write(`chc ${getCliVersion()}\n`);
   process.exitCode = 0;
 } else if (rawArgs.length === 0) {
   await showNativeUsage(rootCommand);
   process.exitCode = 0;
-} else if (omittedTopLevelCommand) {
-  await showNativeUsage(omittedTopLevelCommand, rootCommand);
+} else if (bareTopLevelHelpCommand) {
+  await showNativeUsage(bareTopLevelHelpCommand, rootCommand);
   process.exitCode = 0;
 } else {
-  await runMain(rootCommand, { showUsage: showNativeUsage }).catch(() => {
-    process.exitCode = 1;
-  });
+  await runMain(rootCommand, { rawArgs, showUsage: showNativeUsage }).catch(
+    () => {
+      process.exitCode = 1;
+    },
+  );
 }

--- a/apps/cli/src/infra/bundled-script-catalog.ts
+++ b/apps/cli/src/infra/bundled-script-catalog.ts
@@ -1,0 +1,84 @@
+import pc from 'picocolors';
+import {
+  listSelectable,
+  type ScriptCatalog,
+  type ScriptCatalogRow,
+} from '../domain/script-catalog';
+import { getBundledScriptsRoot } from './bundled-scripts-root';
+import { discoverScripts } from './discover-scripts';
+
+const maxDescriptionLength = 160;
+const maxWarnings = 5;
+
+function boundedDescription(value: string | undefined): string | undefined {
+  if (!value) {
+    return undefined;
+  }
+  return value.length <= maxDescriptionLength
+    ? value
+    : `${value.slice(0, maxDescriptionLength - 1)}…`;
+}
+
+export function toBundledScriptCatalogRows(
+  catalog: ScriptCatalog,
+): readonly ScriptCatalogRow[] {
+  return listSelectable(catalog).map((row) => ({
+    ...row,
+    description: boundedDescription(row.description),
+  }));
+}
+
+export function loadBundledScriptCatalog() {
+  return discoverScripts(getBundledScriptsRoot());
+}
+
+export async function getBundledScriptIdCandidates(): Promise<
+  readonly string[]
+> {
+  const discovered = await loadBundledScriptCatalog();
+  return discovered.isOk()
+    ? toBundledScriptCatalogRows(discovered.value).map((row) => row.id)
+    : [];
+}
+
+export function formatBundledScriptCatalog(
+  catalog: ScriptCatalog,
+  heading = 'AVAILABLE SCRIPTS',
+): string {
+  const rows = toBundledScriptCatalogRows(catalog);
+  const width = Math.max(0, ...rows.map((row) => row.id.length));
+  const lines = [heading, ''];
+  if (rows.length === 0) {
+    lines.push('  No bundled scripts available.');
+  } else {
+    for (const row of rows) {
+      const detail = row.description
+        ? `${row.title} — ${row.description}`
+        : row.title;
+      lines.push(`  ${pc.cyan(row.id.padEnd(width + 2))}${detail}`);
+    }
+  }
+  if (catalog.warnings.length > 0) {
+    lines.push('', 'WARNINGS', '');
+    for (const warning of catalog.warnings.slice(0, maxWarnings)) {
+      lines.push(`  ${warning.path}: ${warning.message}`);
+    }
+    const omitted = catalog.warnings.length - maxWarnings;
+    if (omitted > 0) {
+      lines.push(`  ... ${omitted} more warnings`);
+    }
+  }
+  return lines.join('\n');
+}
+
+export async function renderBundledScriptHelpAppendix(): Promise<string> {
+  const discovered = await loadBundledScriptCatalog();
+  if (discovered.isErr()) {
+    return [
+      'AVAILABLE SCRIPTS',
+      '',
+      `  Unavailable: ${discovered.error.message}`,
+    ].join('\n');
+  }
+  return formatBundledScriptCatalog(discovered.value);
+}

--- a/apps/cli/src/infra/discover-scripts.ts
+++ b/apps/cli/src/infra/discover-scripts.ts
@@ -13,6 +13,7 @@ import { parseScriptManifest } from '../domain/script-manifest-schema';
 export type DiscoveryError = { readonly message: string };
 
 const MANIFEST_FILE = 'script.json';
+export const reservedScriptIds = new Set(['list', 'run']);
 
 const pushWarning = (
   warnings: Array<{ path: string; message: string }>,
@@ -130,6 +131,15 @@ async function scanScriptsRoot(scriptsRoot: string): Promise<ScriptCatalog> {
         warnings,
         manifestPath,
         `manifest id "${manifest.id}" does not match folder name "${name}"`,
+      );
+      continue;
+    }
+
+    if (reservedScriptIds.has(manifest.id)) {
+      pushWarning(
+        warnings,
+        manifestPath,
+        `script id "${manifest.id}" is reserved for a scripts command operation`,
       );
       continue;
     }

--- a/apps/cli/tests/integration/cli-command-diagnostics.test.ts
+++ b/apps/cli/tests/integration/cli-command-diagnostics.test.ts
@@ -50,13 +50,13 @@ describe('CLI command diagnostics coverage', () => {
   });
 
   test('emits failure diagnostics for a deliberate command error', async () => {
-    const result = await runCli(['completion', 'fish'], {
+    const result = await runCli(['completion', 'enable', 'fish'], {
       CHC_CLI_DIAGNOSTICS: '1',
     });
 
     expect(result.code).not.toBe(0);
     expect(result.out).toBe('');
-    expect(result.err).toContain('unsupported shell: fish');
+    expect(result.err).toContain('unsupported managed completion shell: fish');
     const diagnostics = parseDiagnostics(result.err);
     expect(diagnostics.map((event) => event.event)).toEqual([
       'cli.command_started',

--- a/apps/cli/tests/integration/completion-command.test.ts
+++ b/apps/cli/tests/integration/completion-command.test.ts
@@ -107,8 +107,29 @@ describe('shell completion command', () => {
     const result = await runCli(['completion', 'fish']);
 
     expect(result.code).not.toBe(0);
-    expect(result.out).toBe('');
-    expect(result.err).toContain('unsupported shell: fish');
+    expect(result.out).toContain('COMMANDS');
+    expect(result.out).toContain('powershell');
+    expect(result.out).toContain('zsh');
+    expect(result.err).toContain('Unknown command');
+    expect(result.err).toContain('fish');
+  });
+
+  test('prints the public completion command tree for a bare group', async () => {
+    const bare = await runCli(['completion']);
+    const explicit = await runCli(['completion', '--help']);
+
+    expect(bare).toEqual(explicit);
+    expect(bare.code).toBe(0);
+    expect(bare.err).toBe('');
+    for (const operation of [
+      'powershell',
+      'zsh',
+      'enable',
+      'disable',
+      'status',
+    ]) {
+      expect(bare.out).toContain(operation);
+    }
   });
 
   test('completes commands, flags, and bundled script ids', async () => {
@@ -124,7 +145,6 @@ describe('shell completion command', () => {
       'scripts',
       'status',
       'update',
-      'version',
     ]);
     expect(lines((await runCli(['__complete', 'co'])).out)).toEqual([
       'codex',
@@ -173,12 +193,21 @@ describe('shell completion command', () => {
         (await runCli(['__complete', 'codex', 'status', '--json', '--'])).out,
       ),
     ).not.toContain('--json');
-    expect(lines((await runCli(['__complete', 'scripts', ''])).out)).toContain(
-      'convert-to-cbz',
+    const scriptList = await runCli(['scripts', 'list', '--json']);
+    const scriptIds = (
+      JSON.parse(scriptList.out) as { scripts: Array<{ id: string }> }
+    ).scripts.map((script) => script.id);
+    expect(scriptList.code).toBe(0);
+    expect(scriptList.err).toBe('');
+    expect(lines((await runCli(['__complete', 'scripts', ''])).out)).toEqual(
+      [...scriptIds, 'list', 'run'].sort(),
     );
     expect(
+      lines((await runCli(['__complete', 'scripts', 'run', ''])).out),
+    ).toEqual([...scriptIds].sort());
+    expect(
       lines((await runCli(['__complete', 'scripts', '--script', ''])).out),
-    ).toContain('convert-to-cbz');
+    ).toEqual([...scriptIds].sort());
   }, 15_000);
 
   test('manages persistent PowerShell completion in an isolated profile', async () => {

--- a/apps/cli/tests/integration/global-bin.test.ts
+++ b/apps/cli/tests/integration/global-bin.test.ts
@@ -132,6 +132,27 @@ describe('global bin', () => {
       expect(out).toBe(`chc ${rootPackage.version}\n`);
     }
 
+    const versionJson = Bun.spawn(
+      ['node', 'bin/chc.mjs', 'version', '--json'],
+      {
+        cwd: cliRoot,
+        stdout: 'pipe',
+        stderr: 'pipe',
+        stdin: 'ignore',
+      },
+    );
+    const versionJsonOut = await new Response(versionJson.stdout).text();
+    const versionJsonErr = await new Response(versionJson.stderr).text();
+    const versionJsonCode = await versionJson.exited;
+
+    expect(versionJsonCode).toBe(0);
+    expect(versionJsonErr).toBe('');
+    expect(JSON.parse(versionJsonOut)).toEqual({
+      ok: true,
+      command: 'version',
+      version: rootPackage.version,
+    });
+
     const installDir = await mkdtemp(join(tmpdir(), 'cthutool-status-'));
     const status = Bun.spawn(
       ['node', 'bin/chc.mjs', 'status', '--install-dir', installDir, '--json'],
@@ -204,7 +225,7 @@ describe('global bin', () => {
       error: {
         code: 'missing_required_argument',
         message:
-          'script id is required in non-interactive mode (use: chc scripts <id> or --script <id>)',
+          'script id is required in non-interactive mode (use: chc scripts run <id>, chc scripts <id>, or --script <id>)',
       },
     });
   });
@@ -249,15 +270,14 @@ describe('global bin', () => {
           '\n  codex       Manage reproducible Codex configuration.',
         );
         expect(plain).toContain(
-          '\n  scripts     Discover and run bundled scripts under apps/cli/src/scripts/<id>/ (script.json + index.ts).',
+          '\n  scripts     Discover, list, and run bundled scripts under apps/cli/src/scripts/<id>/.',
         );
         expect(plain).not.toContain('\n  self-update');
         expect(plain).toContain(
           '\n  update      Update the global chc command from the CthuTool Git repository.',
         );
-        expect(plain).toContain(
-          '\n  version     Print the current chc CLI version.',
-        );
+        expect(plain).not.toContain('version');
+        expect(plain).not.toContain('__complete');
         expect(plain).toContain(
           '\n  status      Show chc CLI installation status.',
         );
@@ -275,16 +295,21 @@ describe('global bin', () => {
         );
         expect(plain).not.toContain('\n   apply');
       } else if (args[0] === 'scripts') {
-        expect(plain).toContain('chc scripts [OPTIONS] [ID]');
+        expect(plain).toContain('COMMANDS');
         expect(plain).toContain(
-          'Discover and run bundled scripts under apps/cli/src/scripts/<id>/ (script.json + index.ts).',
+          'Discover, list, and run bundled scripts under apps/cli/src/scripts/<id>/.',
         );
-        expect(plain).toContain('Examples:');
+        expect(plain).toContain('list');
+        expect(plain).toContain('run');
+        expect(plain).toContain('AVAILABLE SCRIPTS');
+        expect(plain).toContain('convert-to-cbz');
       } else {
-        expect(plain).toContain('chc completion [OPTIONS] <SHELL>');
-        expect(plain).toContain(
-          'Shell to generate completion for (powershell or zsh), or action to manage persistent completion',
-        );
+        expect(plain).toContain('COMMANDS');
+        expect(plain).toContain('powershell');
+        expect(plain).toContain('zsh');
+        expect(plain).toContain('enable');
+        expect(plain).toContain('disable');
+        expect(plain).toContain('status');
       }
     }
   });

--- a/apps/cli/tests/integration/run-scripts-explicit-id.test.ts
+++ b/apps/cli/tests/integration/run-scripts-explicit-id.test.ts
@@ -38,4 +38,22 @@ describe('scripts command explicit id', () => {
     expect(code).toBe(0);
     expect(out).toContain('Hello from bundled script: hello-world');
   });
+
+  test('runs hello-world through the canonical run operation', async () => {
+    const proc = Bun.spawn(
+      ['bun', 'run', 'src/index.ts', 'scripts', 'run', 'hello-world'],
+      {
+        cwd: cliRoot,
+        stdout: 'pipe',
+        stderr: 'pipe',
+        stdin: 'ignore',
+      },
+    );
+    const out = await new Response(proc.stdout).text();
+    const err = await new Response(proc.stderr).text();
+    const code = await proc.exited;
+    expect(code).toBe(0);
+    expect(err).toBe('');
+    expect(out).toContain('Hello from bundled script: hello-world');
+  });
 });

--- a/apps/cli/tests/integration/run-scripts-interactive.test.ts
+++ b/apps/cli/tests/integration/run-scripts-interactive.test.ts
@@ -24,7 +24,7 @@ describe('scripts command interactive selection', () => {
       origErr(...a);
     };
     try {
-      await runCommand(cmd, { rawArgs: [] });
+      await runCommand(cmd, { rawArgs: ['run'] });
     } finally {
       console.log = origLog;
       console.error = origErr;

--- a/apps/cli/tests/integration/run-scripts-non-tty.test.ts
+++ b/apps/cli/tests/integration/run-scripts-non-tty.test.ts
@@ -18,8 +18,11 @@ describe('scripts command non-interactive', () => {
     expect(code).toBe(0);
     expect(err).toBe('');
     expect(out).toContain('USAGE');
-    expect(out).toContain('chc scripts [OPTIONS] [ID]');
-    expect(out).toContain('Examples:');
+    expect(out).toContain('COMMANDS');
+    expect(out).toContain('AVAILABLE SCRIPTS');
+    expect(out).toContain('convert-to-cbz');
+    expect(out).toContain('list');
+    expect(out).toContain('run');
   });
 
   test('prints JSON error when script id is missing in JSON mode', async () => {
@@ -41,9 +44,83 @@ describe('scripts command non-interactive', () => {
       error: {
         code: 'missing_required_argument',
         message:
-          'script id is required in non-interactive mode (use: chc scripts <id> or --script <id>)',
+          'script id is required in non-interactive mode (use: chc scripts run <id>, chc scripts <id>, or --script <id>)',
       },
     });
     expect(err).toBe('');
+  });
+
+  test('lists discovered scripts in human and JSON modes', async () => {
+    const human = Bun.spawn(['bun', 'run', 'src/index.ts', 'scripts', 'list'], {
+      cwd: cliRoot,
+      stdout: 'pipe',
+      stderr: 'pipe',
+      stdin: 'ignore',
+    });
+    const humanOut = await new Response(human.stdout).text();
+    expect(await human.exited).toBe(0);
+    expect(humanOut).toContain('AVAILABLE SCRIPTS');
+    expect(humanOut).toContain('convert-to-cbz');
+
+    const json = Bun.spawn(
+      ['bun', 'run', 'src/index.ts', 'scripts', 'list', '--json'],
+      {
+        cwd: cliRoot,
+        stdout: 'pipe',
+        stderr: 'pipe',
+        stdin: 'ignore',
+      },
+    );
+    const jsonOut = await new Response(json.stdout).text();
+    expect(await json.exited).toBe(0);
+    const payload = JSON.parse(jsonOut) as {
+      ok: boolean;
+      command: string;
+      scripts: Array<{ id: string; title: string; description?: string }>;
+    };
+    expect(payload.ok).toBe(true);
+    expect(payload.command).toBe('scripts list');
+    const listedIds = payload.scripts.map((script) => script.id).sort();
+    expect(payload.scripts).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: 'convert-to-cbz' }),
+      ]),
+    );
+
+    const help = Bun.spawn(
+      ['bun', 'run', 'src/index.ts', 'scripts', '--help'],
+      {
+        cwd: cliRoot,
+        stdout: 'pipe',
+        stderr: 'pipe',
+        stdin: 'ignore',
+      },
+    );
+    const helpOut = await new Response(help.stdout).text();
+    expect(await help.exited).toBe(0);
+
+    const completion = Bun.spawn(
+      ['bun', 'run', 'src/index.ts', '__complete', 'scripts', ''],
+      {
+        cwd: cliRoot,
+        stdout: 'pipe',
+        stderr: 'pipe',
+        stdin: 'ignore',
+      },
+    );
+    const completionIds = (await new Response(completion.stdout).text())
+      .trim()
+      .split(/\r?\n/)
+      .filter((candidate) => candidate !== 'list' && candidate !== 'run')
+      .sort();
+    expect(await completion.exited).toBe(0);
+
+    expect(completionIds).toEqual(listedIds);
+    for (const script of payload.scripts) {
+      expect(humanOut).toContain(script.id);
+      expect(humanOut).toContain(script.title);
+      expect(helpOut).toContain(script.id);
+      expect(helpOut).toContain(script.title);
+    }
   });
 });

--- a/apps/cli/tests/integration/self-update-command.test.ts
+++ b/apps/cli/tests/integration/self-update-command.test.ts
@@ -1,0 +1,393 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  chmod,
+  mkdir,
+  mkdtemp,
+  readFile,
+  rm,
+  writeFile,
+} from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const cliRoot = join(dirname(fileURLToPath(import.meta.url)), '../..');
+const scriptExecutable = Bun.which('script');
+
+async function runProcess(command: string, args: string[], cwd: string) {
+  const proc = Bun.spawn([command, ...args], {
+    cwd,
+    stdout: 'pipe',
+    stderr: 'pipe',
+    stdin: 'ignore',
+  });
+  const out = await new Response(proc.stdout).text();
+  const err = await new Response(proc.stderr).text();
+  const code = await proc.exited;
+  if (code !== 0) {
+    throw new Error(`${command} ${args.join(' ')} failed: ${err || out}`);
+  }
+  return out.trim();
+}
+
+async function runCli(
+  args: string[],
+  env: Record<string, string | undefined> = {},
+) {
+  const proc = Bun.spawn(['bun', 'run', 'src/index.ts', ...args], {
+    cwd: cliRoot,
+    env: { ...process.env, ...env },
+    stdout: 'pipe',
+    stderr: 'pipe',
+    stdin: 'ignore',
+  });
+  const out = await new Response(proc.stdout).text();
+  const err = await new Response(proc.stderr).text();
+  const code = await proc.exited;
+  return { code, out, err };
+}
+
+async function createFixture() {
+  const root = await mkdtemp(join(tmpdir(), 'cthutool-update-'));
+  const source = join(root, 'source');
+  const installDir = join(root, 'managed', 'CthuTool');
+  const fakeBin = join(root, 'bin');
+  const npmLog = join(root, 'npm.log');
+  await mkdir(join(source, 'apps/cli/dist'), { recursive: true });
+  await mkdir(fakeBin, { recursive: true });
+  await writeFile(
+    join(source, 'package.json'),
+    JSON.stringify({ name: 'cthutool', version: '0.0.0' }),
+  );
+  await writeFile(join(source, 'apps/cli/dist/index.js'), 'first bundle\n');
+  const fakeNpm = join(fakeBin, 'npm');
+  await writeFile(
+    fakeNpm,
+    [
+      '#!/bin/sh',
+      'printf \'%s\\n\' "$*" >> "$' + '{FAKE_NPM_LOG:?}"',
+      'exit 0',
+      '',
+    ].join('\n'),
+  );
+  await chmod(fakeNpm, 0o755);
+
+  await runProcess('git', ['init', '-b', 'main'], source);
+  await runProcess('git', ['config', 'user.name', 'CthuTool Test'], source);
+  await runProcess(
+    'git',
+    ['config', 'user.email', 'cthutool@example.invalid'],
+    source,
+  );
+  await runProcess('git', ['add', '.'], source);
+  await runProcess('git', ['commit', '-m', 'Initial CLI bundle'], source);
+
+  const env = {
+    PATH: `${fakeBin}:${process.env.PATH ?? ''}`,
+    FAKE_NPM_LOG: npmLog,
+  };
+  const clone = async () => {
+    await mkdir(dirname(installDir), { recursive: true });
+    await runProcess('git', ['clone', source, installDir], root);
+    await runProcess(
+      'git',
+      ['config', 'user.name', 'CthuTool Test'],
+      installDir,
+    );
+    await runProcess(
+      'git',
+      ['config', 'user.email', 'cthutool@example.invalid'],
+      installDir,
+    );
+  };
+  const advanceSource = async (message: string) => {
+    await writeFile(
+      join(source, 'apps/cli/dist/index.js'),
+      `${message} bundle\n`,
+    );
+    await runProcess('git', ['add', '.'], source);
+    await runProcess('git', ['commit', '-m', message], source);
+  };
+  const npmInvocations = async () => {
+    try {
+      return (await readFile(npmLog, 'utf8'))
+        .trim()
+        .split(/\r?\n/)
+        .filter(Boolean);
+    } catch {
+      return [];
+    }
+  };
+  return {
+    root,
+    source,
+    installDir,
+    env,
+    clone,
+    advanceSource,
+    npmInvocations,
+    cleanup: () => rm(root, { force: true, recursive: true }),
+  };
+}
+
+function updateArgs(fixture: {
+  readonly source: string;
+  readonly installDir: string;
+}) {
+  return [
+    'update',
+    '--repo',
+    fixture.source,
+    '--ref',
+    'main',
+    '--install-dir',
+    fixture.installDir,
+  ];
+}
+
+describe('self-update command', () => {
+  test('checks a missing installation without cloning or invoking npm', async () => {
+    const fixture = await createFixture();
+    try {
+      const result = await runCli(
+        [...updateArgs(fixture), '--check', '--json'],
+        fixture.env,
+      );
+
+      expect(result.code).toBe(0);
+      expect(result.err).toBe('');
+      expect(JSON.parse(result.out)).toMatchObject({
+        ok: true,
+        command: 'update',
+        result: {
+          status: 'install_required',
+          phases: ['preflight'],
+        },
+      });
+      expect(await fixture.npmInvocations()).toEqual([]);
+      expect(await Bun.file(join(fixture.installDir, '.git')).exists()).toBe(
+        false,
+      );
+    } finally {
+      await fixture.cleanup();
+    }
+  });
+
+  test('installs a missing managed checkout with structured JSON output', async () => {
+    const fixture = await createFixture();
+    try {
+      const result = await runCli(
+        [...updateArgs(fixture), '--json'],
+        fixture.env,
+      );
+
+      expect(result.code).toBe(0);
+      expect(result.err).toBe('');
+      expect(JSON.parse(result.out)).toMatchObject({
+        ok: true,
+        command: 'update',
+        result: {
+          status: 'installed',
+          phases: expect.arrayContaining([
+            'clone',
+            'checkout',
+            'verify_bundle',
+            'install_global',
+          ]),
+        },
+      });
+      expect(await fixture.npmInvocations()).toHaveLength(1);
+    } finally {
+      await fixture.cleanup();
+    }
+  });
+
+  test('applies an available update and skips a subsequent no-op reinstall', async () => {
+    const fixture = await createFixture();
+    try {
+      await fixture.clone();
+      await fixture.advanceSource('Friendlier update output');
+
+      const updated = await runCli(
+        [...updateArgs(fixture), '--json'],
+        fixture.env,
+      );
+      expect(updated.code).toBe(0);
+      expect(JSON.parse(updated.out)).toMatchObject({
+        result: {
+          status: 'updated',
+          before: { commit: expect.any(String) },
+          after: { commit: expect.any(String) },
+          changes: { count: 1 },
+        },
+      });
+      expect(await fixture.npmInvocations()).toHaveLength(1);
+      expect(
+        await runProcess('git', ['rev-parse', 'HEAD'], fixture.installDir),
+      ).toBe(await runProcess('git', ['rev-parse', 'HEAD'], fixture.source));
+
+      const current = await runCli(
+        [...updateArgs(fixture), '--json'],
+        fixture.env,
+      );
+      expect(current.code).toBe(0);
+      expect(JSON.parse(current.out)).toMatchObject({
+        result: { status: 'up_to_date', steps: [] },
+      });
+      expect(await fixture.npmInvocations()).toHaveLength(1);
+    } finally {
+      await fixture.cleanup();
+    }
+  });
+
+  test('blocks dirty and diverged checkouts with actionable JSON errors', async () => {
+    const dirty = await createFixture();
+    try {
+      await dirty.clone();
+      await writeFile(join(dirty.installDir, 'local-change.txt'), 'keep me');
+      const originalRemote = await runProcess(
+        'git',
+        ['remote', 'get-url', 'origin'],
+        dirty.installDir,
+      );
+      const result = await runCli(
+        [
+          ...updateArgs(dirty),
+          '--repo',
+          join(dirty.root, 'different-remote'),
+          '--json',
+        ],
+        dirty.env,
+      );
+
+      expect(result.code).not.toBe(0);
+      expect(JSON.parse(result.out)).toMatchObject({
+        ok: false,
+        error: {
+          code: 'update_failed',
+          phase: 'preflight',
+          message: expect.stringContaining('Update blocked'),
+          hint: expect.stringContaining('Commit, stash, or remove'),
+        },
+      });
+      expect(
+        await runProcess(
+          'git',
+          ['remote', 'get-url', 'origin'],
+          dirty.installDir,
+        ),
+      ).toBe(originalRemote);
+      expect(await dirty.npmInvocations()).toEqual([]);
+
+      const human = await runCli([...updateArgs(dirty), '--quiet'], dirty.env);
+      expect(human.code).not.toBe(0);
+      expect(human.out).toBe('');
+      expect(human.err).toContain('Update blocked');
+      expect(human.err).toContain('Next: Commit, stash, or remove');
+    } finally {
+      await dirty.cleanup();
+    }
+
+    const diverged = await createFixture();
+    try {
+      await diverged.clone();
+      await diverged.advanceSource('Remote update');
+      await writeFile(
+        join(diverged.installDir, 'apps/cli/dist/index.js'),
+        'local update\n',
+      );
+      await runProcess('git', ['add', '.'], diverged.installDir);
+      await runProcess(
+        'git',
+        ['commit', '-m', 'Independent local update'],
+        diverged.installDir,
+      );
+
+      const result = await runCli(
+        [...updateArgs(diverged), '--check', '--json'],
+        diverged.env,
+      );
+      expect(result.code).not.toBe(0);
+      expect(JSON.parse(result.out)).toMatchObject({
+        error: {
+          code: 'update_failed',
+          message: expect.stringContaining('cannot fast-forward'),
+        },
+      });
+      expect(await diverged.npmInvocations()).toEqual([]);
+    } finally {
+      await diverged.cleanup();
+    }
+  });
+
+  test('renders stable non-TTY, quiet, and verbose check output', async () => {
+    const fixture = await createFixture();
+    try {
+      await fixture.clone();
+      const human = await runCli(
+        [...updateArgs(fixture), '--check'],
+        fixture.env,
+      );
+      expect(human.code).toBe(0);
+      expect(human.out).toContain('chc is already up to date');
+      expect(human.out).not.toContain('\u001b[');
+
+      const quiet = await runCli(
+        [...updateArgs(fixture), '--check', '--quiet'],
+        fixture.env,
+      );
+      expect(quiet).toMatchObject({ code: 0, out: '', err: '' });
+
+      const verbose = await runCli(
+        [...updateArgs(fixture), '--check', '--json', '--verbose'],
+        fixture.env,
+      );
+      expect(verbose.code).toBe(0);
+      expect(JSON.parse(verbose.out)).toMatchObject({
+        result: { status: 'up_to_date' },
+      });
+      expect(verbose.err).toContain('$ git');
+    } finally {
+      await fixture.cleanup();
+    }
+  });
+
+  test.skipIf(process.platform !== 'darwin' || !scriptExecutable)(
+    'renders active progress when the command owns a TTY',
+    async () => {
+      const fixture = await createFixture();
+      try {
+        await fixture.clone();
+        const proc = Bun.spawn(
+          [
+            scriptExecutable ?? 'script',
+            '-q',
+            '/dev/null',
+            'bun',
+            'run',
+            'src/index.ts',
+            ...updateArgs(fixture),
+            '--check',
+          ],
+          {
+            cwd: cliRoot,
+            env: { ...process.env, ...fixture.env },
+            stdout: 'pipe',
+            stderr: 'pipe',
+            stdin: 'ignore',
+          },
+        );
+        const out = await new Response(proc.stdout).text();
+        const err = await new Response(proc.stderr).text();
+
+        expect(await proc.exited).toBe(0);
+        expect(err).toBe('');
+        expect(out).toContain('Checking local update state complete');
+        expect(out).toContain('chc is already up to date');
+        expect(out).toContain('\u001b[?25l');
+      } finally {
+        await fixture.cleanup();
+      }
+    },
+  );
+});

--- a/apps/cli/tests/unit/command-discovery.test.ts
+++ b/apps/cli/tests/unit/command-discovery.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from 'bun:test';
 import {
+  filterUsageCommandChoices,
   getCommandRegistration,
   getCommandRegistrations,
 } from '../../src/command/command-discovery';
@@ -7,6 +8,15 @@ import { rootCommand } from '../../src/command/root.command';
 import { getCompletionCandidates } from '../../src/domain/completion-candidates';
 
 describe('command discovery registry', () => {
+  test('filters hidden usage choices from ANSI-styled help', () => {
+    const line =
+      '\u001b[36mUSAGE chc codex|version|status|__complete|scripts\u001b[39m';
+
+    expect(
+      filterUsageCommandChoices(line, new Set(['version', '__complete'])),
+    ).toBe('USAGE chc codex|status|scripts');
+  });
+
   test('root completion candidates match public registrations', async () => {
     const registrations = getCommandRegistrations(rootCommand) ?? [];
     const publicNames = registrations

--- a/apps/cli/tests/unit/command-discovery.test.ts
+++ b/apps/cli/tests/unit/command-discovery.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  getCommandRegistration,
+  getCommandRegistrations,
+} from '../../src/command/command-discovery';
+import { rootCommand } from '../../src/command/root.command';
+import { getCompletionCandidates } from '../../src/domain/completion-candidates';
+
+describe('command discovery registry', () => {
+  test('root completion candidates match public registrations', async () => {
+    const registrations = getCommandRegistrations(rootCommand) ?? [];
+    const publicNames = registrations
+      .filter((registration) => registration.visibility === 'public')
+      .map((registration) => registration.name)
+      .sort();
+
+    await expect(
+      getCompletionCandidates({ rootCommand, words: [''] }),
+    ).resolves.toEqual(publicNames);
+
+    const hiddenNames = registrations
+      .filter((registration) => registration.visibility !== 'public')
+      .map((registration) => registration.name);
+    expect(hiddenNames).toEqual(
+      expect.arrayContaining(['__complete', 'version']),
+    );
+    expect(publicNames).not.toEqual(expect.arrayContaining(hiddenNames));
+  });
+
+  test('public command groups declare help for bare invocation', () => {
+    const registrations = getCommandRegistrations(rootCommand) ?? [];
+    const bareHelpNames = registrations
+      .filter(
+        (registration) =>
+          registration.visibility === 'public' &&
+          registration.bareBehavior === 'help',
+      )
+      .map((registration) => registration.name)
+      .sort();
+
+    expect(bareHelpNames).toEqual(['codex', 'completion', 'scripts']);
+  });
+
+  test('nested completion candidates match public child registrations', async () => {
+    const completion = getCommandRegistration(rootCommand, 'completion');
+    expect(completion).toBeDefined();
+    const childNames = (
+      getCommandRegistrations(completion?.command ?? rootCommand) ?? []
+    )
+      .filter((registration) => registration.visibility === 'public')
+      .map((registration) => registration.name)
+      .sort();
+
+    await expect(
+      getCompletionCandidates({
+        rootCommand,
+        words: ['completion', ''],
+      }),
+    ).resolves.toEqual(childNames);
+  });
+});

--- a/apps/cli/tests/unit/discover-scripts.test.ts
+++ b/apps/cli/tests/unit/discover-scripts.test.ts
@@ -51,4 +51,41 @@ describe('discoverScripts', () => {
     const root = getBundledScriptsRoot();
     expect(root.replaceAll('\\', '/')).toContain('/apps/cli/src/scripts');
   });
+
+  test('returns a bounded discovery error when the scripts root is unavailable', async () => {
+    const root = join(
+      tmpdir(),
+      `cthutool-missing-scripts-${crypto.randomUUID()}`,
+    );
+    const result = await discoverScripts(root);
+
+    expect(result.isErr()).toBe(true);
+    if (!result.isErr()) return;
+    expect(result.error.message).toContain(
+      `cannot read bundled scripts directory (${root})`,
+    );
+  });
+
+  test('skips script ids reserved for group operations', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'cthutool-reserved-script-'));
+    await writePackage(root, 'list', { id: 'list', title: 'Reserved list' });
+    await writePackage(root, 'run', { id: 'run', title: 'Reserved run' });
+    await writePackage(root, 'valid-script', {
+      id: 'valid-script',
+      title: 'Valid',
+    });
+
+    const result = await discoverScripts(root);
+    expect(result.isOk()).toBe(true);
+    if (!result.isOk()) return;
+    expect(result.value.packages.map((pkg) => pkg.id)).toEqual([
+      'valid-script',
+    ]);
+    expect(result.value.warnings.map((warning) => warning.message)).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining('script id "list" is reserved'),
+        expect.stringContaining('script id "run" is reserved'),
+      ]),
+    );
+  });
 });

--- a/apps/cli/tests/unit/self-update-manager.test.ts
+++ b/apps/cli/tests/unit/self-update-manager.test.ts
@@ -4,31 +4,51 @@ import {
   committedCliBundlePath,
   defaultSelfUpdateRepo,
   getCliInstallationStatus,
+  planSelfUpdate,
   runSelfUpdate,
   type SelfUpdateCommandResult,
   type SelfUpdateDeps,
-  type SelfUpdateStep,
+  SelfUpdateError,
+  type SelfUpdateEvent,
 } from '../../src/domain/self-update-manager';
 
-function createDeps(options: {
-  readonly existingCheckout: boolean;
-  readonly remoteRefExists?: boolean;
+const currentCommit = '1111111111111111111111111111111111111111';
+const targetCommit = '2222222222222222222222222222222222222222';
+
+type FakeOptions = {
+  readonly existingCheckout?: boolean;
+  readonly currentCommit?: string;
+  readonly targetCommit?: string;
+  readonly targetKind?: 'branch' | 'tag' | 'raw';
+  readonly dirty?: boolean;
+  readonly dirtyOnRecheck?: boolean;
+  readonly diverged?: boolean;
   readonly bundlePresent?: boolean;
-}) {
+  readonly failCommand?: string;
+  readonly failOutput?: string;
+  readonly changeCount?: number;
+};
+
+function createDeps(options: FakeOptions = {}) {
   const commands: Array<{
     readonly command: string;
     readonly args: readonly string[];
     readonly cwd?: string;
   }> = [];
-  const steps: SelfUpdateStep[] = [];
+  const events: SelfUpdateEvent[] = [];
   const mkdirs: string[] = [];
   const installDir = '/tmp/cthutool/source/CthuTool';
+  let checkoutExists = options.existingCheckout ?? true;
+  let head = options.currentCommit ?? currentCommit;
+  let ref = 'main';
+  let statusCalls = 0;
+  const wantedTarget = options.targetCommit ?? targetCommit;
+  const targetKind = options.targetKind ?? 'branch';
+  const changeCount = options.changeCount ?? 7;
 
   const deps: SelfUpdateDeps = {
     exists(path) {
-      if (path === join(installDir, '.git')) {
-        return options.existingCheckout;
-      }
+      if (path === join(installDir, '.git')) return checkoutExists;
       if (path === join(installDir, committedCliBundlePath)) {
         return options.bundlePresent ?? true;
       }
@@ -43,37 +63,118 @@ function createDeps(options: {
       runOptions = {},
     ): Promise<SelfUpdateCommandResult> {
       commands.push({ command, args, cwd: runOptions.cwd });
-      const isRemoteRefCheck =
-        command === 'git' && args[0] === 'rev-parse' && args[1] === '--verify';
-      const stdout =
-        command === 'git' && args[0] === 'remote' && args[1] === 'get-url'
-          ? 'git@github.com:me/CthuTool.git\n'
-          : command === 'git' &&
-              args[0] === 'rev-parse' &&
-              args[1] === '--abbrev-ref'
-            ? 'main\n'
-            : command === 'git' &&
-                args[0] === 'rev-parse' &&
-                args[1] === '--short'
-              ? 'abc1234\n'
-              : '';
+      const signature = `${command} ${args.join(' ')}`;
+      if (options.failCommand && signature.includes(options.failCommand)) {
+        return {
+          command,
+          args,
+          cwd: runOptions.cwd,
+          code: 1,
+          stdout: '',
+          stderr: options.failOutput ?? 'simulated failure',
+        };
+      }
+
+      let code = 0;
+      let stdout = '';
+      if (command === 'git' && args[0] === 'status') {
+        statusCalls += 1;
+        const dirty =
+          options.dirty === true ||
+          (options.dirtyOnRecheck === true && statusCalls > 1);
+        stdout = dirty ? '?? local-change\n' : '';
+      } else if (
+        command === 'git' &&
+        args[0] === 'rev-parse' &&
+        args[2] === 'HEAD^{commit}'
+      ) {
+        stdout = `${head}\n`;
+      } else if (
+        command === 'git' &&
+        args[0] === 'rev-parse' &&
+        args[2] === 'FETCH_HEAD^{commit}'
+      ) {
+        stdout = `${wantedTarget}\n`;
+      } else if (
+        command === 'git' &&
+        args[0] === 'symbolic-ref' &&
+        targetKind !== 'tag'
+      ) {
+        stdout = `${ref}\n`;
+      } else if (command === 'git' && args[0] === 'symbolic-ref') {
+        code = 1;
+      } else if (command === 'git' && args[0] === 'ls-remote') {
+        if (targetKind === 'branch') {
+          stdout = `${wantedTarget}\trefs/heads/main\n`;
+        } else {
+          code = 2;
+        }
+      } else if (command === 'git' && args[0] === 'merge-base') {
+        code = options.diverged === true ? 1 : 0;
+      } else if (command === 'git' && args[0] === 'rev-list') {
+        stdout = `${changeCount}\n`;
+      } else if (command === 'git' && args[0] === 'log') {
+        stdout = Array.from(
+          { length: Math.min(changeCount, 5) },
+          (_, index) => `c${index + 1}\tCommit subject ${index + 1}`,
+        ).join('\n');
+      } else if (command === 'git' && args[0] === 'clone') {
+        checkoutExists = true;
+        head = wantedTarget;
+      } else if (command === 'git' && args[0] === 'checkout') {
+        ref = args[1] ?? ref;
+        head = wantedTarget;
+      } else if (
+        command === 'git' &&
+        args[0] === 'rev-parse' &&
+        args[1] === '--verify' &&
+        String(args[2]).startsWith('origin/')
+      ) {
+        code = targetKind === 'branch' ? 0 : 1;
+        stdout = code === 0 ? `${wantedTarget}\n` : '';
+      } else if (
+        command === 'git' &&
+        args[0] === 'remote' &&
+        args[1] === 'get-url'
+      ) {
+        stdout = 'git@github.com:me/CthuTool.git\n';
+      } else if (
+        command === 'git' &&
+        args[0] === 'rev-parse' &&
+        args[1] === '--abbrev-ref'
+      ) {
+        stdout = `${ref}\n`;
+      } else if (
+        command === 'git' &&
+        args[0] === 'rev-parse' &&
+        args[1] === '--short'
+      ) {
+        stdout = `${head.slice(0, 7)}\n`;
+      }
       return {
         command,
         args,
         cwd: runOptions.cwd,
-        code: isRemoteRefCheck && options.remoteRefExists === false ? 1 : 0,
+        code,
         stdout,
         stderr: '',
       };
     },
     env: {},
     home: () => '/home/tester',
-    onStep: (step) => {
-      steps.push(step);
-    },
+    onEvent: (event) => events.push(event),
   };
 
-  return { commands, deps, installDir, mkdirs, steps };
+  return { commands, deps, events, installDir, mkdirs };
+}
+
+function signatures(
+  commands: ReadonlyArray<{
+    readonly command: string;
+    readonly args: readonly string[];
+  }>,
+) {
+  return commands.map(({ command, args }) => `${command} ${args.join(' ')}`);
 }
 
 describe('self-update manager', () => {
@@ -83,140 +184,212 @@ describe('self-update manager', () => {
     );
   });
 
-  test('clones, verifies bundle, and installs the CLI when no checkout exists', async () => {
-    const { commands, deps, installDir, mkdirs, steps } = createDeps({
+  test('classifies an absent managed checkout without running commands', async () => {
+    const { commands, deps, installDir } = createDeps({
       existingCheckout: false,
     });
 
-    const result = await runSelfUpdate(
+    await expect(planSelfUpdate({ installDir }, deps)).resolves.toMatchObject({
+      status: 'install_required',
+      installDir,
+      phases: ['preflight'],
+    });
+    expect(commands).toEqual([]);
+  });
+
+  test('classifies an equal branch target as already current', async () => {
+    const { commands, deps, installDir } = createDeps({
+      targetCommit: currentCommit,
+    });
+    const plan = await planSelfUpdate({ installDir }, deps);
+
+    expect(plan).toMatchObject({
+      status: 'up_to_date',
+      before: { commit: currentCommit },
+      target: { commit: currentCommit },
+    });
+    expect(signatures(commands)).toContain(
+      `git fetch --no-tags ${defaultSelfUpdateRepo} main`,
+    );
+    expect(signatures(commands)).not.toContain(
+      `git remote set-url origin ${defaultSelfUpdateRepo}`,
+    );
+  });
+
+  test('redacts repository credentials from emitted command events', async () => {
+    const { deps, events, installDir } = createDeps({
+      targetCommit: currentCommit,
+    });
+    await planSelfUpdate(
       {
-        repo: 'git@github.com:me/CthuTool.git',
-        ref: 'main',
         installDir,
+        repo: 'https://update-user:super-secret@example.invalid/repo.git',
       },
       deps,
     );
+
+    const serialized = JSON.stringify(events);
+    expect(serialized).not.toContain('super-secret');
+    expect(serialized).toContain('https://***@example.invalid/repo.git');
+  });
+
+  test('classifies a branch update and bounds its change summary', async () => {
+    const { deps, installDir } = createDeps({ changeCount: 7 });
+    const plan = await planSelfUpdate({ installDir }, deps);
+
+    expect(plan).toMatchObject({
+      status: 'update_available',
+      before: { commit: currentCommit },
+      target: { commit: targetCommit },
+      changes: { count: 7, omitted: 2 },
+    });
+    expect(plan.changes?.highlights).toHaveLength(5);
+  });
+
+  for (const targetKind of ['tag', 'raw'] as const) {
+    test(`supports an available ${targetKind} target without branch fast-forward checks`, async () => {
+      const { commands, deps, installDir } = createDeps({ targetKind });
+      const plan = await planSelfUpdate(
+        { installDir, ref: targetKind === 'tag' ? 'v1.0.0' : targetCommit },
+        deps,
+      );
+
+      expect(plan.status).toBe('update_available');
+      expect(plan.target?.commit).toBe(targetCommit);
+      expect(
+        signatures(commands).some((value) => value.includes('merge-base')),
+      ).toBe(false);
+    });
+  }
+
+  test('blocks dirty checkout state before any remote operation', async () => {
+    const { commands, deps, installDir } = createDeps({ dirty: true });
+    const plan = await planSelfUpdate({ installDir }, deps);
+
+    expect(plan).toMatchObject({
+      status: 'blocked',
+      block: { kind: 'dirty_checkout' },
+    });
+    expect(signatures(commands)).toEqual([
+      'git status --porcelain --untracked-files=normal',
+    ]);
+  });
+
+  test('blocks a diverged branch without resetting or rebasing it', async () => {
+    const { commands, deps, installDir } = createDeps({ diverged: true });
+    const plan = await planSelfUpdate({ installDir }, deps);
+
+    expect(plan).toMatchObject({
+      status: 'blocked',
+      block: { kind: 'diverged_branch' },
+    });
+    expect(signatures(commands).join('\n')).not.toMatch(
+      /reset|rebase|checkout|pull/,
+    );
+  });
+
+  test('installs from an absent checkout and returns structured phases', async () => {
+    const { commands, deps, installDir, mkdirs } = createDeps({
+      existingCheckout: false,
+    });
+    const result = await runSelfUpdate({ installDir }, deps);
 
     expect(result).toMatchObject({
-      repo: 'git@github.com:me/CthuTool.git',
-      ref: 'main',
-      installDir,
+      status: 'installed',
+      after: { commit: targetCommit },
+      phases: [
+        'preflight',
+        'clone',
+        'checkout',
+        'verify_bundle',
+        'install_global',
+      ],
+      steps: ['clone', 'checkout', 'pull', 'verify-bundle', 'install-global'],
     });
-    expect(steps).toEqual([
-      'clone',
-      'checkout',
-      'pull',
-      'verify-bundle',
-      'install-global',
-    ]);
     expect(mkdirs).toEqual(['/tmp/cthutool/source']);
-    expect(commands).toEqual([
-      {
-        command: 'git',
-        args: ['clone', 'git@github.com:me/CthuTool.git', installDir],
-        cwd: undefined,
-      },
-      {
-        command: 'git',
-        args: ['checkout', 'main'],
-        cwd: installDir,
-      },
-      {
-        command: 'git',
-        args: ['rev-parse', '--verify', 'origin/main'],
-        cwd: installDir,
-      },
-      {
-        command: 'git',
-        args: ['pull', '--ff-only', 'origin', 'main'],
-        cwd: installDir,
-      },
-      {
-        command: 'npm',
-        args: ['install', '-g', '--ignore-scripts', installDir],
-        cwd: undefined,
-      },
-    ]);
+    expect(signatures(commands)).toContain(
+      `npm install -g --ignore-scripts ${installDir}`,
+    );
   });
 
-  test('fetches an existing checkout and skips pull for tags', async () => {
-    const { commands, deps, installDir, steps } = createDeps({
-      existingCheckout: true,
-      remoteRefExists: false,
-    });
+  test('applies an available update in stable subprocess order', async () => {
+    const { commands, deps, installDir } = createDeps();
+    const result = await runSelfUpdate({ installDir }, deps);
+    const all = signatures(commands);
 
-    await runSelfUpdate(
-      {
-        repo: 'git@github.com:me/CthuTool.git',
-        ref: 'v0.1.0',
-        installDir,
-      },
-      deps,
+    expect(result).toMatchObject({
+      status: 'updated',
+      before: { commit: currentCommit },
+      after: { commit: targetCommit },
+    });
+    expect(
+      all.indexOf('git status --porcelain --untracked-files=normal'),
+    ).toBeLessThan(
+      all.indexOf(`git remote set-url origin ${defaultSelfUpdateRepo}`),
+    );
+    expect(
+      all.indexOf(`git remote set-url origin ${defaultSelfUpdateRepo}`),
+    ).toBeLessThan(all.indexOf('git checkout main'));
+    const npmInstall = all.indexOf(
+      `npm install -g --ignore-scripts ${installDir}`,
+    );
+    expect(npmInstall).toBeGreaterThan(all.indexOf('git checkout main'));
+    expect(npmInstall).toBeLessThan(
+      all.lastIndexOf('git rev-parse --verify HEAD^{commit}'),
+    );
+  });
+
+  test('skips checkout, bundle verification, and global install when current', async () => {
+    const { commands, deps, installDir } = createDeps({
+      targetCommit: currentCommit,
+    });
+    const result = await runSelfUpdate({ installDir }, deps);
+    const all = signatures(commands).join('\n');
+
+    expect(result).toMatchObject({ status: 'up_to_date', steps: [] });
+    expect(all).not.toMatch(/remote set-url|checkout|npm install/);
+  });
+
+  test('rechecks safety and stops before mutation when the checkout changes', async () => {
+    const { commands, deps, installDir } = createDeps({ dirtyOnRecheck: true });
+
+    await expect(runSelfUpdate({ installDir }, deps)).rejects.toMatchObject({
+      phase: 'preflight',
+      summary: expect.stringContaining('changed after preflight'),
+    });
+    expect(signatures(commands).join('\n')).not.toMatch(
+      /remote set-url|checkout|npm install/,
+    );
+  });
+
+  test('reports bundle and subprocess failures with stable phases and bounded causes', async () => {
+    const missing = createDeps({ bundlePresent: false });
+    await expect(
+      runSelfUpdate({ installDir: missing.installDir }, missing.deps),
+    ).rejects.toMatchObject({ phase: 'verify_bundle' });
+    expect(signatures(missing.commands).join('\n')).not.toContain(
+      'npm install',
     );
 
-    expect(steps).toEqual([
-      'fetch',
-      'checkout',
-      'verify-bundle',
-      'install-global',
-    ]);
-    expect(commands.slice(0, 4)).toEqual([
-      {
-        command: 'git',
-        args: ['remote', 'set-url', 'origin', 'git@github.com:me/CthuTool.git'],
-        cwd: installDir,
-      },
-      {
-        command: 'git',
-        args: ['fetch', '--tags', 'origin'],
-        cwd: installDir,
-      },
-      {
-        command: 'git',
-        args: ['checkout', 'v0.1.0'],
-        cwd: installDir,
-      },
-      {
-        command: 'git',
-        args: ['rev-parse', '--verify', 'origin/v0.1.0'],
-        cwd: installDir,
-      },
-    ]);
-    expect(commands).not.toContainEqual({
-      command: 'git',
-      args: ['pull', '--ff-only', 'origin', 'v0.1.0'],
-      cwd: installDir,
+    const failed = createDeps({
+      failCommand: 'npm install',
+      failOutput: Array.from(
+        { length: 20 },
+        (_, index) => `line ${index}`,
+      ).join('\n'),
     });
-  });
-
-  test('fails before global install when the committed bundle is missing', async () => {
-    const { commands, deps, installDir } = createDeps({
-      existingCheckout: true,
-      bundlePresent: false,
-    });
-
-    await expect(
-      runSelfUpdate(
-        {
-          repo: 'git@github.com:me/CthuTool.git',
-          ref: 'main',
-          installDir,
-        },
-        deps,
-      ),
-    ).rejects.toThrow('missing committed CLI bundle');
-    expect(commands).not.toContainEqual({
-      command: 'npm',
-      args: ['install', '-g', '--ignore-scripts', installDir],
-      cwd: undefined,
-    });
+    try {
+      await runSelfUpdate({ installDir: failed.installDir }, failed.deps);
+      throw new Error('expected update to fail');
+    } catch (error) {
+      expect(error).toBeInstanceOf(SelfUpdateError);
+      expect(error).toMatchObject({ phase: 'install_global' });
+      expect((error as SelfUpdateError).causeText?.split('\n')).toHaveLength(8);
+    }
   });
 
   test('reports installation status from an explicit checkout', async () => {
-    const { deps, installDir } = createDeps({
-      existingCheckout: true,
-      bundlePresent: true,
-    });
+    const { deps, installDir } = createDeps();
 
     await expect(
       getCliInstallationStatus({ installDir }, deps),
@@ -226,24 +399,18 @@ describe('self-update manager', () => {
       installDir,
       repo: 'git@github.com:me/CthuTool.git',
       ref: 'main',
-      commit: 'abc1234',
+      commit: currentCommit.slice(0, 7),
       bundlePath: join(installDir, committedCliBundlePath),
       bundlePresent: true,
     });
   });
 
   test('reports remote mode for the default managed checkout', async () => {
-    const { deps } = createDeps({
-      existingCheckout: false,
-      bundlePresent: false,
-    });
+    const { deps } = createDeps({ existingCheckout: false });
     const installDir = '/home/tester/.cthutool/source/CthuTool';
 
     await expect(
       getCliInstallationStatus({ installDir }, deps),
-    ).resolves.toMatchObject({
-      mode: 'remote',
-      installDir,
-    });
+    ).resolves.toMatchObject({ mode: 'remote', installDir });
   });
 });

--- a/apps/cli/tests/unit/self-update-output.test.ts
+++ b/apps/cli/tests/unit/self-update-output.test.ts
@@ -95,7 +95,7 @@ describe('self-update output', () => {
       'start:Checking local update state',
       'stop:0:Checking local update state complete',
     ]);
-    expect(harness.stdout()).toBe('CthuTool update\n');
+    expect(harness.stdout()).toBe('\u001b[36mCthuTool update\u001b[39m\n');
   });
 
   test('renders stable non-TTY progress and a bounded change summary', () => {

--- a/apps/cli/tests/unit/self-update-output.test.ts
+++ b/apps/cli/tests/unit/self-update-output.test.ts
@@ -1,0 +1,168 @@
+import { describe, expect, test } from 'bun:test';
+import { createSelfUpdateRenderer } from '../../src/command/self-update-output';
+import type {
+  SelfUpdateEvent,
+  SelfUpdatePlan,
+} from '../../src/domain/self-update-manager';
+import type { CliContext } from '../../src/runtime/cli-context';
+import type { CliOutput } from '../../src/runtime/output';
+
+function createHarness(
+  options: {
+    readonly context?: Partial<CliContext>;
+    readonly outputTty?: boolean;
+    readonly verbose?: boolean;
+  } = {},
+) {
+  let stdout = '';
+  let stderr = '';
+  const spinnerCalls: string[] = [];
+  const output: CliOutput = {
+    stdout: { write: (chunk) => (stdout += chunk) },
+    stderr: { write: (chunk) => (stderr += chunk) },
+  };
+  const context: CliContext = {
+    isTty: false,
+    interactive: false,
+    json: false,
+    quiet: false,
+    ...options.context,
+  };
+  const renderer = createSelfUpdateRenderer(
+    context,
+    { verbose: options.verbose ?? false },
+    {
+      output,
+      isOutputTty: () => options.outputTty ?? false,
+      createSpinner: () => ({
+        start: (message = '') => spinnerCalls.push(`start:${message}`),
+        stop: (message = '', code) =>
+          spinnerCalls.push(`stop:${code ?? 0}:${message}`),
+        message: (message = '') => spinnerCalls.push(`message:${message}`),
+      }),
+    },
+  );
+  return {
+    renderer,
+    spinnerCalls,
+    stdout: () => stdout,
+    stderr: () => stderr,
+  };
+}
+
+const plan: SelfUpdatePlan = {
+  status: 'update_available',
+  repo: 'https://github.com/example/CthuTool.git',
+  ref: 'main',
+  installDir: '/tmp/CthuTool',
+  before: {
+    ref: 'main',
+    commit: '1111111111111111111111111111111111111111',
+    shortCommit: '1111111',
+  },
+  target: {
+    ref: 'main',
+    commit: '2222222222222222222222222222222222222222',
+    shortCommit: '2222222',
+  },
+  changes: {
+    count: 7,
+    highlights: Array.from({ length: 5 }, (_, index) => ({
+      commit: `c${index + 1}`,
+      subject: `Change ${index + 1}`,
+    })),
+    omitted: 2,
+  },
+  phases: ['preflight', 'check_remote'],
+};
+
+describe('self-update output', () => {
+  test('uses one active spinner for TTY phase progress', () => {
+    const harness = createHarness({
+      context: { isTty: true, interactive: true },
+      outputTty: true,
+    });
+    harness.renderer.onEvent({
+      type: 'phase_started',
+      phase: 'preflight',
+    });
+    harness.renderer.onEvent({
+      type: 'phase_completed',
+      phase: 'preflight',
+    });
+
+    expect(harness.spinnerCalls).toEqual([
+      'start:Checking local update state',
+      'stop:0:Checking local update state complete',
+    ]);
+    expect(harness.stdout()).toBe('CthuTool update\n');
+  });
+
+  test('renders stable non-TTY progress and a bounded change summary', () => {
+    const harness = createHarness();
+    const events: SelfUpdateEvent[] = [
+      { type: 'phase_started', phase: 'preflight' },
+      { type: 'phase_completed', phase: 'preflight' },
+      { type: 'plan', plan },
+    ];
+    for (const event of events) harness.renderer.onEvent(event);
+    harness.renderer.renderCheckResult(plan);
+
+    expect(harness.stdout()).toContain('- Checking local update state');
+    expect(harness.stdout()).toContain('1111111');
+    expect(harness.stdout()).toContain('2222222');
+    expect(harness.stdout()).toContain('changes: 7 commit(s)');
+    expect(harness.stdout()).toContain('… 2 more commit(s)');
+    expect(harness.stdout()).toContain('Update available');
+    expect(harness.stdout()).not.toContain('\u001b[');
+  });
+
+  test('suppresses human progress in quiet and JSON modes', () => {
+    for (const context of [{ quiet: true }, { json: true }]) {
+      const harness = createHarness({ context });
+      harness.renderer.onEvent({ type: 'phase_started', phase: 'preflight' });
+      harness.renderer.onEvent({ type: 'plan', plan });
+      harness.renderer.renderCheckResult(plan);
+      expect(harness.stdout()).toBe('');
+      expect(harness.stderr()).toBe('');
+    }
+  });
+
+  test('writes bounded verbose command details only to stderr', () => {
+    const harness = createHarness({
+      context: { json: true },
+      verbose: true,
+    });
+    harness.renderer.onEvent({
+      type: 'command',
+      phase: 'check_remote',
+      command: 'git',
+      args: ['fetch', 'https://***@github.com/example/repo.git'],
+      cwd: '/tmp/CthuTool',
+      code: 0,
+      stderr: 'remote output',
+    });
+
+    expect(harness.stdout()).toBe('');
+    expect(harness.stderr()).toContain('$ git fetch');
+    expect(harness.stderr()).toContain('remote output');
+  });
+
+  test('stops active TTY progress with a failure state', () => {
+    const harness = createHarness({
+      context: { isTty: true, interactive: true },
+      outputTty: true,
+    });
+    harness.renderer.onEvent({ type: 'phase_started', phase: 'fetch' });
+    harness.renderer.onEvent({
+      type: 'failure',
+      phase: 'fetch',
+      summary: 'Fetch failed',
+      hint: 'Retry',
+    });
+
+    expect(harness.spinnerCalls.at(-1)).toBe(
+      'stop:1:Fetching repository updates failed',
+    );
+  });
+});

--- a/apps/docs/src/content/docs/architecture/cli.md
+++ b/apps/docs/src/content/docs/architecture/cli.md
@@ -11,7 +11,7 @@ Commands derive `CliContext` at the boundary, reserve stdout for JSON in `--json
 
 ## Install and Update
 
-The GitHub installer keeps a source checkout, builds `@cthutool/cli`, and installs the root package globally. `chc update` updates that checkout and reinstall path.
+The GitHub installer keeps a source checkout, verifies the committed CLI bundle, and installs the root package globally. `chc update --check` inspects the selected target without changing checkout files or the global command. `chc update` safely updates that checkout and reinstalls only when its commit changes.
 
 ## Requirements Sources
 

--- a/apps/docs/src/content/docs/client/cli.md
+++ b/apps/docs/src/content/docs/client/cli.md
@@ -60,13 +60,29 @@ CHC_INSTALL_MODE=remote scripts/install-chc.sh
 ## Update
 
 ```bash
-chc version
+chc --version
 chc status
+chc update --check
 chc update
 chc update --ref v0.1.0
 ```
 
-`chc status` detects the source checkout used by the running global command. It reports `mode: local` for a linked development checkout and `mode: remote` for the default managed checkout, together with that checkout's Git and bundle state. Pass `--install-dir <path>` to inspect a different checkout explicitly.
+Use `chc --version` for the lightweight version-only check. `chc status` includes that version and detects the source checkout used by the running global command. It reports `mode: local` for a linked development checkout and `mode: remote` for the default managed checkout, together with that checkout's Git and bundle state. Pass `--install-dir <path>` to inspect a different checkout explicitly.
+
+`chc update --check` reports whether installation or an update is required without changing checkout files or the global command. A clean managed `chc update` proceeds directly, shows current-to-target commit progress, and skips global reinstallation when already current. Dirty or diverged checkouts are blocked without automatic stash, reset, clean, or rebase.
+
+Use `--quiet` for errors-only human output, `--verbose` for bounded Git and npm details on stderr, or `--json` for one structured result. Checks only run when explicitly requested; there is no periodic or shell-startup background update checker.
+
+## Discover Commands
+
+```bash
+chc completion
+chc scripts
+chc scripts list
+chc scripts run convert-to-cbz --input ./samples
+```
+
+Bare command groups print their registered child operations. `chc scripts` also includes an `AVAILABLE SCRIPTS` catalog. The compatibility forms `chc scripts <id>` and `chc scripts --script <id>` remain supported; `chc scripts run <id>` is the canonical execution form. See [CLI Commands](/reference/cli/) for completion lifecycle and script examples.
 
 ## Uninstall
 

--- a/apps/docs/src/content/docs/quick-start.md
+++ b/apps/docs/src/content/docs/quick-start.md
@@ -62,6 +62,7 @@ chc --help
 Update later with:
 
 ```bash
+chc update --check
 chc update
 ```
 

--- a/apps/docs/src/content/docs/reference/cli.md
+++ b/apps/docs/src/content/docs/reference/cli.md
@@ -9,13 +9,38 @@ Install `chc` from [CLI Tool](/client/cli/) before using these commands.
 
 ```bash
 chc --help
-chc version
+chc --version
 chc status
+chc update --check
 chc update
 chc update --ref v0.1.0
 ```
 
-`chc status` reports the detected `local` or `remote` installation mode and inspects the source checkout used by the running command. `chc status --install-dir <path>` overrides automatic source detection.
+Use `chc --version` for the lightweight version-only check. `chc status` includes that version, reports the detected `local` or `remote` installation mode, and inspects the source checkout used by the running command. `chc status --install-dir <path>` overrides automatic source detection.
+
+## Update
+
+```bash
+chc update --check
+chc update
+chc update --quiet
+chc update --verbose
+chc update --json
+chc update --check --json
+```
+
+`--check` reports `install_required`, `update_available`, or `up_to_date`
+without cloning, changing checkout files, or invoking global installation. A
+clean managed update runs directly without a second confirmation. It shows the
+current and target commits, at most five commit highlights, and an omitted
+count when more changes exist. If both commits are equal, checkout, bundle
+installation verification, and `npm install -g` are skipped.
+
+Dirty or diverged checkouts fail before checkout mutation or global install;
+the updater does not stash, reset, clean, or rebase user work. `--quiet`
+suppresses nonessential human progress, `--verbose` adds bounded subprocess
+details to stderr, and `--json` writes one structured status value to stdout.
+The CLI performs no periodic or shell-startup update checks.
 
 ## Shared Flags
 
@@ -30,6 +55,9 @@ Commands that support the agent contract accept common flags:
 In JSON mode, stdout is reserved for the JSON response. Human warnings and diagnostics are written to stderr.
 
 ## Shell Completion
+
+Run `chc completion` to show the registered `powershell`, `zsh`, `enable`,
+`disable`, and `status` operations without changing a profile.
 
 ```powershell
 chc completion powershell
@@ -51,7 +79,20 @@ The installer enables zsh completion automatically when zsh is the user's login 
 
 ```bash
 chc scripts
+chc scripts list
+chc scripts list --json
+chc scripts run convert-to-cbz --input ./samples
+```
+
+Bare `chc scripts` prints the public `list` and `run` operations followed by an
+`AVAILABLE SCRIPTS` catalog. `chc scripts list` renders the same discovered
+catalog; its JSON form returns bounded script ids, titles, and descriptions.
+Use `chc scripts run <id>` as the canonical execution form. These compatibility
+forms remain supported and route through the same runner:
+
+```bash
 chc scripts convert-to-cbz --input ./samples
+chc scripts --script convert-to-cbz --input ./samples
 chc scripts convert-to-cbz --input ./samples --format jpg --quality 90 --concurrency 4
 chc scripts convert-to-cbz --input ./samples --json --no-interactive
 ```

--- a/openspec/changes/archive/2026-07-13-apps-cli-command-discovery/.openspec.yaml
+++ b/openspec/changes/archive/2026-07-13-apps-cli-command-discovery/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-13

--- a/openspec/changes/archive/2026-07-13-apps-cli-command-discovery/design.md
+++ b/openspec/changes/archive/2026-07-13-apps-cli-command-discovery/design.md
@@ -1,0 +1,87 @@
+## Context
+
+The CLI currently has a reliable Citty command tree for static groups such as `codex`, but several discovery behaviors live outside that tree:
+
+- top-level bare-command help is selected by a name whitelist in the entrypoint;
+- compatibility and internal command visibility is filtered separately in help and completion;
+- `completion` lifecycle actions are parsed from `rawArgs` and repeated as hard-coded completion candidates;
+- bundled scripts are dynamically discovered for execution and completion, but not represented in help;
+- current OpenSpec requirements and entrypoint interception disagree about what a bare `chc scripts` invocation does.
+
+The design must preserve existing documented invocations, keep dynamic script discovery inexpensive and failure-tolerant, and continue using Citty rather than introducing another CLI framework.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Establish one registration model for static command dispatch, visibility, help, completion, and bare behavior.
+- Represent completion lifecycle operations as real Citty commands without changing existing user syntax.
+- Give bundled scripts canonical `list` and `run` operations while retaining positional and `--script` shorthand.
+- Use one discovered script catalog for help, listing, completion, interactive selection, and execution.
+- Make command-discovery consistency enforceable with focused invariant tests.
+
+**Non-Goals:**
+
+- Describe every bundled script option in `script.json` or synthesize full Citty argument schemas for scripts.
+- Remove existing `chc completion <shell>`, `chc completion <action> <shell>`, `chc scripts <id>`, or `chc scripts --script <id>` forms.
+- Add support for new shells or change profile file semantics.
+- Change bundled script execution, JSON summary, diagnostics, or progress contracts after target selection.
+- Replace Citty or build a general-purpose CLI framework.
+
+## Decisions
+
+- Add a thin CLI registration layer around Citty command definitions.
+  - Each registration carries a stable name, `CommandDef`, visibility (`public`, `compat`, or `internal`), and bare behavior (`help` or `run`).
+  - Root dispatch, root help, and root completion consume the same registrations.
+  - Rationale: visibility and bare behavior are command metadata, not properties that should be inferred repeatedly from command names.
+  - Alternative considered: retain independent hidden-name and omitted-command sets. That is smaller initially but preserves the drift this change is intended to remove.
+
+- Use the real Citty tree as the source of truth for static nested operations.
+  - `completion` registers `powershell`, `zsh`, `enable`, `disable`, and `status` as actual children.
+  - `enable`, `disable`, and `status` accept a shell positional argument; `powershell` and `zsh` remain leaf commands that emit adapters.
+  - A single supported-shell definition supplies validation and shell candidates.
+  - Rationale: existing command syntax already looks hierarchical, so representing it hierarchically eliminates raw argument dispatch and hard-coded action candidates without a user migration.
+  - Alternative considered: introduce `completion generate <shell>`. It is structurally uniform but makes common `source <(chc completion zsh)` usage more verbose and requires unnecessary documentation churn.
+
+- Model bundled scripts as a dynamic catalog behind static `scripts list` and `scripts run` operations.
+  - `chc scripts` is a public group whose bare behavior renders group help plus an `AVAILABLE SCRIPTS` catalog.
+  - `chc scripts list` renders the catalog and supports machine-readable JSON.
+  - `chc scripts run <id>` is the canonical execution form and retains interactive selection when the id is omitted in an interactive context.
+  - The parent command continues routing `chc scripts <id>` and `chc scripts --script <id>` to the same runner as compatibility shorthand.
+  - Rationale: script ids and descriptions are dynamic, but the catalog manifest does not describe each script's complete option schema. Treating every id as a generated Citty command would imply stronger schemas than the repository has.
+  - Alternative considered: generate a subcommand per script id. That gives a native `COMMANDS` table but complicates arbitrary script option forwarding, startup discovery failures, and contributor manifests.
+
+- Introduce a shared dynamic discovery provider for catalog-backed help and completion.
+  - The provider returns bounded name/title/description rows from existing `discoverScripts()` and `listSelectable()` behavior.
+  - Human help and list output may report discovery warnings; internal completion remains silent on failure.
+  - Rationale: the same catalog must not be reformatted from separate independently maintained lists.
+
+- Remove entrypoint name whitelists and special completion action lists after registrations and command children carry the required structure.
+  - Explicit `--help` and a bare command whose registration selects `help` use the same renderer.
+  - Commands selecting `run` reach their command handler instead of being intercepted globally.
+
+- Preserve compatibility through routing and tests rather than duplicate public help entries.
+  - Compatibility and internal registrations remain callable but are omitted from help and completion.
+  - Existing version compatibility behavior established by the preceding change remains unchanged.
+
+## Risks / Trade-offs
+
+- [Risk] Citty parent commands with both child commands and compatibility positional routing may have ambiguous parsing. → Add parser-level integration tests for `scripts list`, `scripts run <id>`, `scripts <id>`, and `scripts --script <id>` before removing old routing.
+- [Risk] Dynamic discovery could make help slower or fail when a manifest is invalid. → Reuse the bounded catalog result, show valid entries with warnings in human output, and keep completion failure quiet.
+- [Risk] Refactoring completion commands could alter adapter stdout. → Keep adapter rendering functions unchanged and assert byte-for-byte output behavior through existing integration tests.
+- [Risk] Adding `list` and `run` may conflict with future bundled script ids. → Reserve those ids in manifest validation or routing and document them as command-group operations.
+- [Trade-off] `scripts` help needs a small custom catalog section because Citty cannot natively render dynamic positional targets. This is preferable to fabricating incomplete command definitions.
+
+## Migration Plan
+
+1. Add command registration and visibility types while keeping existing dispatch operational.
+2. Convert `completion` actions and shell emitters into real child commands, then remove raw argument action parsing and hard-coded completion candidates.
+3. Add `scripts list` and `scripts run`, shared catalog rendering, and compatibility routing for existing shorthand.
+4. Replace the entrypoint bare-command whitelist with registration metadata and derive help/completion visibility from the registry.
+5. Update documentation, tests, and the committed CLI bundle; validate both new canonical forms and all compatibility forms.
+
+Rollback is code-only: the previous command definitions and entrypoint routing can be restored without migrating persisted user data or completion profiles.
+
+## Open Questions
+
+- None. Canonical forms, compatibility expectations, and bare-command behavior are defined by the accompanying specs.

--- a/openspec/changes/archive/2026-07-13-apps-cli-command-discovery/proposal.md
+++ b/openspec/changes/archive/2026-07-13-apps-cli-command-discovery/proposal.md
@@ -1,0 +1,31 @@
+## Why
+
+CLI execution, help rendering, shell completion, command visibility, and bare-command behavior currently derive from several separate hard-coded paths. This duplication has already allowed supported `completion` operations and dynamically discovered scripts to appear in completion without appearing in help, and it makes every new command likely to require synchronized edits across unrelated files.
+
+## What Changes
+
+- Introduce a shared command-discovery model for public, compatibility, and internal command visibility plus bare-command behavior.
+- Derive static command help and completion candidates from the same registered Citty command tree.
+- Model `completion` operations as real subcommands while preserving existing `chc completion <shell>` and `chc completion <action> <shell>` syntax.
+- Add a discoverable bundled-script catalog with human and JSON listing, and use the same discovered catalog for script help, completion, interactive selection, and execution.
+- Keep `chc scripts <id>` and `chc scripts --script <id>` working as compatibility-friendly shorthand for script execution.
+- Define and test consistency invariants so public commands offered by completion are represented in help, while compatibility and internal commands remain callable but undiscoverable.
+
+## Capabilities
+
+### New Capabilities
+
+- `apps-cli-command-discovery`: Defines the shared command registration, visibility, help, completion, and bare-command behavior contract for the CLI.
+
+### Modified Capabilities
+
+- `apps-cli-shell-completion`: Derive completion lifecycle actions and supported shells from the real command model instead of parallel hard-coded parsing and candidate lists.
+- `apps-cli-bundled-script-execution`: Add catalog listing and consistent bare/help behavior while preserving existing script invocation syntax.
+
+## Impact
+
+- CLI root registration, help rendering, command dispatch, and completion candidate traversal under `apps/cli`.
+- Completion lifecycle command definitions and their compatibility routes.
+- Bundled-script discovery, catalog presentation, and runner entry points.
+- CLI unit and integration tests, committed runtime bundle, and user-facing CLI documentation.
+- No existing documented completion or script execution command is removed.

--- a/openspec/changes/archive/2026-07-13-apps-cli-command-discovery/specs/apps-cli-bundled-script-execution/spec.md
+++ b/openspec/changes/archive/2026-07-13-apps-cli-command-discovery/specs/apps-cli-bundled-script-execution/spec.md
@@ -1,0 +1,59 @@
+## ADDED Requirements
+
+### Requirement: Bundled Script Catalog Discovery
+The `scripts` command group SHALL expose the discovered bundled-script catalog through group help and an explicit `list` operation using the same catalog used for completion, selection, and execution.
+
+#### Scenario: Bare scripts group help
+- **WHEN** a user runs `chc scripts` or `chc scripts --help`
+- **THEN** stdout presents the public `list` and `run` operations
+- **AND** includes an `AVAILABLE SCRIPTS` section with discovered script ids, titles, and descriptions
+- **AND** exits successfully without running a bundled script
+
+#### Scenario: Human script listing
+- **WHEN** a user runs `chc scripts list`
+- **THEN** stdout lists discovered script ids, titles, and descriptions
+- **AND** the listed entries come from the same catalog used by script execution
+
+#### Scenario: JSON script listing
+- **WHEN** a user runs `chc scripts list --json`
+- **THEN** stdout contains exactly one success JSON value with `command: "scripts list"` and bounded script metadata
+- **AND** no human catalog text is written to stdout
+
+#### Scenario: Reserved script operation ids
+- **WHEN** a bundled script manifest declares `list` or `run` as its script id
+- **THEN** discovery rejects or clearly warns about the reserved id
+- **AND** static group operations remain unambiguous
+
+## MODIFIED Requirements
+
+### Requirement: Script Selection
+The `scripts` command group SHALL resolve the target bundled script through the canonical `run` operation or the existing positional and `--script` compatibility forms.
+
+#### Scenario: Canonical run command
+- **WHEN** the user runs `chc scripts run convert-to-cbz`
+- **THEN** the `scripts` command selects the bundled script with id `convert-to-cbz`
+
+#### Scenario: Positional script id
+- **WHEN** the user runs `chc scripts convert-to-cbz`
+- **THEN** the `scripts` command selects the bundled script with id `convert-to-cbz`
+- **AND** the compatibility form routes to the same runner used by `chc scripts run convert-to-cbz`
+
+#### Scenario: Script flag
+- **WHEN** the user runs `chc scripts --script convert-to-cbz`
+- **THEN** the `scripts` command selects the bundled script with id `convert-to-cbz`
+- **AND** the compatibility form routes to the same runner used by the canonical `run` operation
+
+#### Scenario: Unknown script id
+- **WHEN** the requested script id does not match a discovered script
+- **THEN** the command fails with an `unknown_selection` command error
+
+### Requirement: Interactive Script Prompt
+The canonical `scripts run` operation SHALL prompt for script selection only when no script id is provided and the shared context is interactive.
+
+#### Scenario: Interactive selection
+- **WHEN** a user runs `chc scripts run` without a script id and the context is interactive
+- **THEN** the command shows the existing script selection prompt using the shared discovered catalog
+
+#### Scenario: Non-interactive missing script id
+- **WHEN** a user runs `chc scripts run` without a script id and the context is non-interactive
+- **THEN** the command fails without prompting and sets a non-zero exit code

--- a/openspec/changes/archive/2026-07-13-apps-cli-command-discovery/specs/apps-cli-command-discovery/spec.md
+++ b/openspec/changes/archive/2026-07-13-apps-cli-command-discovery/specs/apps-cli-command-discovery/spec.md
@@ -1,0 +1,76 @@
+## ADDED Requirements
+
+### Requirement: Shared command registration
+The CLI SHALL maintain one registration model for static command dispatch, visibility, help discovery, completion discovery, and bare-command behavior.
+
+#### Scenario: Public command registration
+- **WHEN** a static command is registered as public
+- **THEN** the command is callable through the CLI dispatcher
+- **AND** it is eligible to appear in help and shell completion from the same registration
+
+#### Scenario: Compatibility command registration
+- **WHEN** a static command is registered as a compatibility command
+- **THEN** the command remains callable for existing users and scripts
+- **AND** it is omitted from public help and shell completion
+
+#### Scenario: Internal command registration
+- **WHEN** a static command is registered as internal
+- **THEN** the command remains callable by its internal protocol consumer
+- **AND** it is omitted from public help and shell completion
+
+### Requirement: Static command discovery consistency
+Public static commands and nested operations SHALL derive their help and completion presence from the same Citty command definitions and registration visibility.
+
+#### Scenario: Public static operation is discoverable
+- **WHEN** a public static operation is offered as a completion candidate at a command path
+- **THEN** the parent command help identifies the same operation
+
+#### Scenario: Static operation is removed
+- **WHEN** a public static operation is removed from its parent command definition
+- **THEN** it no longer appears in dispatch, help, or completion without requiring a separate candidate-list edit
+
+#### Scenario: Hidden operation stays hidden
+- **WHEN** an internal or compatibility operation exists in the dispatch tree
+- **THEN** help and completion omit it according to its registration visibility
+
+### Requirement: Bare command behavior
+Each registered top-level command SHALL declare whether a bare invocation renders help or runs its command handler.
+
+#### Scenario: Bare command group renders help
+- **WHEN** a user invokes a public command group whose bare behavior is `help`
+- **THEN** the CLI renders the same group help used by the explicit `--help` form
+- **AND** exits successfully without running a child operation
+
+#### Scenario: Bare runnable command reaches its handler
+- **WHEN** a user invokes a command whose bare behavior is `run`
+- **THEN** the CLI reaches that command's normal validation or interactive behavior
+- **AND** the entrypoint does not replace execution with a name-based help shortcut
+
+### Requirement: Dynamic discovery provider
+A command with dynamic targets SHALL use one discovery provider to supply human help, listing, shell completion, selection, and execution resolution.
+
+#### Scenario: Dynamic targets remain consistent
+- **WHEN** dynamic target discovery succeeds
+- **THEN** help, explicit listing, completion, and execution resolution use the same discovered target ids and metadata
+
+#### Scenario: Dynamic discovery fails during completion
+- **WHEN** the discovery provider fails while serving the internal completion protocol
+- **THEN** completion returns no dynamic candidates
+- **AND** it does not emit interactive prompts or noisy diagnostics
+
+#### Scenario: Dynamic discovery warns in human output
+- **WHEN** discovery returns valid targets together with bounded warnings
+- **THEN** human help or listing shows the valid targets
+- **AND** reports actionable warnings without preventing valid targets from being used
+
+### Requirement: Command discovery invariant tests
+The CLI SHALL verify command-discovery consistency through automated tests rather than relying only on fixed output snapshots.
+
+#### Scenario: Help and completion invariant
+- **WHEN** the registered public static command tree is tested
+- **THEN** every public static completion operation is represented by its parent help
+- **AND** internal and compatibility operations are absent from both discovery surfaces
+
+#### Scenario: Documented compatibility forms
+- **WHEN** compatibility command forms are tested
+- **THEN** they continue to dispatch successfully without becoming public discovery entries

--- a/openspec/changes/archive/2026-07-13-apps-cli-command-discovery/specs/apps-cli-shell-completion/spec.md
+++ b/openspec/changes/archive/2026-07-13-apps-cli-command-discovery/specs/apps-cli-shell-completion/spec.md
@@ -1,0 +1,64 @@
+## MODIFIED Requirements
+
+### Requirement: Completion command group
+The CLI SHALL expose `completion` as a real command group whose public child commands generate shell adapters or manage persistent completion setup.
+
+#### Scenario: Bare completion group help
+- **WHEN** a user runs `chc completion` or `chc completion --help`
+- **THEN** stdout presents public operations for `powershell`, `zsh`, `enable`, `disable`, and `status`
+- **AND** the bare command exits successfully without modifying a shell profile
+
+#### Scenario: PowerShell completion script
+- **WHEN** a user runs `chc completion powershell`
+- **THEN** stdout contains a PowerShell registration script
+- **AND** the script registers completion for the `chc` command
+- **AND** the script calls `chc __complete` to retrieve candidates
+
+#### Scenario: zsh completion script
+- **WHEN** a user runs `chc completion zsh`
+- **THEN** stdout contains a zsh completion function
+- **AND** the script registers completion for the `chc` command
+- **AND** the script calls `chc __complete` to retrieve candidates
+
+#### Scenario: Unsupported shell
+- **WHEN** a user runs `chc completion fish`
+- **THEN** the command fails with a clear unsupported shell error
+- **AND** it exits non-zero
+
+#### Scenario: Completion lifecycle child dispatch
+- **WHEN** a user runs `chc completion enable <shell>`, `chc completion disable <shell>`, or `chc completion status <shell>`
+- **THEN** Citty dispatches through the corresponding registered child command
+- **AND** the child command validates the shell without parent-level `rawArgs` action parsing
+
+### Requirement: Command and flag candidates
+Completion SHALL derive public static command, nested operation, and flag candidates from the shared CLI registrations and Citty command definitions, while dynamic values use their registered discovery providers.
+
+#### Scenario: Root command candidates
+- **WHEN** a shell adapter requests completion for the root command position
+- **THEN** candidates include `codex`, `scripts`, `update`, and `completion`
+
+#### Scenario: Codex subcommand candidates
+- **WHEN** a shell adapter requests completion after `chc codex`
+- **THEN** candidates include `status`, `export`, `apply`, and `install`
+
+#### Scenario: Completion command candidates
+- **WHEN** a shell adapter requests completion after `chc completion`
+- **THEN** candidates include `powershell`, `zsh`, `enable`, `disable`, and `status`
+- **AND** those candidates derive from the registered public completion child commands rather than an independently maintained action list
+
+#### Scenario: Managed completion shell candidates
+- **WHEN** a shell adapter requests completion after `chc completion enable`
+- **THEN** candidates include `powershell` and `zsh`
+- **AND** candidates derive from the same supported-shell definition used for command validation
+
+#### Scenario: Shared flag candidates
+- **WHEN** a shell adapter requests flag completion for a command that accepts the shared CLI contract flags
+- **THEN** candidates include `--json`, `--no-interactive`, and `--quiet`
+
+#### Scenario: Command-specific flag candidates
+- **WHEN** a shell adapter requests flag completion for `chc codex status --`
+- **THEN** candidates include command-specific flags such as `--repo-root`, `--codex-home`, and `--plugins-root`
+
+#### Scenario: Already used flags are not repeated
+- **WHEN** a shell adapter requests flag completion after `chc codex status --json --`
+- **THEN** `--json` is not returned again

--- a/openspec/changes/archive/2026-07-13-apps-cli-command-discovery/tasks.md
+++ b/openspec/changes/archive/2026-07-13-apps-cli-command-discovery/tasks.md
@@ -1,0 +1,23 @@
+## 1. Shared Command Registration
+
+- [x] 1.1 Add a thin command registration model for Citty definitions, public/compat/internal visibility, and help/run bare behavior, then construct the root command tree from those registrations.
+- [x] 1.2 Make root help, root completion, and bare-command routing consume registration metadata; remove command-name visibility filters and the omitted-command whitelist.
+- [x] 1.3 Add invariant tests proving public static operations agree across dispatch, help, and completion while compatibility and internal operations remain callable but hidden.
+
+## 2. Completion Command Tree
+
+- [x] 2.1 Centralize supported completion shells and their adapter renderers so validation, help, and completion candidates share one definition.
+- [x] 2.2 Refactor `completion` into real `powershell`, `zsh`, `enable`, `disable`, and `status` child commands and remove parent-level lifecycle `rawArgs` parsing.
+- [x] 2.3 Update completion integration tests to cover bare group help, child dispatch, derived candidates, unsupported shells, and unchanged adapter/profile behavior.
+
+## 3. Bundled Script Discovery
+
+- [x] 3.1 Add shared bounded catalog rendering, `scripts list` human/JSON output, and reserved-id validation for static `list` and `run` operations.
+- [x] 3.2 Add the canonical `scripts run <id>` flow and interactive missing-id behavior while retaining `scripts <id>` and `scripts --script <id>` compatibility routing through the same runner.
+- [x] 3.3 Render dynamic `AVAILABLE SCRIPTS` group help and make help, list, completion, selection, and execution consume the same discovery provider; add consistency and failure-path tests.
+
+## 4. Documentation and Verification
+
+- [x] 4.1 Update root, CLI, and docs-site command documentation with the canonical completion tree, `scripts list`, `scripts run`, available-script help, and preserved shorthand forms.
+- [x] 4.2 Refresh the committed CLI runtime bundle and confirm generated `.claude/`, `.codex/`, and `.cursor/` adapters remain unchanged.
+- [x] 4.3 Run CLI formatting/lint, type checking, full CLI tests, committed-bundle verification, docs build, OpenSpec strict validation, and command help/completion smoke tests.

--- a/openspec/changes/archive/2026-07-13-apps-cli-update-experience/.openspec.yaml
+++ b/openspec/changes/archive/2026-07-13-apps-cli-update-experience/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-13

--- a/openspec/changes/archive/2026-07-13-apps-cli-update-experience/design.md
+++ b/openspec/changes/archive/2026-07-13-apps-cli-update-experience/design.md
@@ -1,0 +1,95 @@
+## Context
+
+The current update path combines option resolution, Git mutation, committed-bundle verification, global installation, and human rendering in one linear operation. It records a step before each command but does not know whether the target differs from the current checkout, whether the checkout is safe to mutate, or what user-facing state should be reported. Subprocess output is buffered until failure, and the final human state is always `updated`.
+
+The CLI already has shared JSON, quiet, non-interactive, diagnostics, and output contracts plus `@clack/prompts` for TTY rendering. The update mechanism must continue to run from the committed Node bundle on machines with Git, Node 24, and npm but without pnpm or Bun. Package version is currently not a useful update identity, so ref and commit remain authoritative.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Separate update inspection and planning from checkout and global-install mutation.
+- Make no-op, install, update, blocked, and failure states explicit and testable.
+- Preserve an efficient one-command managed update while protecting dirty or diverged checkouts.
+- Give TTY users live progress and all users concise current-to-target and recovery information.
+- Keep JSON deterministic, quiet mode quiet, diagnostics structured, and failure details bounded.
+
+**Non-Goals:**
+
+- Periodic, background, or shell-startup update checks.
+- Semantic-version release selection or a new release channel service.
+- Automatic stash, reset, clean, rebase, rollback, or repair of user Git state.
+- Changing the public repository, default ref, managed checkout location, committed bundle, or npm global-install mechanism.
+- Replacing Citty, the shared CLI context, or existing observability infrastructure.
+
+## Decisions
+
+- Introduce a domain-level update plan before apply.
+  - The plan carries a stable classification (`install_required`, `update_available`, `up_to_date`, or `blocked`), source configuration, optional before/target identities, change count, bounded commit subjects, and block reason.
+  - Existing checkout inspection checks Git availability, repository state, worktree cleanliness, current identity, target identity, and fast-forward safety before checkout-file or global-install mutation.
+  - Rationale: rendering and execution need the same factual state, and tests should not infer state from emitted step strings.
+  - Alternative considered: add prettier output around the existing linear runner. This would still reinstall no-op updates and discover unsafe checkout state only after mutations begin.
+
+- Keep `chc update` direct for a safe managed checkout.
+  - An explicit update command is sufficient user intent; it does not ask for a second confirmation in the normal path.
+  - Dirty or diverged checkouts are blocked rather than prompting to overwrite, stash, reset, or rebase.
+  - Rationale: this preserves fast manual updates while placing friction only where user work is at risk.
+  - Alternative considered: confirm every update. This adds ceremony, complicates automation, and does not improve safety for clean managed state.
+
+- Add `--check` as a mode of the existing update command.
+  - Check mode resolves remote availability and returns a plan without cloning, checking out, pulling, verifying for installation, or invoking npm.
+  - Remote branch and tag identities should be queried without changing checkout files; unsupported or unreachable targets fail with bounded check-phase context.
+  - Rationale: a flag preserves `chc update` as the simple lifecycle entry point and avoids turning it into another command group.
+  - Alternative considered: `chc update check` and `chc update apply`. This is structurally explicit but makes the common action more verbose and introduces compatibility routing for little benefit.
+
+- Treat commit identity as the update comparison key.
+  - The plan compares the current checkout commit with the resolved branch, tag, or commit target.
+  - For branch targets, the updater verifies that the current commit can fast-forward to the target before apply.
+  - Equal commits return `up_to_date` and skip checkout, bundle verification for installation, and global npm installation.
+  - Rationale: the repository package version is currently static and cannot distinguish builds reliably.
+
+- Replace step callbacks with structured update events and results.
+  - Stable phases are `preflight`, `check_remote`, `clone` or `fetch`, `checkout`, `verify_bundle`, and `install_global`.
+  - Events distinguish phase start, phase completion, state discovery, and failure; results distinguish `installed`, `updated`, and `up_to_date`.
+  - The default change summary contains at most five commit subjects, each bounded in length, and reports an omitted count. JSON uses the same bounded data.
+  - Rationale: renderers and diagnostics can share lifecycle facts without parsing prose.
+
+- Use mode-specific renderers over the same event stream.
+  - Interactive human mode uses existing TTY-capable prompt primitives for one active phase and completed checkmarks.
+  - Non-TTY human mode writes stable plain lines without cursor controls.
+  - Quiet mode suppresses source detail, progress, and changelog while preserving errors.
+  - JSON mode emits no human progress and writes exactly one final value.
+  - `--verbose` adds bounded command and subprocess details to human stderr and diagnostics but never to JSON stdout.
+  - Rationale: output mode is a presentation concern and must not change update decisions.
+
+- Introduce typed phase failures while preserving the public error code.
+  - Internal update failures carry phase, concise summary, bounded safe cause, recovery hint, and optional command metadata.
+  - The command boundary continues returning `update_failed`; default human rendering omits raw cwd and full subprocess output, while verbose and diagnostics may expose bounded non-secret details.
+  - Rationale: stable automation behavior and useful human recovery are both required.
+
+- Keep install and update execution on the current mechanism.
+  - Missing checkouts clone, existing safe checkouts fetch and fast-forward or check out the selected immutable ref, selected output verifies `apps/cli/dist/index.js`, and npm installs the repository root globally with `--ignore-scripts`.
+  - Rationale: this change improves planning and experience rather than replacing distribution.
+
+## Risks / Trade-offs
+
+- [Risk] Remote identity resolution differs for branches, annotated tags, lightweight tags, and raw commits. → Normalize targets to peeled commit ids and cover each ref type with dependency-injected Git command tests.
+- [Risk] A worktree can change after preflight but before checkout. → Recheck cleanliness immediately before the first checkout mutation and fail closed.
+- [Risk] TTY progress can corrupt captured or piped output. → Gate cursor-based rendering on output TTY and use a plain renderer otherwise.
+- [Risk] Verbose subprocess output can be large or contain sensitive values. → Bound line count and length, redact configured repository credentials, and keep raw environment values out of events.
+- [Risk] Skipping global installation on equal commits could miss a manually removed or broken global link. → Treat repair as explicit future behavior; users can reinstall through the installer, while `chc status` remains the diagnostic path.
+- [Trade-off] Blocking dirty custom checkouts makes some developer workflows less automatic. This is preferable to silently stashing or overwriting user work.
+
+## Migration Plan
+
+1. Add update plan, identity, state, event, and typed failure models behind the existing command API.
+2. Add preflight and check-mode Git operations with unit coverage before changing apply routing.
+3. Route apply through the plan, add no-op and safety behavior, then add mode-specific rendering.
+4. Extend JSON additively while retaining `ok`, `command`, result source fields, and `update_failed`.
+5. Update integration tests, documentation, and the committed CLI bundle.
+
+Rollback is code-only: the previous linear runner and coarse renderer can be restored without migrating persisted user data. Managed checkouts and global installation layout do not change.
+
+## Open Questions
+
+- None. The safety, direct-update, output-mode, and scope boundaries are defined above.

--- a/openspec/changes/archive/2026-07-13-apps-cli-update-experience/proposal.md
+++ b/openspec/changes/archive/2026-07-13-apps-cli-update-experience/proposal.md
@@ -1,0 +1,32 @@
+## Why
+
+`chc update` currently starts mutating the managed checkout immediately and reports only raw configuration, coarse step names, and a generic `updated` result. Users cannot tell whether an update exists, what changed, whether a long-running step is still active, or how to recover safely from a blocked or failed update.
+
+## What Changes
+
+- Add an update preflight model that resolves the source, inspects checkout safety, identifies current and target commits, and classifies install, update, no-op, blocked, and failed states before global installation.
+- Keep an explicit, safe managed `chc update` direct—without a redundant confirmation—but stop before mutation when the checkout is dirty or cannot fast-forward safely.
+- Add a read-only `chc update --check` path for update availability without changing the checkout or global installation.
+- Skip checkout and `npm install -g` when the selected ref is already current.
+- Replace coarse human output with TTY-aware progress, concise non-TTY output, current-to-target summaries, bounded commit highlights, and actionable phase-specific failures.
+- Add command-specific verbose output while preserving shared `--quiet`, `--no-interactive`, and single-value `--json` contracts.
+- Extend machine-readable update results with stable status, before/after identities, change counts, completed phases, and bounded failure context.
+- Update CLI documentation and tests for check, install, update, already-current, blocked, failure, JSON, quiet, verbose, and TTY/non-TTY paths.
+- Do not add periodic or shell-startup automatic update checks in this change.
+
+## Capabilities
+
+### New Capabilities
+
+- `apps-cli-update-experience`: Defines update availability checks, preflight safety, state classification, adaptive human output, result summaries, and phase-specific recovery guidance.
+
+### Modified Capabilities
+
+- `apps-cli-self-installation`: Changes managed update execution to detect no-op updates, avoid unnecessary global reinstall, and refuse unsafe checkout mutation before applying an update.
+
+## Impact
+
+- `apps/cli` self-update command, manager, subprocess execution, output rendering, diagnostics, unit tests, integration tests, and committed runtime bundle.
+- Root, CLI package, and docs-site lifecycle documentation.
+- Existing `chc update`, override flags, `update_failed` error code, committed-bundle verification, and global install mechanism remain supported.
+- No background service, shell startup hook, remote API, or new runtime dependency is introduced.

--- a/openspec/changes/archive/2026-07-13-apps-cli-update-experience/specs/apps-cli-self-installation/spec.md
+++ b/openspec/changes/archive/2026-07-13-apps-cli-update-experience/specs/apps-cli-self-installation/spec.md
@@ -1,0 +1,92 @@
+## ADDED Requirements
+
+### Requirement: Managed Update Safety
+Managed checkout updates SHALL preserve local work and SHALL complete safety checks before mutating checkout files or reinstalling the global command.
+
+#### Scenario: Local changes remain untouched
+- **WHEN** the selected update checkout contains tracked or untracked changes
+- **THEN** the update fails before changing the remote URL, checking out a ref, pulling, or globally installing the package
+- **AND** it does not automatically stash, reset, clean, or overwrite those changes
+
+#### Scenario: Diverged branch remains untouched
+- **WHEN** an existing selected branch has diverged from its resolved remote branch
+- **THEN** the update fails before checkout or global installation
+- **AND** it does not reset or rebase the branch
+
+## MODIFIED Requirements
+
+### Requirement: CLI Lifecycle Commands
+The CLI SHALL provide top-level lifecycle entry points for viewing the installed CLI version, inspecting installation state, and updating the global `chc` installation from committed prebuilt output. The discoverable interface SHALL use `chc --version` for version-only output and `chc status` for installation diagnostics, while retaining `chc version` as an undiscoverable compatibility alias.
+
+#### Scenario: Version flag
+- **WHEN** a user runs `chc --version`
+- **THEN** stdout reports the current `chc` CLI version
+- **AND** the command exits successfully without inspecting Git installation state
+
+#### Scenario: Legacy version command
+- **WHEN** a user runs `chc version`
+- **THEN** stdout reports the current `chc` CLI version using the existing output contract
+- **AND** the command exits successfully
+
+#### Scenario: Legacy version JSON command
+- **WHEN** a user runs `chc version --json`
+- **THEN** stdout reports the existing machine-readable version response
+- **AND** the command exits successfully
+
+#### Scenario: Consolidated command discovery
+- **WHEN** a user views top-level help or requests top-level shell completion candidates
+- **THEN** the discoverable lifecycle commands include `status` and `update`
+- **AND** the legacy `version` subcommand is not listed
+
+#### Scenario: Status command
+- **WHEN** a user runs `chc status`
+- **THEN** stdout reports CLI installation state including version, installation mode, actual source checkout directory, repository URL, ref, commit when available, and committed bundle presence
+
+#### Scenario: Local checkout status detection
+- **WHEN** the globally installed CLI resolves to a local checkout outside the default managed source directory
+- **THEN** `chc status` reports `mode: local`
+- **AND** it inspects that checkout for repository, ref, commit, and bundle state
+
+#### Scenario: Remote managed status detection
+- **WHEN** the globally installed CLI resolves to the default managed source directory
+- **THEN** `chc status` reports `mode: remote`
+- **AND** it inspects the managed checkout for repository, ref, commit, and bundle state
+
+#### Scenario: Explicit status directory override
+- **WHEN** a user runs `chc status --install-dir <path>`
+- **THEN** status inspects the requested directory instead of the automatically detected source checkout
+
+#### Scenario: Executable CLI bin shim
+- **WHEN** the root package is installed globally on a Unix-like target
+- **THEN** the committed `apps/cli/bin/chc.mjs` entrypoint has executable permission
+- **AND** the installed `chc` command can invoke it directly
+
+#### Scenario: Default update with available changes
+- **WHEN** a user runs `chc update` and the default repository `main` ref differs from the safe managed checkout
+- **THEN** the command updates the managed checkout to the resolved target
+- **AND** verifies the committed CLI bundle is present
+- **AND** reinstalls the root package globally without running dependency installation or CLI build commands
+
+#### Scenario: Default update already current
+- **WHEN** a user runs `chc update` and the safe managed checkout already matches the resolved target
+- **THEN** the command exits successfully as already current
+- **AND** does not check out files or reinstall the root package globally
+
+#### Scenario: Update availability check
+- **WHEN** a user runs `chc update --check`
+- **THEN** the command reports whether installation or an update is required
+- **AND** does not clone, check out, pull, or globally install the package
+
+#### Scenario: Update overrides
+- **WHEN** a user runs `chc update --repo <url> --ref <ref> --install-dir <path>`
+- **THEN** the command uses the provided repository URL, Git ref, and checkout directory
+- **AND** applies the same preflight safety and no-op detection as the default managed update
+
+#### Scenario: Update JSON success
+- **WHEN** a user runs `chc update --json` and the update succeeds or is already current
+- **THEN** stdout contains exactly one JSON object with `ok: true`, `command: "update"`, and structured result status and identity details
+
+#### Scenario: Update failure
+- **WHEN** preflight safety, Git, committed-bundle verification, or global install fails during `chc update`
+- **THEN** the command exits non-zero
+- **AND** reports an `update_failed` command error with the failed phase and bounded recovery context

--- a/openspec/changes/archive/2026-07-13-apps-cli-update-experience/specs/apps-cli-update-experience/spec.md
+++ b/openspec/changes/archive/2026-07-13-apps-cli-update-experience/specs/apps-cli-update-experience/spec.md
@@ -1,0 +1,122 @@
+## ADDED Requirements
+
+### Requirement: Update Preflight Classification
+The CLI SHALL inspect the selected update source and classify the intended operation before changing the checkout worktree or global installation.
+
+#### Scenario: Managed install required
+- **WHEN** the selected managed install directory has no Git checkout
+- **THEN** preflight classifies the operation as `install_required`
+- **AND** identifies the selected repository, ref, and install directory
+
+#### Scenario: Update available
+- **WHEN** the selected checkout is safe to update and its current commit differs from the resolved target commit
+- **THEN** preflight classifies the operation as `update_available`
+- **AND** reports the current and target commit identities and bounded change count when available
+
+#### Scenario: Already current
+- **WHEN** the selected checkout already resolves to the target commit
+- **THEN** preflight classifies the operation as `up_to_date`
+- **AND** the update command exits successfully without checking out files or reinstalling the global command
+
+#### Scenario: Dirty checkout is blocked
+- **WHEN** an existing selected checkout has tracked or untracked worktree changes
+- **THEN** preflight classifies the operation as `blocked`
+- **AND** reports that the user must preserve or remove the local changes before retrying
+- **AND** does not change the remote URL, checkout, or global installation
+
+#### Scenario: Non-fast-forward branch is blocked
+- **WHEN** the current branch cannot safely fast-forward to the resolved remote branch target
+- **THEN** preflight classifies the operation as `blocked`
+- **AND** does not rewrite, reset, or automatically stash the checkout
+
+### Requirement: Read-only Update Availability Check
+The CLI SHALL provide `chc update --check` to report update availability without changing checkout files or the global installation.
+
+#### Scenario: Check reports available update
+- **WHEN** a user runs `chc update --check` and the selected target differs from the installed source commit
+- **THEN** the command reports `update_available`
+- **AND** exits successfully without checkout or global install phases
+
+#### Scenario: Check reports current installation
+- **WHEN** a user runs `chc update --check` and the selected target matches the installed source commit
+- **THEN** the command reports `up_to_date`
+- **AND** exits successfully
+
+#### Scenario: Check reports missing managed installation
+- **WHEN** a user runs `chc update --check` and the selected managed checkout is absent
+- **THEN** the command reports `install_required`
+- **AND** does not clone the repository
+
+### Requirement: Adaptive Human Update Output
+The CLI SHALL render update progress and results according to TTY, quiet, and verbose modes while keeping explicit safe updates direct.
+
+#### Scenario: Interactive safe update
+- **WHEN** a user runs `chc update` in an interactive TTY for a safe managed checkout with an available update
+- **THEN** the command proceeds without a redundant confirmation prompt
+- **AND** presents active and completed phases using TTY-safe progress rendering
+- **AND** finishes with a current-to-target summary
+
+#### Scenario: Non-TTY update output
+- **WHEN** human update output is written without a TTY
+- **THEN** the command writes stable plain lines without cursor control sequences or animation
+
+#### Scenario: Already-current human output
+- **WHEN** a human update invocation is already current
+- **THEN** the command clearly states that `chc` is already up to date
+- **AND** identifies the selected ref and commit when available
+
+#### Scenario: Bounded change highlights
+- **WHEN** an update contains one or more commits
+- **THEN** default human output presents a bounded list of commit subjects
+- **AND** identifies when additional commits were omitted
+
+#### Scenario: Quiet update output
+- **WHEN** a user runs an update with `--quiet`
+- **THEN** nonessential source details, progress, and change highlights are suppressed
+- **AND** errors remain visible
+
+#### Scenario: Verbose update output
+- **WHEN** a user runs an update with `--verbose`
+- **THEN** the command includes bounded subprocess command and output details for diagnosis
+- **AND** does not expose secrets or corrupt JSON stdout
+
+### Requirement: Structured Update Results
+The CLI SHALL expose stable machine-readable update states and identities while preserving the single-value JSON stdout contract.
+
+#### Scenario: JSON update applied
+- **WHEN** `chc update --json` applies an available update
+- **THEN** stdout contains exactly one success JSON object with `command: "update"`
+- **AND** its result includes `status: "updated"`, before and after identities, completed phases, and bounded change metadata
+
+#### Scenario: JSON already current
+- **WHEN** `chc update --json` finds no change to apply
+- **THEN** stdout contains exactly one success JSON object with `status: "up_to_date"`
+- **AND** no human progress is written to stdout
+
+#### Scenario: JSON initial managed install
+- **WHEN** `chc update --json` creates a previously absent managed checkout and installs the command
+- **THEN** the result includes `status: "installed"` and the installed target identity
+
+#### Scenario: JSON availability check
+- **WHEN** `chc update --check --json` completes
+- **THEN** stdout contains exactly one success JSON object whose result status is `install_required`, `update_available`, or `up_to_date`
+- **AND** no apply-only phase is reported as completed
+
+### Requirement: Actionable Update Failures
+The CLI SHALL report update failures by stable phase with a concise summary, bounded cause, and recovery hint while retaining the `update_failed` command error code.
+
+#### Scenario: Preflight failure
+- **WHEN** update prerequisites or checkout safety checks fail
+- **THEN** the command identifies the preflight phase and the blocked resource or condition
+- **AND** no global installation is attempted
+
+#### Scenario: Apply phase failure
+- **WHEN** clone, fetch, checkout, bundle verification, or global installation fails
+- **THEN** the command identifies the failed phase
+- **AND** provides a recovery hint appropriate to that phase
+- **AND** exits non-zero with error code `update_failed`
+
+#### Scenario: Default failure detail is bounded
+- **WHEN** a subprocess produces lengthy output during a failed update
+- **THEN** default human and JSON errors include only bounded safe context
+- **AND** direct command, cwd, and expanded output details are reserved for verbose output or diagnostics

--- a/openspec/changes/archive/2026-07-13-apps-cli-update-experience/tasks.md
+++ b/openspec/changes/archive/2026-07-13-apps-cli-update-experience/tasks.md
@@ -1,0 +1,25 @@
+## 1. Update Planning Model
+
+- [x] 1.1 Add stable update identity, plan classification, apply result, phase event, bounded change-summary, and typed phase-failure models to the self-update domain.
+- [x] 1.2 Implement preflight resolution for absent, current, update-available, dirty, and diverged checkout states without changing checkout files or the global installation.
+- [x] 1.3 Add dependency-injected unit tests for branch, annotated/lightweight tag, raw commit, missing checkout, dirty checkout, diverged branch, equal target, and available target planning.
+
+## 2. Check and Apply Execution
+
+- [x] 2.1 Add the `chc update --check` command path and prove it performs no clone, checkout, pull, bundle-install verification, or npm global installation.
+- [x] 2.2 Route `chc update` through its plan, recheck checkout safety before mutation, skip all apply phases when current, and preserve clone/fetch/checkout/bundle/global-install behavior when work is required.
+- [x] 2.3 Replace raw update failures with phase-aware `update_failed` errors containing concise summaries, bounded safe causes, recovery hints, and optional verbose command context.
+- [x] 2.4 Extend self-update unit tests to verify installed, updated, up-to-date, blocked, phase-failure, no-op, and time-of-check/time-of-use safety behavior and exact subprocess ordering.
+
+## 3. User-Facing Output Contracts
+
+- [x] 3.1 Implement shared update event rendering for interactive TTY progress and stable non-TTY lines, including source identity, current-to-target summary, and at most five bounded commit highlights.
+- [x] 3.2 Add command-specific `--verbose` rendering and preserve quiet suppression, non-interactive prompt suppression, diagnostics separation, redaction, and single-value JSON stdout.
+- [x] 3.3 Extend structured JSON results with stable check/apply status, before/target/after identities, completed phases, and bounded change or failure metadata.
+- [x] 3.4 Add integration tests for TTY and non-TTY check, install, update, already-current, dirty/diverged block, quiet, verbose, JSON success/error, and actionable human failure output.
+
+## 4. Documentation and Verification
+
+- [x] 4.1 Update root, CLI package, and docs-site lifecycle documentation for direct safe updates, `--check`, already-current behavior, commit summaries, safety blocks, quiet/verbose/JSON modes, and the absence of automatic background checks.
+- [x] 4.2 Refresh the committed CLI runtime bundle and confirm generated `.claude/`, `.codex/`, and `.cursor/` adapters remain unchanged.
+- [x] 4.3 Run CLI formatting/lint, type checking, full CLI tests, committed-bundle verification, docs build, OpenSpec strict validation, and source/committed-bundle update help and non-mutating check smoke tests.

--- a/openspec/changes/archive/2026-07-13-consolidate-cli-version-status/.openspec.yaml
+++ b/openspec/changes/archive/2026-07-13-consolidate-cli-version-status/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-13

--- a/openspec/changes/archive/2026-07-13-consolidate-cli-version-status/design.md
+++ b/openspec/changes/archive/2026-07-13-consolidate-cli-version-status/design.md
@@ -1,0 +1,43 @@
+## Context
+
+The root CLI currently registers `version` and `status` as visible sibling commands. `version` reads only the package version, while `status` includes that version and inspects the source checkout with optional Git subprocesses. The CLI also implements the conventional `--version` fast path. The overlap is therefore in the discoverable command surface, not in the underlying workloads.
+
+Compatibility matters because `chc version` supports both human output and the shared `--json` contract. The command framework derives help and completion from the same root command tree used for dispatch, so the legacy command must remain dispatchable while being filtered from discovery surfaces.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Present `chc --version`, `chc status`, and `chc update` as the canonical lifecycle interface.
+- Preserve current `chc version` behavior for existing users and scripts.
+- Keep the lightweight version path independent of status checkout inspection.
+- Align help, completion, tests, and documentation with the consolidated interface.
+
+**Non-Goals:**
+
+- Merge status diagnostics into version output.
+- Change status fields, Git inspection, JSON schemas, or exit codes.
+- Remove the legacy `chc version` parser entry in this change.
+- Introduce a nested lifecycle command group.
+
+## Decisions
+
+- Keep `versionCommand` registered for dispatch but treat it as a hidden compatibility alias.
+  - Rationale: this preserves human and JSON contracts without requiring a migration deadline.
+  - Alternative considered: remove the command immediately. That simplifies registration but needlessly breaks callers.
+
+- Filter the legacy alias at the help-rendering and completion-candidate boundaries.
+  - Rationale: these are the two discovery surfaces that define the visible command interface, while dispatch remains unchanged.
+  - Alternative considered: special-case raw arguments before command dispatch. That would duplicate argument parsing and risk losing shared flags such as `--json`.
+
+- Keep `chc --version` as a direct lightweight fast path and keep version included in `chc status`.
+  - Rationale: scripts expect a cheap standard version check, whereas status is intentionally a richer diagnostic that can spawn Git commands.
+  - Alternative considered: make version invoke status. That would make version checks slower and change both human and JSON output contracts.
+
+- Update normative specs and user-facing examples to name only canonical entry points, while explicitly specifying legacy compatibility.
+
+## Risks / Trade-offs
+
+- [Risk] A future help-rendering change could expose `version` again. → Keep an integration assertion that top-level help omits the alias.
+- [Risk] Completion and help could diverge. → Test both discovery surfaces against the same expected canonical command set.
+- [Risk] Users may assume the hidden alias is removed. → Preserve explicit compatibility tests for plain and JSON invocation.

--- a/openspec/changes/archive/2026-07-13-consolidate-cli-version-status/proposal.md
+++ b/openspec/changes/archive/2026-07-13-consolidate-cli-version-status/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+`chc version` and `chc status` currently overlap because installation status already includes the CLI version, while the standard `chc --version` flag provides the lightweight version-only behavior users and scripts expect. Consolidating the documented command surface makes CLI lifecycle commands easier to understand without removing compatibility for existing `chc version` callers.
+
+## What Changes
+
+- Make `chc --version` the documented, completion-visible version-only entry point.
+- Keep `chc status` as the documented installation diagnostic command, including the installed CLI version.
+- Retain `chc version` as an undocumented compatibility alias with its existing human and JSON output contracts.
+- Remove `chc version` from top-level help, shell completion candidates, and user-facing lifecycle examples.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `apps-cli-self-installation`: Consolidate the visible version and installation-status command surface while preserving the legacy version subcommand as a compatibility alias.
+- `apps-docs-site`: Document `chc --version` and `chc status` as the canonical inspection entry points.
+
+## Impact
+
+- CLI command registration, help rendering, and completion candidate generation under `apps/cli`.
+- CLI integration and completion tests.
+- Root, package-local, and docs-site CLI documentation.
+- Existing `chc version` invocations continue to work, so the change is not breaking.

--- a/openspec/changes/archive/2026-07-13-consolidate-cli-version-status/specs/apps-cli-self-installation/spec.md
+++ b/openspec/changes/archive/2026-07-13-consolidate-cli-version-status/specs/apps-cli-self-installation/spec.md
@@ -1,0 +1,101 @@
+## MODIFIED Requirements
+
+### Requirement: CLI Lifecycle Commands
+The CLI SHALL provide top-level lifecycle entry points for viewing the installed CLI version, inspecting installation state, and updating the global `chc` installation from committed prebuilt output. The discoverable interface SHALL use `chc --version` for version-only output and `chc status` for installation diagnostics, while retaining `chc version` as an undiscoverable compatibility alias.
+
+#### Scenario: Version flag
+- **WHEN** a user runs `chc --version`
+- **THEN** stdout reports the current `chc` CLI version
+- **AND** the command exits successfully without inspecting Git installation state
+
+#### Scenario: Legacy version command
+- **WHEN** a user runs `chc version`
+- **THEN** stdout reports the current `chc` CLI version using the existing output contract
+- **AND** the command exits successfully
+
+#### Scenario: Legacy version JSON command
+- **WHEN** a user runs `chc version --json`
+- **THEN** stdout reports the existing machine-readable version response
+- **AND** the command exits successfully
+
+#### Scenario: Consolidated command discovery
+- **WHEN** a user views top-level help or requests top-level shell completion candidates
+- **THEN** the discoverable lifecycle commands include `status` and `update`
+- **AND** the legacy `version` subcommand is not listed
+
+#### Scenario: Status command
+- **WHEN** a user runs `chc status`
+- **THEN** stdout reports CLI installation state including version, installation mode, actual source checkout directory, repository URL, ref, commit when available, and committed bundle presence
+
+#### Scenario: Local checkout status detection
+- **WHEN** the globally installed CLI resolves to a local checkout outside the default managed source directory
+- **THEN** `chc status` reports `mode: local`
+- **AND** it inspects that checkout for repository, ref, commit, and bundle state
+
+#### Scenario: Remote managed status detection
+- **WHEN** the globally installed CLI resolves to the default managed source directory
+- **THEN** `chc status` reports `mode: remote`
+- **AND** it inspects the managed checkout for repository, ref, commit, and bundle state
+
+#### Scenario: Explicit status directory override
+- **WHEN** a user runs `chc status --install-dir <path>`
+- **THEN** status inspects the requested directory instead of the automatically detected source checkout
+
+#### Scenario: Executable CLI bin shim
+- **WHEN** the root package is installed globally on a Unix-like target
+- **THEN** the committed `apps/cli/bin/chc.mjs` entrypoint has executable permission
+- **AND** the installed `chc` command can invoke it directly
+
+#### Scenario: Default update
+- **WHEN** a user runs `chc update`
+- **THEN** the command uses the default repository, `main` ref, and managed checkout directory
+- **AND** it verifies the committed CLI bundle is present
+- **AND** it reinstalls the root package globally without running dependency installation or CLI build commands
+
+#### Scenario: Update overrides
+- **WHEN** a user runs `chc update --repo <url> --ref <ref> --install-dir <path>`
+- **THEN** the command uses the provided repository URL, Git ref, and checkout directory
+
+#### Scenario: Update JSON success
+- **WHEN** a user runs `chc update --json` and the update succeeds
+- **THEN** stdout contains exactly one JSON object with `ok: true`, `command: "update"`, and result details
+
+#### Scenario: Update failure
+- **WHEN** any Git, committed-bundle verification, or global install step fails during `chc update`
+- **THEN** the command exits non-zero
+- **AND** it reports an `update_failed` command error
+
+### Requirement: Installation Documentation
+The repository SHALL document the public and local CLI install flows, lightweight target prerequisites, committed runtime bundle, canonical lifecycle commands, and update path.
+
+#### Scenario: Public install documented
+- **WHEN** a user reads the root README
+- **THEN** it shows a `curl -fsSL https://raw.githubusercontent.com/mickmetalholic/CthuTool/main/scripts/install-chc.sh | bash` installation command
+- **AND** it explains that public raw installation uses the managed checkout
+- **AND** it explains automatic zsh completion setup and its opt-out
+
+#### Scenario: Local checkout install documented
+- **WHEN** a developer reads the CLI installation documentation
+- **THEN** it explains that running `scripts/install-chc.sh` from a local checkout installs global `chc` from that checkout
+- **AND** it shows the CLI watch build command needed for source-editing development
+
+#### Scenario: Remote restore documented
+- **WHEN** a developer reads the CLI installation documentation
+- **THEN** it shows how to force remote managed installation after a local checkout install
+
+#### Scenario: Lighter target prerequisites documented
+- **WHEN** a user reads the CLI installation documentation
+- **THEN** it explains that target machines need `git`, Node 24, and `npm`, but do not need `pnpm` or `bun` for install/update
+
+#### Scenario: Committed bundle documented
+- **WHEN** a developer reads the CLI installation documentation
+- **THEN** it explains that CLI source changes must refresh the committed `apps/cli/dist/index.js` bundle
+
+#### Scenario: Lifecycle commands documented
+- **WHEN** a user reads the CLI installation documentation
+- **THEN** it shows `chc --version`, `chc status`, and `chc update` as the canonical lifecycle entry points
+- **AND** it does not present `chc version` as a canonical command
+
+#### Scenario: Update documented
+- **WHEN** a user reads the CLI installation documentation
+- **THEN** it shows `chc update` as the update path after the first install

--- a/openspec/changes/archive/2026-07-13-consolidate-cli-version-status/specs/apps-docs-site/spec.md
+++ b/openspec/changes/archive/2026-07-13-consolidate-cli-version-status/specs/apps-docs-site/spec.md
@@ -1,0 +1,22 @@
+## MODIFIED Requirements
+
+### Requirement: Client installation documentation
+The docs site SHALL document how users install, inspect, update, and remove CthuTool client tools on client computers using the canonical CLI lifecycle interface.
+
+#### Scenario: Reader installs CLI tooling
+- **WHEN** a reader opens CLI installation documentation
+- **THEN** the documentation explains target-machine prerequisites, public raw installer usage, committed bundle runtime behavior, remote install mode, local checkout install mode, automatic zsh completion behavior, and supported override environment variables
+
+#### Scenario: Reader checks the installed CLI version
+- **WHEN** a reader needs only the installed CLI version
+- **THEN** the documentation presents `chc --version` as the canonical version-only entry point
+- **AND** it does not present the legacy `chc version` compatibility alias as a canonical command
+
+#### Scenario: Reader inspects installed CLI tooling
+- **WHEN** a reader needs to inspect CLI installation state
+- **THEN** the documentation explains that `chc status` includes the installed version and reports the detected local or remote source checkout
+- **AND** it documents the explicit install-directory override
+
+#### Scenario: Reader manages installed CLI tooling
+- **WHEN** a reader needs to update CLI tooling
+- **THEN** the documentation presents `chc update` as the update command

--- a/openspec/changes/archive/2026-07-13-consolidate-cli-version-status/tasks.md
+++ b/openspec/changes/archive/2026-07-13-consolidate-cli-version-status/tasks.md
@@ -1,0 +1,15 @@
+## 1. CLI Command Surface
+
+- [x] 1.1 Hide the legacy `version` subcommand from top-level help while preserving command dispatch and output contracts.
+- [x] 1.2 Exclude the legacy `version` subcommand from top-level completion candidates without affecting nested candidates.
+- [x] 1.3 Update CLI integration tests for canonical discovery and legacy compatibility behavior.
+
+## 2. Documentation
+
+- [x] 2.1 Replace canonical `chc version` examples with `chc --version` in root, package-local, and docs-site lifecycle documentation.
+- [x] 2.2 Document that `chc status` includes the installed version and remains the full installation diagnostic command.
+
+## 3. Generated Runtime and Verification
+
+- [x] 3.1 Refresh the committed CLI runtime bundle and confirm generated agent adapter files remain unchanged.
+- [x] 3.2 Run focused CLI tests, CLI type checking, committed-bundle verification, and OpenSpec validation.

--- a/openspec/specs/apps-cli-bundled-script-execution/spec.md
+++ b/openspec/specs/apps-cli-bundled-script-execution/spec.md
@@ -2,33 +2,37 @@
 
 ## Purpose
 Define how apps/cli discovers and invokes bundled scripts, forwards script arguments, preserves interactive selection, and exposes JSON-safe execution behavior.
-
 ## Requirements
-
 ### Requirement: Script Selection
-The `scripts` command SHALL resolve the target bundled script from either the positional script id or the `--script` flag.
+The `scripts` command group SHALL resolve the target bundled script through the canonical `run` operation or the existing positional and `--script` compatibility forms.
+
+#### Scenario: Canonical run command
+- **WHEN** the user runs `chc scripts run convert-to-cbz`
+- **THEN** the `scripts` command selects the bundled script with id `convert-to-cbz`
 
 #### Scenario: Positional script id
 - **WHEN** the user runs `chc scripts convert-to-cbz`
 - **THEN** the `scripts` command selects the bundled script with id `convert-to-cbz`
+- **AND** the compatibility form routes to the same runner used by `chc scripts run convert-to-cbz`
 
 #### Scenario: Script flag
 - **WHEN** the user runs `chc scripts --script convert-to-cbz`
 - **THEN** the `scripts` command selects the bundled script with id `convert-to-cbz`
+- **AND** the compatibility form routes to the same runner used by the canonical `run` operation
 
 #### Scenario: Unknown script id
 - **WHEN** the requested script id does not match a discovered script
 - **THEN** the command fails with an `unknown_selection` command error
 
 ### Requirement: Interactive Script Prompt
-The `scripts` command SHALL prompt for script selection only when no script id is provided and the shared context is interactive.
+The canonical `scripts run` operation SHALL prompt for script selection only when no script id is provided and the shared context is interactive.
 
 #### Scenario: Interactive selection
-- **WHEN** no script id is provided and the context is interactive
-- **THEN** the command shows the existing script selection prompt
+- **WHEN** a user runs `chc scripts run` without a script id and the context is interactive
+- **THEN** the command shows the existing script selection prompt using the shared discovered catalog
 
 #### Scenario: Non-interactive missing script id
-- **WHEN** no script id is provided and the context is non-interactive
+- **WHEN** a user runs `chc scripts run` without a script id and the context is non-interactive
 - **THEN** the command fails without prompting and sets a non-zero exit code
 
 ### Requirement: Bundled Script Invocation Contract
@@ -94,3 +98,27 @@ Bundled script execution SHALL emit safe lifecycle diagnostics through the share
 #### Scenario: Script diagnostics are cleaned up
 - **WHEN** a bundled script completes with zero work, succeeds after work, or fails with a deliberate command error
 - **THEN** progress loggers and diagnostics are flushed or stopped so the spawned CLI process can exit
+
+### Requirement: Bundled Script Catalog Discovery
+The `scripts` command group SHALL expose the discovered bundled-script catalog through group help and an explicit `list` operation using the same catalog used for completion, selection, and execution.
+
+#### Scenario: Bare scripts group help
+- **WHEN** a user runs `chc scripts` or `chc scripts --help`
+- **THEN** stdout presents the public `list` and `run` operations
+- **AND** includes an `AVAILABLE SCRIPTS` section with discovered script ids, titles, and descriptions
+- **AND** exits successfully without running a bundled script
+
+#### Scenario: Human script listing
+- **WHEN** a user runs `chc scripts list`
+- **THEN** stdout lists discovered script ids, titles, and descriptions
+- **AND** the listed entries come from the same catalog used by script execution
+
+#### Scenario: JSON script listing
+- **WHEN** a user runs `chc scripts list --json`
+- **THEN** stdout contains exactly one success JSON value with `command: "scripts list"` and bounded script metadata
+- **AND** no human catalog text is written to stdout
+
+#### Scenario: Reserved script operation ids
+- **WHEN** a bundled script manifest declares `list` or `run` as its script id
+- **THEN** discovery rejects or clearly warns about the reserved id
+- **AND** static group operations remain unambiguous

--- a/openspec/specs/apps-cli-command-discovery/spec.md
+++ b/openspec/specs/apps-cli-command-discovery/spec.md
@@ -1,0 +1,79 @@
+# apps-cli-command-discovery Specification
+
+## Purpose
+TBD - created by archiving change apps-cli-command-discovery. Update Purpose after archive.
+## Requirements
+### Requirement: Shared command registration
+The CLI SHALL maintain one registration model for static command dispatch, visibility, help discovery, completion discovery, and bare-command behavior.
+
+#### Scenario: Public command registration
+- **WHEN** a static command is registered as public
+- **THEN** the command is callable through the CLI dispatcher
+- **AND** it is eligible to appear in help and shell completion from the same registration
+
+#### Scenario: Compatibility command registration
+- **WHEN** a static command is registered as a compatibility command
+- **THEN** the command remains callable for existing users and scripts
+- **AND** it is omitted from public help and shell completion
+
+#### Scenario: Internal command registration
+- **WHEN** a static command is registered as internal
+- **THEN** the command remains callable by its internal protocol consumer
+- **AND** it is omitted from public help and shell completion
+
+### Requirement: Static command discovery consistency
+Public static commands and nested operations SHALL derive their help and completion presence from the same Citty command definitions and registration visibility.
+
+#### Scenario: Public static operation is discoverable
+- **WHEN** a public static operation is offered as a completion candidate at a command path
+- **THEN** the parent command help identifies the same operation
+
+#### Scenario: Static operation is removed
+- **WHEN** a public static operation is removed from its parent command definition
+- **THEN** it no longer appears in dispatch, help, or completion without requiring a separate candidate-list edit
+
+#### Scenario: Hidden operation stays hidden
+- **WHEN** an internal or compatibility operation exists in the dispatch tree
+- **THEN** help and completion omit it according to its registration visibility
+
+### Requirement: Bare command behavior
+Each registered top-level command SHALL declare whether a bare invocation renders help or runs its command handler.
+
+#### Scenario: Bare command group renders help
+- **WHEN** a user invokes a public command group whose bare behavior is `help`
+- **THEN** the CLI renders the same group help used by the explicit `--help` form
+- **AND** exits successfully without running a child operation
+
+#### Scenario: Bare runnable command reaches its handler
+- **WHEN** a user invokes a command whose bare behavior is `run`
+- **THEN** the CLI reaches that command's normal validation or interactive behavior
+- **AND** the entrypoint does not replace execution with a name-based help shortcut
+
+### Requirement: Dynamic discovery provider
+A command with dynamic targets SHALL use one discovery provider to supply human help, listing, shell completion, selection, and execution resolution.
+
+#### Scenario: Dynamic targets remain consistent
+- **WHEN** dynamic target discovery succeeds
+- **THEN** help, explicit listing, completion, and execution resolution use the same discovered target ids and metadata
+
+#### Scenario: Dynamic discovery fails during completion
+- **WHEN** the discovery provider fails while serving the internal completion protocol
+- **THEN** completion returns no dynamic candidates
+- **AND** it does not emit interactive prompts or noisy diagnostics
+
+#### Scenario: Dynamic discovery warns in human output
+- **WHEN** discovery returns valid targets together with bounded warnings
+- **THEN** human help or listing shows the valid targets
+- **AND** reports actionable warnings without preventing valid targets from being used
+
+### Requirement: Command discovery invariant tests
+The CLI SHALL verify command-discovery consistency through automated tests rather than relying only on fixed output snapshots.
+
+#### Scenario: Help and completion invariant
+- **WHEN** the registered public static command tree is tested
+- **THEN** every public static completion operation is represented by its parent help
+- **AND** internal and compatibility operations are absent from both discovery surfaces
+
+#### Scenario: Documented compatibility forms
+- **WHEN** compatibility command forms are tested
+- **THEN** they continue to dispatch successfully without becoming public discovery entries

--- a/openspec/specs/apps-cli-self-installation/spec.md
+++ b/openspec/specs/apps-cli-self-installation/spec.md
@@ -87,16 +87,27 @@ Remote managed install and update flows SHALL use a managed source checkout cont
 - **THEN** the install flow fails before global installation with a clear missing-bundle message
 
 ### Requirement: CLI Lifecycle Commands
-The CLI SHALL provide top-level lifecycle commands for viewing the installed CLI version, inspecting installation state, and updating the global `chc` installation from committed prebuilt output.
-
-#### Scenario: Version command
-- **WHEN** a user runs `chc version`
-- **THEN** stdout reports the current `chc` CLI version
+The CLI SHALL provide top-level lifecycle entry points for viewing the installed CLI version, inspecting installation state, and updating the global `chc` installation from committed prebuilt output. The discoverable interface SHALL use `chc --version` for version-only output and `chc status` for installation diagnostics, while retaining `chc version` as an undiscoverable compatibility alias.
 
 #### Scenario: Version flag
 - **WHEN** a user runs `chc --version`
 - **THEN** stdout reports the current `chc` CLI version
+- **AND** the command exits successfully without inspecting Git installation state
+
+#### Scenario: Legacy version command
+- **WHEN** a user runs `chc version`
+- **THEN** stdout reports the current `chc` CLI version using the existing output contract
 - **AND** the command exits successfully
+
+#### Scenario: Legacy version JSON command
+- **WHEN** a user runs `chc version --json`
+- **THEN** stdout reports the existing machine-readable version response
+- **AND** the command exits successfully
+
+#### Scenario: Consolidated command discovery
+- **WHEN** a user views top-level help or requests top-level shell completion candidates
+- **THEN** the discoverable lifecycle commands include `status` and `update`
+- **AND** the legacy `version` subcommand is not listed
 
 #### Scenario: Status command
 - **WHEN** a user runs `chc status`
@@ -121,27 +132,38 @@ The CLI SHALL provide top-level lifecycle commands for viewing the installed CLI
 - **THEN** the committed `apps/cli/bin/chc.mjs` entrypoint has executable permission
 - **AND** the installed `chc` command can invoke it directly
 
-#### Scenario: Default update
-- **WHEN** a user runs `chc update`
-- **THEN** the command uses the default repository, `main` ref, and managed checkout directory
-- **AND** it verifies the committed CLI bundle is present
-- **AND** it reinstalls the root package globally without running dependency installation or CLI build commands
+#### Scenario: Default update with available changes
+- **WHEN** a user runs `chc update` and the default repository `main` ref differs from the safe managed checkout
+- **THEN** the command updates the managed checkout to the resolved target
+- **AND** verifies the committed CLI bundle is present
+- **AND** reinstalls the root package globally without running dependency installation or CLI build commands
+
+#### Scenario: Default update already current
+- **WHEN** a user runs `chc update` and the safe managed checkout already matches the resolved target
+- **THEN** the command exits successfully as already current
+- **AND** does not check out files or reinstall the root package globally
+
+#### Scenario: Update availability check
+- **WHEN** a user runs `chc update --check`
+- **THEN** the command reports whether installation or an update is required
+- **AND** does not clone, check out, pull, or globally install the package
 
 #### Scenario: Update overrides
 - **WHEN** a user runs `chc update --repo <url> --ref <ref> --install-dir <path>`
 - **THEN** the command uses the provided repository URL, Git ref, and checkout directory
+- **AND** applies the same preflight safety and no-op detection as the default managed update
 
 #### Scenario: Update JSON success
-- **WHEN** a user runs `chc update --json` and the update succeeds
-- **THEN** stdout contains exactly one JSON object with `ok: true`, `command: "update"`, and result details
+- **WHEN** a user runs `chc update --json` and the update succeeds or is already current
+- **THEN** stdout contains exactly one JSON object with `ok: true`, `command: "update"`, and structured result status and identity details
 
 #### Scenario: Update failure
-- **WHEN** any Git, committed-bundle verification, or global install step fails during `chc update`
+- **WHEN** preflight safety, Git, committed-bundle verification, or global install fails during `chc update`
 - **THEN** the command exits non-zero
-- **AND** it reports an `update_failed` command error
+- **AND** reports an `update_failed` command error with the failed phase and bounded recovery context
 
 ### Requirement: Installation Documentation
-The repository documentation SHALL describe public GitHub installation, local checkout installation, prebuilt bundle expectations, lifecycle commands, and update usage.
+The repository SHALL document the public and local CLI install flows, lightweight target prerequisites, committed runtime bundle, canonical lifecycle commands, and update path.
 
 #### Scenario: Public install documented
 - **WHEN** a user reads the root README
@@ -168,8 +190,22 @@ The repository documentation SHALL describe public GitHub installation, local ch
 
 #### Scenario: Lifecycle commands documented
 - **WHEN** a user reads the CLI installation documentation
-- **THEN** it shows `chc version`, `chc status`, and `chc update`
+- **THEN** it shows `chc --version`, `chc status`, and `chc update` as the canonical lifecycle entry points
+- **AND** it does not present `chc version` as a canonical command
 
 #### Scenario: Update documented
 - **WHEN** a user reads the CLI installation documentation
 - **THEN** it shows `chc update` as the update path after the first install
+
+### Requirement: Managed Update Safety
+Managed checkout updates SHALL preserve local work and SHALL complete safety checks before mutating checkout files or reinstalling the global command.
+
+#### Scenario: Local changes remain untouched
+- **WHEN** the selected update checkout contains tracked or untracked changes
+- **THEN** the update fails before changing the remote URL, checking out a ref, pulling, or globally installing the package
+- **AND** it does not automatically stash, reset, clean, or overwrite those changes
+
+#### Scenario: Diverged branch remains untouched
+- **WHEN** an existing selected branch has diverged from its resolved remote branch
+- **THEN** the update fails before checkout or global installation
+- **AND** it does not reset or rebase the branch

--- a/openspec/specs/apps-cli-shell-completion/spec.md
+++ b/openspec/specs/apps-cli-shell-completion/spec.md
@@ -4,7 +4,12 @@
 Define PowerShell and zsh shell completion behavior for the `chc` CLI.
 ## Requirements
 ### Requirement: Completion command group
-The CLI SHALL expose a `completion` command group for shell completion setup scripts.
+The CLI SHALL expose `completion` as a real command group whose public child commands generate shell adapters or manage persistent completion setup.
+
+#### Scenario: Bare completion group help
+- **WHEN** a user runs `chc completion` or `chc completion --help`
+- **THEN** stdout presents public operations for `powershell`, `zsh`, `enable`, `disable`, and `status`
+- **AND** the bare command exits successfully without modifying a shell profile
 
 #### Scenario: PowerShell completion script
 - **WHEN** a user runs `chc completion powershell`
@@ -22,6 +27,11 @@ The CLI SHALL expose a `completion` command group for shell completion setup scr
 - **WHEN** a user runs `chc completion fish`
 - **THEN** the command fails with a clear unsupported shell error
 - **AND** it exits non-zero
+
+#### Scenario: Completion lifecycle child dispatch
+- **WHEN** a user runs `chc completion enable <shell>`, `chc completion disable <shell>`, or `chc completion status <shell>`
+- **THEN** Citty dispatches through the corresponding registered child command
+- **AND** the child command validates the shell without parent-level `rawArgs` action parsing
 
 ### Requirement: Internal completion protocol
 The CLI SHALL expose an internal `__complete` command that returns completion candidates for shell adapters.
@@ -43,7 +53,7 @@ The CLI SHALL expose an internal `__complete` command that returns completion ca
 - **AND** it does not print noisy diagnostics to stderr
 
 ### Requirement: Command and flag candidates
-Completion SHALL derive command and flag candidates from the shared CLI command definitions.
+Completion SHALL derive public static command, nested operation, and flag candidates from the shared CLI registrations and Citty command definitions, while dynamic values use their registered discovery providers.
 
 #### Scenario: Root command candidates
 - **WHEN** a shell adapter requests completion for the root command position
@@ -56,10 +66,12 @@ Completion SHALL derive command and flag candidates from the shared CLI command 
 #### Scenario: Completion command candidates
 - **WHEN** a shell adapter requests completion after `chc completion`
 - **THEN** candidates include `powershell`, `zsh`, `enable`, `disable`, and `status`
+- **AND** those candidates derive from the registered public completion child commands rather than an independently maintained action list
 
 #### Scenario: Managed completion shell candidates
 - **WHEN** a shell adapter requests completion after `chc completion enable`
 - **THEN** candidates include `powershell` and `zsh`
+- **AND** candidates derive from the same supported-shell definition used for command validation
 
 #### Scenario: Shared flag candidates
 - **WHEN** a shell adapter requests flag completion for a command that accepts the shared CLI contract flags

--- a/openspec/specs/apps-cli-update-experience/spec.md
+++ b/openspec/specs/apps-cli-update-experience/spec.md
@@ -1,0 +1,125 @@
+# apps-cli-update-experience Specification
+
+## Purpose
+TBD - created by archiving change apps-cli-update-experience. Update Purpose after archive.
+## Requirements
+### Requirement: Update Preflight Classification
+The CLI SHALL inspect the selected update source and classify the intended operation before changing the checkout worktree or global installation.
+
+#### Scenario: Managed install required
+- **WHEN** the selected managed install directory has no Git checkout
+- **THEN** preflight classifies the operation as `install_required`
+- **AND** identifies the selected repository, ref, and install directory
+
+#### Scenario: Update available
+- **WHEN** the selected checkout is safe to update and its current commit differs from the resolved target commit
+- **THEN** preflight classifies the operation as `update_available`
+- **AND** reports the current and target commit identities and bounded change count when available
+
+#### Scenario: Already current
+- **WHEN** the selected checkout already resolves to the target commit
+- **THEN** preflight classifies the operation as `up_to_date`
+- **AND** the update command exits successfully without checking out files or reinstalling the global command
+
+#### Scenario: Dirty checkout is blocked
+- **WHEN** an existing selected checkout has tracked or untracked worktree changes
+- **THEN** preflight classifies the operation as `blocked`
+- **AND** reports that the user must preserve or remove the local changes before retrying
+- **AND** does not change the remote URL, checkout, or global installation
+
+#### Scenario: Non-fast-forward branch is blocked
+- **WHEN** the current branch cannot safely fast-forward to the resolved remote branch target
+- **THEN** preflight classifies the operation as `blocked`
+- **AND** does not rewrite, reset, or automatically stash the checkout
+
+### Requirement: Read-only Update Availability Check
+The CLI SHALL provide `chc update --check` to report update availability without changing checkout files or the global installation.
+
+#### Scenario: Check reports available update
+- **WHEN** a user runs `chc update --check` and the selected target differs from the installed source commit
+- **THEN** the command reports `update_available`
+- **AND** exits successfully without checkout or global install phases
+
+#### Scenario: Check reports current installation
+- **WHEN** a user runs `chc update --check` and the selected target matches the installed source commit
+- **THEN** the command reports `up_to_date`
+- **AND** exits successfully
+
+#### Scenario: Check reports missing managed installation
+- **WHEN** a user runs `chc update --check` and the selected managed checkout is absent
+- **THEN** the command reports `install_required`
+- **AND** does not clone the repository
+
+### Requirement: Adaptive Human Update Output
+The CLI SHALL render update progress and results according to TTY, quiet, and verbose modes while keeping explicit safe updates direct.
+
+#### Scenario: Interactive safe update
+- **WHEN** a user runs `chc update` in an interactive TTY for a safe managed checkout with an available update
+- **THEN** the command proceeds without a redundant confirmation prompt
+- **AND** presents active and completed phases using TTY-safe progress rendering
+- **AND** finishes with a current-to-target summary
+
+#### Scenario: Non-TTY update output
+- **WHEN** human update output is written without a TTY
+- **THEN** the command writes stable plain lines without cursor control sequences or animation
+
+#### Scenario: Already-current human output
+- **WHEN** a human update invocation is already current
+- **THEN** the command clearly states that `chc` is already up to date
+- **AND** identifies the selected ref and commit when available
+
+#### Scenario: Bounded change highlights
+- **WHEN** an update contains one or more commits
+- **THEN** default human output presents a bounded list of commit subjects
+- **AND** identifies when additional commits were omitted
+
+#### Scenario: Quiet update output
+- **WHEN** a user runs an update with `--quiet`
+- **THEN** nonessential source details, progress, and change highlights are suppressed
+- **AND** errors remain visible
+
+#### Scenario: Verbose update output
+- **WHEN** a user runs an update with `--verbose`
+- **THEN** the command includes bounded subprocess command and output details for diagnosis
+- **AND** does not expose secrets or corrupt JSON stdout
+
+### Requirement: Structured Update Results
+The CLI SHALL expose stable machine-readable update states and identities while preserving the single-value JSON stdout contract.
+
+#### Scenario: JSON update applied
+- **WHEN** `chc update --json` applies an available update
+- **THEN** stdout contains exactly one success JSON object with `command: "update"`
+- **AND** its result includes `status: "updated"`, before and after identities, completed phases, and bounded change metadata
+
+#### Scenario: JSON already current
+- **WHEN** `chc update --json` finds no change to apply
+- **THEN** stdout contains exactly one success JSON object with `status: "up_to_date"`
+- **AND** no human progress is written to stdout
+
+#### Scenario: JSON initial managed install
+- **WHEN** `chc update --json` creates a previously absent managed checkout and installs the command
+- **THEN** the result includes `status: "installed"` and the installed target identity
+
+#### Scenario: JSON availability check
+- **WHEN** `chc update --check --json` completes
+- **THEN** stdout contains exactly one success JSON object whose result status is `install_required`, `update_available`, or `up_to_date`
+- **AND** no apply-only phase is reported as completed
+
+### Requirement: Actionable Update Failures
+The CLI SHALL report update failures by stable phase with a concise summary, bounded cause, and recovery hint while retaining the `update_failed` command error code.
+
+#### Scenario: Preflight failure
+- **WHEN** update prerequisites or checkout safety checks fail
+- **THEN** the command identifies the preflight phase and the blocked resource or condition
+- **AND** no global installation is attempted
+
+#### Scenario: Apply phase failure
+- **WHEN** clone, fetch, checkout, bundle verification, or global installation fails
+- **THEN** the command identifies the failed phase
+- **AND** provides a recovery hint appropriate to that phase
+- **AND** exits non-zero with error code `update_failed`
+
+#### Scenario: Default failure detail is bounded
+- **WHEN** a subprocess produces lengthy output during a failed update
+- **THEN** default human and JSON errors include only bounded safe context
+- **AND** direct command, cwd, and expanded output details are reserved for verbose output or diagnostics

--- a/openspec/specs/apps-docs-site/spec.md
+++ b/openspec/specs/apps-docs-site/spec.md
@@ -84,15 +84,20 @@ The docs site SHALL document Kubernetes/GitOps as the official user-facing deplo
 - **THEN** the documentation identifies the GitOps-managed observability namespace, ArgoCD Applications, Prometheus metrics scrape path, Loki log collection path, Tempo trace storage path, and OpenTelemetry Collector ingestion path
 
 ### Requirement: Client installation documentation
-The docs site SHALL document how users install, update, and remove CthuTool client tools on client computers.
+The docs site SHALL document how users install, inspect, update, and remove CthuTool client tools on client computers using the canonical CLI lifecycle interface.
 
 #### Scenario: Reader installs CLI tooling
 - **WHEN** a reader opens CLI installation documentation
 - **THEN** the documentation explains target-machine prerequisites, public raw installer usage, committed bundle runtime behavior, remote install mode, local checkout install mode, automatic zsh completion behavior, and supported override environment variables
 
+#### Scenario: Reader checks the installed CLI version
+- **WHEN** a reader needs only the installed CLI version
+- **THEN** the documentation presents `chc --version` as the canonical version-only entry point
+- **AND** it does not present the legacy `chc version` compatibility alias as a canonical command
+
 #### Scenario: Reader inspects installed CLI tooling
 - **WHEN** a reader needs to inspect CLI installation state
-- **THEN** the documentation explains that `chc status` reports the detected local or remote source checkout
+- **THEN** the documentation explains that `chc status` includes the installed version and reports the detected local or remote source checkout
 - **AND** it documents the explicit install-directory override
 
 #### Scenario: Reader manages installed CLI tooling


### PR DESCRIPTION
## Summary

- consolidate CLI lifecycle discovery around `chc --version`, `chc status`, and `chc update` while preserving the hidden `chc version` compatibility alias
- centralize static and dynamic command discovery so dispatch, help, completion, script listing, selection, and execution share the same registrations and catalog
- add a safer, more informative self-update flow with `chc update --check`, dirty/diverged checkout protection, no-op detection, bounded change summaries, TTY progress, and structured errors
- refresh the committed CLI bundle and documentation, sync the resulting capability specs, and archive all three completed OpenSpec changes

## Why

CLI commands, help output, and completion candidates were maintained through overlapping lists and special cases, making them easy to drift apart. The update command also applied changes directly with limited preflight visibility and recovery guidance. This change establishes shared discovery sources and separates update planning from mutation.

## User and developer impact

- bare `scripts` and `completion` groups now show useful child-command help
- `scripts list` and canonical `scripts run <id>` are discoverable while existing shorthand forms remain compatible
- update checks are explicit and non-mutating, current installs skip redundant global reinstalls, and unsafe local checkout states are preserved
- human, quiet, verbose, non-TTY, and JSON update output have stable contracts
- command registration and catalog invariants are covered by automated tests

## Validation

- `pnpm --filter @cthutool/cli lint`
- `pnpm --filter @cthutool/cli typecheck`
- `pnpm --filter @cthutool/cli test` (82 unit and 68 integration tests passed)
- `pnpm run check:cli-dist`
- `pnpm --filter @cthutool/docs build`
- `openspec validate --all --strict` (46/46 passed)
- source and committed-bundle update help and non-mutating `--check` smoke tests
- `git diff --check`
