### PR TITLE
Organize CthuCodex skills and add Notion channel workflow

### DIFF
--- a/apps/docs/src/content/docs/modules/codex-plugin.md
+++ b/apps/docs/src/content/docs/modules/codex-plugin.md
@@ -9,9 +9,8 @@ CthuCodex is the repository-managed Codex plugin for CthuTool workflows and reus
 
 - language coach hook
 - Anki MCP server
-- Japanese sentence card maker skill
-- Japanese vocabulary card maker skill
-- English expression card maker skill
+- Anki card-creation skills
+- Notion channel-library skill
 
 The language coach uses deterministic local filtering before injecting coaching instructions. It ignores code blocks, inline code, command lines, and identifier-only snippets, and it does not translate Chinese prompts by default.
 
@@ -52,7 +51,7 @@ Available tools:
 
 ## Japanese Sentence Cards
 
-Use `$anki-japanese-sentence-card-maker` for Japanese grammar sentence cards. The skill defaults to deck `0.Japanese::Japanese Sentences` and model `Japanese Sentence`.
+Use `$anki-create-japanese-sentence-card` for Japanese grammar sentence cards. The skill defaults to deck `0.Japanese::Japanese Sentences` and model `Japanese Sentence`.
 
 It accepts either a marked grammar point:
 
@@ -71,7 +70,7 @@ When `tags:` is provided, or when a standalone line looks like a tag hierarchy, 
 
 ## Japanese Vocabulary Cards
 
-Use `$anki-japanese-vocabulary-card-maker` for Japanese vocabulary cards. The skill defaults to deck `0.Japanese::Japanese Vocabulary` and model `Japanese Vocabulary`.
+Use `$anki-create-japanese-vocabulary-card` for Japanese vocabulary cards. The skill defaults to deck `0.Japanese::Japanese Vocabulary` and model `Japanese Vocabulary`.
 
 It accepts a vocabulary target marked with double brackets:
 
@@ -89,7 +88,7 @@ The skill removes markup, preserves kana annotations, stores dictionary-form voc
 
 ## English Expression Cards
 
-Use `$anki-english-expression-card-maker` for English expression cards. The skill defaults to deck `0.English` and model `English Expression`.
+Use `$anki-create-english-expression-card` for English expression cards. The skill defaults to deck `0.English` and model `English Expression`.
 
 It accepts a marked expression:
 
@@ -105,6 +104,10 @@ get past the maze of
 ```
 
 The `Sentence` field uses Anki cloze syntax with a short synonym or paraphrase hint. The `Explanation` field uses the existing English style with `Definition`, `Synonyms`, and `Other Examples` sections.
+
+## Notion Channel Library
+
+Use `$notion-add-channel` to add a YouTube or Bilibili channel to the personal Notion Channel Library. The explicit-only skill checks for duplicates, resolves an existing category, selects the platform-specific template, verifies the created entry, and returns its Notion URL.
 
 ## Authoritative Sources
 

--- a/codex/plugins/cthu-codex/.codex-plugin/plugin.json
+++ b/codex/plugins/cthu-codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cthu-codex",
-  "version": "0.1.5",
+  "version": "0.1.5+codex.20260715115305",
   "description": "Provides a personal Codex toolkit for CthuTool workflows and reusable assistant utilities.",
   "author": {
     "name": "mickmetalholic"
@@ -8,14 +8,21 @@
   "interface": {
     "displayName": "CthuCodex",
     "shortDescription": "Personal Codex toolkit for CthuTool workflows.",
-    "longDescription": "CthuCodex provides reusable Codex utilities for CthuTool workflows, including a prompt-submission language coaching hook and an Anki MCP server for reading local Anki collection context, validating notes, creating cards, and opening created notes for review.",
+    "longDescription": "CthuCodex provides reusable Codex utilities for CthuTool workflows, including a prompt-submission language coaching hook, an Anki MCP server, explicit Anki card-creation skills, and a Notion channel-library skill.",
     "developerName": "mickmetalholic",
     "category": "Productivity",
     "brandColor": "#6D5DFD",
     "composerIcon": "./assets/icon.png",
     "logo": "./assets/logo.png",
-    "capabilities": ["Hooks", "MCP"],
-    "defaultPrompt": ["Use the CthuCodex toolkit when a matching utility applies."]
+    "capabilities": [
+      "Skills",
+      "Hooks",
+      "MCP"
+    ],
+    "defaultPrompt": [
+      "Use the CthuCodex toolkit when a matching utility applies."
+    ]
   },
+  "skills": "./skills/",
   "mcpServers": "./.mcp.json"
 }

--- a/codex/plugins/cthu-codex/README.md
+++ b/codex/plugins/cthu-codex/README.md
@@ -7,7 +7,7 @@
 Repository-managed Codex plugin for CthuTool workflows and reusable assistant
 utilities.
 
-User-facing plugin, Anki MCP, and card-maker skill documentation lives in the
+User-facing plugin, Anki MCP, and manually invoked skill documentation lives in the
 docs site:
 
 - `apps/docs/src/content/docs/modules/codex-plugin.md`

--- a/codex/plugins/cthu-codex/skills/anki-create-english-expression-card/SKILL.md
+++ b/codex/plugins/cthu-codex/skills/anki-create-english-expression-card/SKILL.md
@@ -1,9 +1,9 @@
 ---
-name: anki-english-expression-card-maker
-description: Create English Expression Anki notes from English sentences, reading excerpts, and one or more target expressions through the CthuCodex Anki MCP tools. Use when the user explicitly asks to make, add, generate, or create English expression cards/notes for Anki, especially for the `English Expression` note type with fields `Sentence`, `Expression`, and `Explanation`, cloze deletion, structured English explanations, examples, optional tags, and batch creation from `[[...]]` markers.
+name: anki-create-english-expression-card
+description: Create one or more `English Expression` Anki notes from English sentences, excerpts, and target-expression markers through the CthuCodex Anki MCP tools. Use only when the user explicitly invokes `$anki-create-english-expression-card`.
 ---
 
-# Anki English Expression Card Maker
+# Anki · Create English Expression Card
 
 Use this skill to create one or more `English Expression` Anki notes from an English sentence or excerpt and target expression markers.
 

--- a/codex/plugins/cthu-codex/skills/anki-create-english-expression-card/agents/openai.yaml
+++ b/codex/plugins/cthu-codex/skills/anki-create-english-expression-card/agents/openai.yaml
@@ -1,0 +1,6 @@
+interface:
+  display_name: "Anki · Create English Expression Card"
+  short_description: "Create English expression cards in Anki."
+  default_prompt: "Use $anki-create-english-expression-card to create English Expression Anki note(s) from this sentence or excerpt and target expression marker(s)."
+policy:
+  allow_implicit_invocation: false

--- a/codex/plugins/cthu-codex/skills/anki-create-japanese-sentence-card/SKILL.md
+++ b/codex/plugins/cthu-codex/skills/anki-create-japanese-sentence-card/SKILL.md
@@ -1,9 +1,9 @@
 ---
-name: anki-japanese-sentence-card-maker
-description: Create Japanese Sentence Anki notes from Japanese example sentences and grammar points through the CthuCodex Anki MCP tools. Use when the user asks to make, add, generate, or create a Japanese grammar sentence card/note for Anki, especially for the `Japanese Sentence` note type with fields `文`, `ヒント`, `訳`, and `メモ`, cloze deletion, English translation, English grammar explanations, and optional tags.
+name: anki-create-japanese-sentence-card
+description: Create a `Japanese Sentence` Anki note from a Japanese example sentence and grammar point through the CthuCodex Anki MCP tools. Use only when the user explicitly invokes `$anki-create-japanese-sentence-card`.
 ---
 
-# Anki Japanese Sentence Card Maker
+# Anki · Create Japanese Sentence Card
 
 Use this skill to create one `Japanese Sentence` Anki note from a Japanese example sentence and grammar point.
 

--- a/codex/plugins/cthu-codex/skills/anki-create-japanese-sentence-card/agents/openai.yaml
+++ b/codex/plugins/cthu-codex/skills/anki-create-japanese-sentence-card/agents/openai.yaml
@@ -1,0 +1,6 @@
+interface:
+  display_name: "Anki · Create Japanese Sentence Card"
+  short_description: "Create Japanese grammar sentence cards in Anki."
+  default_prompt: "Use $anki-create-japanese-sentence-card to create a Japanese Sentence Anki note from this example sentence and grammar point."
+policy:
+  allow_implicit_invocation: false

--- a/codex/plugins/cthu-codex/skills/anki-create-japanese-vocabulary-card/SKILL.md
+++ b/codex/plugins/cthu-codex/skills/anki-create-japanese-vocabulary-card/SKILL.md
@@ -1,9 +1,9 @@
 ---
-name: anki-japanese-vocabulary-card-maker
-description: Create Japanese Vocabulary Anki notes from Japanese example sentences and marked vocabulary targets through the CthuCodex Anki MCP tools. Use when the user explicitly asks to make, add, generate, or create a Japanese vocabulary card/note for Anki, especially for the `Japanese Vocabulary` note type with fields `単語`, `読み方`, `穴埋め例文`, `例文`, and `意味`, dictionary-form normalization, English meaning cues, kana annotations, and optional tags.
+name: anki-create-japanese-vocabulary-card
+description: Create a `Japanese Vocabulary` Anki note from a Japanese example sentence and marked vocabulary target through the CthuCodex Anki MCP tools. Use only when the user explicitly invokes `$anki-create-japanese-vocabulary-card`.
 ---
 
-# Anki Japanese Vocabulary Card Maker
+# Anki · Create Japanese Vocabulary Card
 
 Use this skill to create one `Japanese Vocabulary` Anki note from a Japanese example sentence and vocabulary target.
 

--- a/codex/plugins/cthu-codex/skills/anki-create-japanese-vocabulary-card/agents/openai.yaml
+++ b/codex/plugins/cthu-codex/skills/anki-create-japanese-vocabulary-card/agents/openai.yaml
@@ -1,0 +1,6 @@
+interface:
+  display_name: "Anki · Create Japanese Vocabulary Card"
+  short_description: "Create Japanese vocabulary cards in Anki."
+  default_prompt: "Use $anki-create-japanese-vocabulary-card to create a Japanese Vocabulary Anki note from this example sentence and vocabulary target."
+policy:
+  allow_implicit_invocation: false

--- a/codex/plugins/cthu-codex/skills/anki-english-expression-card-maker/agents/openai.yaml
+++ b/codex/plugins/cthu-codex/skills/anki-english-expression-card-maker/agents/openai.yaml
@@ -1,6 +1,0 @@
-interface:
-  display_name: "Anki English Expression Card Maker"
-  short_description: "Create English expression notes in Anki."
-  default_prompt: "Use $anki-english-expression-card-maker to create English Expression Anki note(s) from this sentence or excerpt and target expression marker(s)."
-policy:
-  allow_implicit_invocation: false

--- a/codex/plugins/cthu-codex/skills/anki-japanese-sentence-card-maker/agents/openai.yaml
+++ b/codex/plugins/cthu-codex/skills/anki-japanese-sentence-card-maker/agents/openai.yaml
@@ -1,6 +1,0 @@
-interface:
-  display_name: "Anki Japanese Sentence Card Maker"
-  short_description: "Create Japanese grammar sentence notes in Anki."
-  default_prompt: "Use $anki-japanese-sentence-card-maker to create a Japanese Sentence Anki note from this example sentence and grammar point."
-policy:
-  allow_implicit_invocation: false

--- a/codex/plugins/cthu-codex/skills/anki-japanese-vocabulary-card-maker/agents/openai.yaml
+++ b/codex/plugins/cthu-codex/skills/anki-japanese-vocabulary-card-maker/agents/openai.yaml
@@ -1,6 +1,0 @@
-interface:
-  display_name: "Anki Japanese Vocabulary Card Maker"
-  short_description: "Create Japanese vocabulary notes in Anki."
-  default_prompt: "Use $anki-japanese-vocabulary-card-maker to create a Japanese Vocabulary Anki note from this example sentence and vocabulary target."
-policy:
-  allow_implicit_invocation: false

--- a/codex/plugins/cthu-codex/skills/notion-add-channel/SKILL.md
+++ b/codex/plugins/cthu-codex/skills/notion-add-channel/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: notion-add-channel
+description: Add a YouTube or Bilibili channel to the personal Notion Channel Library after checking for duplicates, resolving an existing category, selecting the platform template, and returning the entry URL. Use only when the user explicitly invokes `$notion-add-channel`.
+---
+
+# Notion · Add Channel
+
+Add one YouTube or Bilibili channel to the configured Notion database. Treat the database as live state: fetch its schema, category options, and templates on every run instead of relying on cached IDs.
+
+## Constants
+
+- Database: `https://app.notion.com/p/2c52c070ae2f42dbad20a3b4ff7764f3?v=3aa4470214734650ab0388d5f5d4bdac&source=copy_link`
+- Required properties: `Name`, `Link`, `Source`, `Tags`
+- Supported `Source` values: `YouTube`, `Bilibili`
+
+## Workflow
+
+1. Parse the explicit invocation for a channel URL and an optional category.
+2. If the channel URL is missing, ask for it and stop without reading or writing Notion.
+3. Fetch the configured database through the Notion connector. Extract the current data-source ID, property schema, `Tags` options, and template IDs. Stop with a clear connection error if the Notion connector is unavailable.
+4. Confirm that the required properties exist and that the platform has a matching `Source` option.
+5. Identify and inspect the channel:
+   - Accept YouTube channel URLs using `/channel/`, `/@handle`, `/c/`, or `/user/`.
+   - Accept Bilibili channel URLs using `space.bilibili.com/<uid>`.
+   - Reject video, playlist, search, and unsupported-site URLs; ask for the channel homepage URL.
+   - Normalize the URL to HTTPS, remove query strings, fragments, and trailing slashes, and preserve the channel identifier or handle.
+   - Read the channel page or current web metadata to determine its display name, canonical identity when available, description, and representative recent content.
+6. Check for an existing entry before creating anything:
+   - Query the fetched data source with parameterized SQL.
+   - Compare normalized `Link` values first.
+   - Also compare the canonical YouTube channel ID or handle, or the numeric Bilibili UID, when available.
+   - Treat a same-name entry as a candidate only; verify its link or platform identity before declaring it a duplicate.
+   - If a duplicate exists, do not create or update anything. Return the existing Notion page URL.
+7. Resolve the category from the data source's current `Tags` options:
+   - If the user supplied a category, require an exact existing option. For a close or invalid value, show the nearest existing options and ask the user to choose; do not create yet.
+   - If the user omitted the category, infer the strongest existing option from the channel description and representative recent content. Present the proposed category with a short reason and ask for explicit confirmation before creating.
+   - If no category is sufficiently supported, present the most plausible two or three existing options, or the full option list when necessary, and ask the user to choose.
+   - Treat a category supplied in the original invocation or explicitly confirmed in a follow-up as authorization for that category only.
+8. Select the correct template dynamically:
+   - Fetch every current database template page.
+   - Select the template whose default `Source` property exactly equals the detected platform.
+   - Prefer the matching platform icon only as a secondary check.
+   - If no template matches, or more than one matching template remains ambiguous, stop and ask the user instead of creating a blank page or guessing.
+9. Create the database page with the selected `template_id` and no explicit page content. Set:
+   - `Name` to the channel display name.
+   - `Link` to the normalized channel URL.
+   - `Source` to the detected platform.
+   - `Tags` to a JSON array containing the confirmed category value or values.
+10. Fetch the created page after template application. Verify its name, link, source, tags, and platform template icon. Retry the fetch briefly if template application is still pending; never apply a second template to compensate for normal asynchronous delay.
+11. Report the channel name, source, confirmed category, and clickable Notion entry URL. If verification is incomplete, say exactly which field or template signal could not be verified.
+
+## Safety Rules
+
+- Never create an entry without a channel URL.
+- Never create an entry from a video URL when the channel homepage cannot be resolved reliably.
+- Never create a duplicate or silently edit an existing entry.
+- Never invent a category or add a new `Tags` option.
+- Never infer a missing category and write it without explicit user confirmation.
+- Never hard-code the data-source ID or template IDs; discover them from the database each run.
+- Never fall back to a blank page when the platform template cannot be identified.

--- a/codex/plugins/cthu-codex/skills/notion-add-channel/agents/openai.yaml
+++ b/codex/plugins/cthu-codex/skills/notion-add-channel/agents/openai.yaml
@@ -1,0 +1,6 @@
+interface:
+  display_name: "Notion · Add Channel"
+  short_description: "Add YouTube or Bilibili channels to Notion."
+  default_prompt: "Use $notion-add-channel to add this channel URL to my Notion Channel Library with an optional category."
+policy:
+  allow_implicit_invocation: false

--- a/openspec/changes/archive/2026-07-15-organize-cthu-codex-skills/.openspec.yaml
+++ b/openspec/changes/archive/2026-07-15-organize-cthu-codex-skills/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-15

--- a/openspec/changes/archive/2026-07-15-organize-cthu-codex-skills/design.md
+++ b/openspec/changes/archive/2026-07-15-organize-cthu-codex-skills/design.md
@@ -1,0 +1,73 @@
+## Context
+
+CthuCodex currently bundles three explicit-only Anki skills whose folder names, invocation names, and UI labels use the older `*-card-maker` convention. A fourth explicit-only skill is being added for a personal Notion Channel Library, creating the need for a naming convention that groups a growing flat skill list without relying on undocumented nested discovery or per-skill categories.
+
+The plugin is installed through the personal marketplace, which points at the main repository copy. Changes developed in a Codex App worktree therefore become loadable only after they are merged, the plugin cachebuster is refreshed, and the plugin is reinstalled in a new task.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Use a predictable `<system>-<action>-<object>` invocation and directory naming convention.
+- Group skills visually through system-prefixed display names while preserving the documented flat plugin layout.
+- Keep every bundled skill explicit-only.
+- Add a safe Notion channel workflow that discovers live database schema and templates, prevents duplicates, and requires confirmation for inferred categories.
+- Keep current documentation and main specifications aligned with the installed skill names.
+
+**Non-Goals:**
+
+- Preserve aliases for the old Anki invocation names.
+- Add nested category directories or custom, undocumented skill metadata.
+- Change the Anki note-generation behavior or Anki MCP server.
+- Add a new Notion MCP server or modify the personal marketplace entry.
+- Rewrite historical archived OpenSpec changes that recorded the former names.
+
+## Decisions
+
+### Use system-prefixed action names in a flat directory
+
+Name the Anki skills `anki-create-english-expression-card`, `anki-create-japanese-sentence-card`, and `anki-create-japanese-vocabulary-card`. Name the Notion skill `notion-add-channel`. Match each folder name to its `SKILL.md` frontmatter name and reference the same name from `agents/openai.yaml`.
+
+Use `Anki · ...` and `Notion · ...` display-name prefixes for visual grouping. Keep all skill folders directly below `skills/` so the plugin follows the documented `skills/<skill-name>/SKILL.md` layout.
+
+Alternative considered: add `skills/anki/` and `skills/notion/` category directories. This was rejected because nested grouping is not a documented plugin discovery contract and would add risk without producing a native category in the skill picker.
+
+### Make manual invocation a per-skill invariant
+
+Set `policy.allow_implicit_invocation: false` in every `agents/openai.yaml`. Include the exact `$skill-name` in every default prompt and, for clarity, state the explicit invocation boundary in each skill description.
+
+Alternative considered: rely only on narrow descriptions to avoid accidental triggering. This was rejected because invocation policy provides deterministic enforcement.
+
+### Discover Notion database state at execution time
+
+Keep the Channel Library database URL as the stable entry point, then fetch the current data source, schema, tag options, and templates on every invocation. Identify templates by their default `Source` property and use the platform icon only as a secondary signal. Do not hard-code data-source or template IDs.
+
+Normalize channel URLs and compare platform identity before creating a record. If a duplicate is found, return the existing entry instead of updating it. If the user omitted a category, infer only from existing options and require explicit confirmation before writing.
+
+Alternative considered: store current data-source, category, and template IDs in the skill. This was rejected because Notion IDs and options can change independently of the plugin.
+
+### Treat the invocation rename as a deliberate breaking migration
+
+Do not keep duplicate alias skill folders for the old names. Duplicate folders would clutter the picker and create two sources of truth. Update current documentation and specifications, retain historical archives unchanged, and document that existing prompts must switch to the new names.
+
+## Risks / Trade-offs
+
+- [Existing prompts using old names stop resolving] → Update current docs and specs, clearly list the name mapping, and reinstall the plugin after merge.
+- [The skill picker remains flat] → Use consistent system prefixes in both invocation and display names so alphabetical lists remain grouped.
+- [Notion page metadata is unavailable or ambiguous] → Stop and ask for a channel homepage, category, or template choice instead of guessing.
+- [Template application is asynchronous] → Fetch the created entry for verification and retry briefly without applying a second template.
+- [Worktree source differs from the installed marketplace path] → Validate in the worktree, merge first, then reinstall from the personal marketplace and test in a new task.
+
+## Migration Plan
+
+1. Rename the four skill directories and update all skill metadata.
+2. Update plugin metadata, user documentation, and current OpenSpec references.
+3. Validate each skill, the plugin manifest, manual-only policy, and repository diff.
+4. Sync and archive this OpenSpec change.
+5. Merge the branch, reinstall `cthu-codex@personal`, and test the new invocation names in a new task.
+
+Rollback by reverting the rename commit and reinstalling the previous plugin source. Existing Notion entries are unaffected because the workflow change only adds new entries during explicit invocation.
+
+## Open Questions
+
+None.

--- a/openspec/changes/archive/2026-07-15-organize-cthu-codex-skills/proposal.md
+++ b/openspec/changes/archive/2026-07-15-organize-cthu-codex-skills/proposal.md
@@ -1,0 +1,32 @@
+## Why
+
+CthuCodex skills are growing beyond the original Anki workflows, but their invocation names and UI labels do not follow one consistent grouping convention. The plugin also needs a reusable, explicit-only workflow for adding YouTube and Bilibili channels to the personal Notion Channel Library without duplicates or incorrect templates.
+
+## What Changes
+
+- **BREAKING** Rename the three Anki skill invocation names and directories to the consistent `anki-create-<object>` convention.
+- **BREAKING** Name the new Notion workflow `$notion-add-channel`, replacing the provisional `$add-channel-to-notion` name.
+- Group skill display names visually with `Anki · ...` and `Notion · ...` prefixes while keeping the plugin's `skills/` directory flat.
+- Keep all four skills explicit-only through `policy.allow_implicit_invocation: false`.
+- Add an explicit-only Notion workflow that validates input, checks duplicates, resolves an existing category, chooses the correct platform template, verifies creation, and returns the Notion entry URL.
+- Declare the plugin's bundled skills in its manifest and update user documentation and current specifications to the new names.
+
+## Capabilities
+
+### New Capabilities
+
+- `codex-plugins-cthu-codex-notion-channel-skill`: Defines the explicit-only Notion Channel Library workflow for YouTube and Bilibili channels.
+
+### Modified Capabilities
+
+- `codex-plugins-cthu-codex-english-expression-skill`: Renames the skill directory and invocation to the `anki-create-*` convention while preserving its explicit-only behavior.
+- `codex-plugins-cthu-codex-japanese-sentence-skill`: Renames the skill directory and invocation to the `anki-create-*` convention while preserving its explicit-only behavior.
+- `codex-plugins-cthu-codex-japanese-vocabulary-skill`: Renames the skill directory and invocation to the `anki-create-*` convention while preserving its explicit-only behavior.
+
+## Impact
+
+- Affected plugin source: `codex/plugins/cthu-codex/`
+- Affected documentation: `apps/docs/src/content/docs/modules/codex-plugin.md`
+- Affected specifications: the three existing CthuCodex Anki skill specs plus one new Notion channel skill spec
+- Existing prompts using the old `$anki-*-card-maker` invocation names must switch to the new `$anki-create-*` names.
+- The personal marketplace entry remains unchanged; reinstalling the plugin after merge exposes the renamed skills.

--- a/openspec/changes/archive/2026-07-15-organize-cthu-codex-skills/specs/codex-plugins-cthu-codex-english-expression-skill/spec.md
+++ b/openspec/changes/archive/2026-07-15-organize-cthu-codex-skills/specs/codex-plugins-cthu-codex-english-expression-skill/spec.md
@@ -1,0 +1,24 @@
+## MODIFIED Requirements
+
+### Requirement: Plugin-local English expression card skill
+CthuCodex SHALL provide a plugin-local explicit-only skill for creating `English Expression` Anki notes from user-provided English sentences, excerpts, and target expressions.
+
+#### Scenario: Skill lives inside CthuCodex
+- **WHEN** the English expression card skill is implemented
+- **THEN** its skill instructions live under `codex/plugins/cthu-codex/skills/anki-create-english-expression-card/`
+- **AND** the skill is packaged with CthuCodex rather than as a standalone top-level repository skill
+
+#### Scenario: Skill uses the grouped invocation name
+- **WHEN** the English expression card skill is presented or invoked
+- **THEN** its skill name is `anki-create-english-expression-card`
+- **AND** its display name starts with `Anki ·`
+
+#### Scenario: Skill is explicit-only
+- **WHEN** the Anki English expression card skill is installed
+- **THEN** its `agents/openai.yaml` sets `policy.allow_implicit_invocation` to `false`
+- **AND** Codex should use it only when explicitly invoked
+
+#### Scenario: Skill remains separate from prompt hook
+- **WHEN** the skill is added to CthuCodex
+- **THEN** the existing language-coach `UserPromptSubmit` hook remains responsible only for English prose review
+- **AND** English expression card generation is not implemented in the prompt hook

--- a/openspec/changes/archive/2026-07-15-organize-cthu-codex-skills/specs/codex-plugins-cthu-codex-japanese-sentence-skill/spec.md
+++ b/openspec/changes/archive/2026-07-15-organize-cthu-codex-skills/specs/codex-plugins-cthu-codex-japanese-sentence-skill/spec.md
@@ -1,0 +1,24 @@
+## MODIFIED Requirements
+
+### Requirement: Plugin-local Japanese sentence card skill
+CthuCodex SHALL provide a plugin-local explicit-only skill for creating `Japanese Sentence` Anki notes from user-provided Japanese example sentences and grammar points.
+
+#### Scenario: Skill lives inside CthuCodex
+- **WHEN** the Japanese sentence card skill is implemented
+- **THEN** its skill instructions live under `codex/plugins/cthu-codex/skills/anki-create-japanese-sentence-card/`
+- **AND** the skill is packaged with CthuCodex rather than as a standalone top-level repository skill
+
+#### Scenario: Skill uses the grouped invocation name
+- **WHEN** the Japanese sentence card skill is presented or invoked
+- **THEN** its skill name is `anki-create-japanese-sentence-card`
+- **AND** its display name starts with `Anki ·`
+
+#### Scenario: Skill is explicit-only
+- **WHEN** the Anki Japanese sentence card skill is installed
+- **THEN** its `agents/openai.yaml` sets `policy.allow_implicit_invocation` to `false`
+- **AND** Codex should use it only when explicitly invoked
+
+#### Scenario: Skill remains separate from prompt hook
+- **WHEN** the skill is added to CthuCodex
+- **THEN** the existing language-coach `UserPromptSubmit` hook remains responsible only for English prose review
+- **AND** Japanese sentence card generation is not implemented in the prompt hook

--- a/openspec/changes/archive/2026-07-15-organize-cthu-codex-skills/specs/codex-plugins-cthu-codex-japanese-vocabulary-skill/spec.md
+++ b/openspec/changes/archive/2026-07-15-organize-cthu-codex-skills/specs/codex-plugins-cthu-codex-japanese-vocabulary-skill/spec.md
@@ -1,0 +1,24 @@
+## MODIFIED Requirements
+
+### Requirement: Plugin-local Japanese vocabulary card skill
+CthuCodex SHALL provide a plugin-local explicit-only skill for creating `Japanese Vocabulary` Anki notes from user-provided Japanese example sentences and vocabulary targets.
+
+#### Scenario: Skill lives inside CthuCodex
+- **WHEN** the Japanese vocabulary card skill is implemented
+- **THEN** its skill instructions live under `codex/plugins/cthu-codex/skills/anki-create-japanese-vocabulary-card/`
+- **AND** the skill is packaged with CthuCodex rather than as a standalone top-level repository skill
+
+#### Scenario: Skill uses the grouped invocation name
+- **WHEN** the Japanese vocabulary card skill is presented or invoked
+- **THEN** its skill name is `anki-create-japanese-vocabulary-card`
+- **AND** its display name starts with `Anki ·`
+
+#### Scenario: Skill is explicit-only
+- **WHEN** the Anki Japanese vocabulary card skill is installed
+- **THEN** its `agents/openai.yaml` sets `policy.allow_implicit_invocation` to `false`
+- **AND** Codex should use it only when explicitly invoked
+
+#### Scenario: Skill remains separate from prompt hook
+- **WHEN** the skill is added to CthuCodex
+- **THEN** the existing language-coach `UserPromptSubmit` hook remains responsible only for English prose review
+- **AND** Japanese vocabulary card generation is not implemented in the prompt hook

--- a/openspec/changes/archive/2026-07-15-organize-cthu-codex-skills/specs/codex-plugins-cthu-codex-notion-channel-skill/spec.md
+++ b/openspec/changes/archive/2026-07-15-organize-cthu-codex-skills/specs/codex-plugins-cthu-codex-notion-channel-skill/spec.md
@@ -1,0 +1,89 @@
+## ADDED Requirements
+
+### Requirement: Plugin-local Notion channel skill
+CthuCodex SHALL provide a plugin-local explicit-only skill for adding YouTube and Bilibili channels to the configured personal Notion Channel Library.
+
+#### Scenario: Skill is packaged and grouped
+- **WHEN** the Notion channel skill is installed
+- **THEN** its instructions live under `codex/plugins/cthu-codex/skills/notion-add-channel/`
+- **AND** its skill name is `notion-add-channel`
+- **AND** its display name starts with `Notion ·`
+
+#### Scenario: Skill is explicit-only
+- **WHEN** the Notion channel skill is installed
+- **THEN** its `agents/openai.yaml` sets `policy.allow_implicit_invocation` to `false`
+- **AND** Codex MUST NOT invoke it implicitly from an ordinary request about channels, YouTube, Bilibili, or Notion
+
+### Requirement: Channel input and platform resolution
+The skill SHALL require a supported channel homepage URL and derive a normalized channel identity before accessing or modifying the Channel Library.
+
+#### Scenario: Channel URL is missing
+- **WHEN** the user invokes the skill without a channel URL
+- **THEN** the skill asks for the URL
+- **AND** it does not read or write the Notion database
+
+#### Scenario: Supported channel URL is provided
+- **WHEN** the user provides a YouTube channel URL or a Bilibili `space.bilibili.com/<uid>` URL
+- **THEN** the skill normalizes the URL to HTTPS without query, fragment, or trailing slash
+- **AND** it resolves the source as `YouTube` or `Bilibili`
+- **AND** it reads current channel metadata to determine the display name and canonical identity when available
+
+#### Scenario: Unsupported content URL is provided
+- **WHEN** the provided URL identifies a video, playlist, search result, or unsupported site and the channel homepage cannot be resolved reliably
+- **THEN** the skill asks for the channel homepage URL
+- **AND** it does not create a Notion entry
+
+### Requirement: Live database discovery and duplicate prevention
+The skill SHALL fetch the configured Channel Library schema, category options, and templates on every run and SHALL NOT create a duplicate channel entry.
+
+#### Scenario: Database state is loaded
+- **WHEN** a supported channel URL is available
+- **THEN** the skill fetches the configured database URL through the Notion connector
+- **AND** it discovers the current data-source ID, required properties, category options, and templates
+- **AND** it does not rely on hard-coded data-source or template IDs
+
+#### Scenario: Existing channel is found
+- **WHEN** a stored entry matches the normalized URL or canonical platform identity
+- **THEN** the skill does not create or update an entry
+- **AND** it returns the existing Notion page URL
+
+#### Scenario: Same display name has a different identity
+- **WHEN** an entry has the same display name but a different or unverifiable platform identity
+- **THEN** the skill does not treat the name alone as proof of a duplicate
+- **AND** it verifies the link or asks for clarification before creating
+
+### Requirement: Existing category resolution
+The skill SHALL use only category values currently defined by the Channel Library and SHALL require explicit confirmation before writing an inferred category.
+
+#### Scenario: Valid category is supplied
+- **WHEN** the user supplies an exact existing category value
+- **THEN** the skill uses that category without requesting a second confirmation
+
+#### Scenario: Category is missing
+- **WHEN** the user omits the category and channel content supports a strongest existing option
+- **THEN** the skill presents the proposed category with a short reason
+- **AND** it waits for explicit user confirmation before creating the entry
+
+#### Scenario: Category cannot be inferred reliably
+- **WHEN** no existing category is sufficiently supported
+- **THEN** the skill presents plausible existing options or the full current option list
+- **AND** it waits for the user to choose
+- **AND** it does not invent or add a category
+
+### Requirement: Platform-template creation and verification
+The skill SHALL create a non-duplicate channel entry with the template whose default source matches the detected platform and SHALL return the verified Notion URL.
+
+#### Scenario: One matching platform template exists
+- **WHEN** exactly one fetched template has a default `Source` equal to the detected platform and the category is confirmed
+- **THEN** the skill creates a page with that template and no explicit page content
+- **AND** it sets `Name`, normalized `Link`, `Source`, and `Tags`
+
+#### Scenario: Template selection is missing or ambiguous
+- **WHEN** no template matches the detected platform or multiple templates remain ambiguous
+- **THEN** the skill asks the user instead of creating a blank page or guessing
+
+#### Scenario: Entry is created successfully
+- **WHEN** Notion returns a created page
+- **THEN** the skill fetches it to verify the name, link, source, tags, and platform template signal
+- **AND** it returns a clickable Notion entry URL
+- **AND** it reports any verification field that remains incomplete

--- a/openspec/changes/archive/2026-07-15-organize-cthu-codex-skills/tasks.md
+++ b/openspec/changes/archive/2026-07-15-organize-cthu-codex-skills/tasks.md
@@ -1,0 +1,20 @@
+## 1. Skill Organization
+
+- [x] 1.1 Rename the three Anki skill directories, frontmatter names, display names, and default prompts to the `anki-create-<object>` convention.
+- [x] 1.2 Keep all Anki skills explicit-only and verify every default prompt references its exact renamed skill.
+- [x] 1.3 Add the flat `notion-add-channel` skill with a grouped display name and explicit-only invocation policy.
+
+## 2. Notion Channel Workflow
+
+- [x] 2.1 Implement channel URL validation, platform resolution, live database discovery, and duplicate detection instructions.
+- [x] 2.2 Implement existing-category validation or confirmed inference, platform-template selection, creation verification, and Notion URL reporting instructions.
+
+## 3. Plugin Contracts and Documentation
+
+- [x] 3.1 Declare bundled skills in the plugin manifest and update its capability description and cachebuster.
+- [x] 3.2 Update current user documentation and main OpenSpec skill paths without modifying historical archived changes or generated agent adapters.
+
+## 4. Verification
+
+- [x] 4.1 Validate all four skills, the CthuCodex plugin, exact name-directory-prompt consistency, and manual-only policies.
+- [x] 4.2 Run `git diff --check` and confirm active plugin, documentation, and main-spec references no longer use the retired invocation names, excluding migration history in this change and archived changes.

--- a/openspec/specs/codex-plugins-cthu-codex-english-expression-skill/spec.md
+++ b/openspec/specs/codex-plugins-cthu-codex-english-expression-skill/spec.md
@@ -9,8 +9,13 @@ CthuCodex SHALL provide a plugin-local explicit-only skill for creating `English
 
 #### Scenario: Skill lives inside CthuCodex
 - **WHEN** the English expression card skill is implemented
-- **THEN** its skill instructions live under `codex/plugins/cthu-codex/skills/anki-english-expression-card-maker/`
+- **THEN** its skill instructions live under `codex/plugins/cthu-codex/skills/anki-create-english-expression-card/`
 - **AND** the skill is packaged with CthuCodex rather than as a standalone top-level repository skill
+
+#### Scenario: Skill uses the grouped invocation name
+- **WHEN** the English expression card skill is presented or invoked
+- **THEN** its skill name is `anki-create-english-expression-card`
+- **AND** its display name starts with `Anki ·`
 
 #### Scenario: Skill is explicit-only
 - **WHEN** the Anki English expression card skill is installed

--- a/openspec/specs/codex-plugins-cthu-codex-japanese-sentence-skill/spec.md
+++ b/openspec/specs/codex-plugins-cthu-codex-japanese-sentence-skill/spec.md
@@ -5,12 +5,17 @@ Specify the CthuCodex plugin-local skill for creating `Japanese Sentence` Anki n
 
 ## Requirements
 ### Requirement: Plugin-local Japanese sentence card skill
-CthuCodex SHALL provide a plugin-local skill for creating `Japanese Sentence` Anki notes from user-provided Japanese example sentences and grammar points.
+CthuCodex SHALL provide a plugin-local explicit-only skill for creating `Japanese Sentence` Anki notes from user-provided Japanese example sentences and grammar points.
 
 #### Scenario: Skill lives inside CthuCodex
 - **WHEN** the Japanese sentence card skill is implemented
-- **THEN** its skill instructions live under `codex/plugins/cthu-codex/skills/anki-japanese-sentence-card-maker/`
+- **THEN** its skill instructions live under `codex/plugins/cthu-codex/skills/anki-create-japanese-sentence-card/`
 - **AND** the skill is packaged with CthuCodex rather than as a standalone top-level repository skill
+
+#### Scenario: Skill uses the grouped invocation name
+- **WHEN** the Japanese sentence card skill is presented or invoked
+- **THEN** its skill name is `anki-create-japanese-sentence-card`
+- **AND** its display name starts with `Anki ·`
 
 #### Scenario: Skill is explicit-only
 - **WHEN** the Anki Japanese sentence card skill is installed

--- a/openspec/specs/codex-plugins-cthu-codex-japanese-vocabulary-skill/spec.md
+++ b/openspec/specs/codex-plugins-cthu-codex-japanese-vocabulary-skill/spec.md
@@ -9,8 +9,13 @@ CthuCodex SHALL provide a plugin-local explicit-only skill for creating `Japanes
 
 #### Scenario: Skill lives inside CthuCodex
 - **WHEN** the Japanese vocabulary card skill is implemented
-- **THEN** its skill instructions live under `codex/plugins/cthu-codex/skills/anki-japanese-vocabulary-card-maker/`
+- **THEN** its skill instructions live under `codex/plugins/cthu-codex/skills/anki-create-japanese-vocabulary-card/`
 - **AND** the skill is packaged with CthuCodex rather than as a standalone top-level repository skill
+
+#### Scenario: Skill uses the grouped invocation name
+- **WHEN** the Japanese vocabulary card skill is presented or invoked
+- **THEN** its skill name is `anki-create-japanese-vocabulary-card`
+- **AND** its display name starts with `Anki ·`
 
 #### Scenario: Skill is explicit-only
 - **WHEN** the Anki Japanese vocabulary card skill is installed

--- a/openspec/specs/codex-plugins-cthu-codex-notion-channel-skill/spec.md
+++ b/openspec/specs/codex-plugins-cthu-codex-notion-channel-skill/spec.md
@@ -1,0 +1,93 @@
+# codex-plugins-cthu-codex-notion-channel-skill Specification
+
+## Purpose
+Define the explicit-only CthuCodex workflow for safely adding YouTube and Bilibili channels to the configured personal Notion Channel Library.
+
+## Requirements
+### Requirement: Plugin-local Notion channel skill
+CthuCodex SHALL provide a plugin-local explicit-only skill for adding YouTube and Bilibili channels to the configured personal Notion Channel Library.
+
+#### Scenario: Skill is packaged and grouped
+- **WHEN** the Notion channel skill is installed
+- **THEN** its instructions live under `codex/plugins/cthu-codex/skills/notion-add-channel/`
+- **AND** its skill name is `notion-add-channel`
+- **AND** its display name starts with `Notion ·`
+
+#### Scenario: Skill is explicit-only
+- **WHEN** the Notion channel skill is installed
+- **THEN** its `agents/openai.yaml` sets `policy.allow_implicit_invocation` to `false`
+- **AND** Codex MUST NOT invoke it implicitly from an ordinary request about channels, YouTube, Bilibili, or Notion
+
+### Requirement: Channel input and platform resolution
+The skill SHALL require a supported channel homepage URL and derive a normalized channel identity before accessing or modifying the Channel Library.
+
+#### Scenario: Channel URL is missing
+- **WHEN** the user invokes the skill without a channel URL
+- **THEN** the skill asks for the URL
+- **AND** it does not read or write the Notion database
+
+#### Scenario: Supported channel URL is provided
+- **WHEN** the user provides a YouTube channel URL or a Bilibili `space.bilibili.com/<uid>` URL
+- **THEN** the skill normalizes the URL to HTTPS without query, fragment, or trailing slash
+- **AND** it resolves the source as `YouTube` or `Bilibili`
+- **AND** it reads current channel metadata to determine the display name and canonical identity when available
+
+#### Scenario: Unsupported content URL is provided
+- **WHEN** the provided URL identifies a video, playlist, search result, or unsupported site and the channel homepage cannot be resolved reliably
+- **THEN** the skill asks for the channel homepage URL
+- **AND** it does not create a Notion entry
+
+### Requirement: Live database discovery and duplicate prevention
+The skill SHALL fetch the configured Channel Library schema, category options, and templates on every run and SHALL NOT create a duplicate channel entry.
+
+#### Scenario: Database state is loaded
+- **WHEN** a supported channel URL is available
+- **THEN** the skill fetches the configured database URL through the Notion connector
+- **AND** it discovers the current data-source ID, required properties, category options, and templates
+- **AND** it does not rely on hard-coded data-source or template IDs
+
+#### Scenario: Existing channel is found
+- **WHEN** a stored entry matches the normalized URL or canonical platform identity
+- **THEN** the skill does not create or update an entry
+- **AND** it returns the existing Notion page URL
+
+#### Scenario: Same display name has a different identity
+- **WHEN** an entry has the same display name but a different or unverifiable platform identity
+- **THEN** the skill does not treat the name alone as proof of a duplicate
+- **AND** it verifies the link or asks for clarification before creating
+
+### Requirement: Existing category resolution
+The skill SHALL use only category values currently defined by the Channel Library and SHALL require explicit confirmation before writing an inferred category.
+
+#### Scenario: Valid category is supplied
+- **WHEN** the user supplies an exact existing category value
+- **THEN** the skill uses that category without requesting a second confirmation
+
+#### Scenario: Category is missing
+- **WHEN** the user omits the category and channel content supports a strongest existing option
+- **THEN** the skill presents the proposed category with a short reason
+- **AND** it waits for explicit user confirmation before creating the entry
+
+#### Scenario: Category cannot be inferred reliably
+- **WHEN** no existing category is sufficiently supported
+- **THEN** the skill presents plausible existing options or the full current option list
+- **AND** it waits for the user to choose
+- **AND** it does not invent or add a category
+
+### Requirement: Platform-template creation and verification
+The skill SHALL create a non-duplicate channel entry with the template whose default source matches the detected platform and SHALL return the verified Notion URL.
+
+#### Scenario: One matching platform template exists
+- **WHEN** exactly one fetched template has a default `Source` equal to the detected platform and the category is confirmed
+- **THEN** the skill creates a page with that template and no explicit page content
+- **AND** it sets `Name`, normalized `Link`, `Source`, and `Tags`
+
+#### Scenario: Template selection is missing or ambiguous
+- **WHEN** no template matches the detected platform or multiple templates remain ambiguous
+- **THEN** the skill asks the user instead of creating a blank page or guessing
+
+#### Scenario: Entry is created successfully
+- **WHEN** Notion returns a created page
+- **THEN** the skill fetches it to verify the name, link, source, tags, and platform template signal
+- **AND** it returns a clickable Notion entry URL
+- **AND** it reports any verification field that remains incomplete


### PR DESCRIPTION
## Summary

- rename the three Anki skills to a consistent `anki-create-*` convention and group their UI names
- add the explicit-only `$notion-add-channel` workflow with duplicate detection, category confirmation, template selection, and post-create verification
- declare bundled skills in the plugin manifest and update documentation
- add, sync, and archive the OpenSpec change and corresponding main specs

## Impact

The old `$anki-*-card-maker` invocation names are replaced by the new `$anki-create-*` names. All four skills remain explicit-only.

## Validation

- all four skills passed `quick_validate.py`
- CthuCodex plugin validation passed
- skill directory/name/default-prompt/manual-policy consistency assertions passed
- `openspec validate organize-cthu-codex-skills --strict`
- `git diff --check`

A full build was not run because these changes only affect plugin skills, documentation, and OpenSpec artifacts.