### PR TITLE
fix(cli): align update source lifecycle

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,12 +106,22 @@ chc update --ref v0.1.0
 
 Use `chc --version` for the lightweight version-only check. `chc status`
 includes that version together with the detected installation mode and source
-checkout diagnostics. `chc update --check` reports whether installation or an
-update is needed without changing checkout files or the global command. A safe
-managed `chc update` runs directly, reports commit progress, and skips the
-global reinstall when already current. Dirty or diverged checkouts are blocked
-without automatic stash, reset, or rebase. Update checks are explicit; the CLI
-does not run a periodic background checker.
+checkout diagnostics. For the default remote managed installation,
+`chc update --check` and `chc update` follow that checkout's existing origin and
+checked-out branch, exact tag, or commit. A safe managed update reports the
+planned commit, validates the committed bundle before checkout, and skips the
+global reinstall when already current.
+
+When `chc status` reports `mode: local`, the command follows that development
+checkout and default update/check commands do not mutate it or the separate
+managed checkout. Update the repository with the normal Git workflow and
+refresh `apps/cli/dist/index.js` with `pnpm --filter @cthutool/cli dev`. Use
+`CHC_INSTALL_MODE=remote scripts/install-chc.sh` to switch the global command
+back to managed mode. Advanced callers can explicitly select another source
+with `--install-dir`, `--repo`, and `--ref`; a successful apply relinks the
+global command to that directory. Dirty, diverged, or invalid-bundle targets are
+blocked without automatic stash, reset, clean, or rebase. Update checks are
+explicit; the CLI does not run a periodic background checker.
 
 Discover command groups and bundled scripts directly from the CLI:
 

--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -69,13 +69,25 @@ inspect a different checkout explicitly.
 
 `chc update --check` resolves the selected remote ref and reports
 `install_required`, `update_available`, or `up_to_date` without changing
-checkout files or the global installation. A normal update of a clean managed
-checkout proceeds directly without a redundant confirmation, shows TTY-aware
-phase progress and a bounded commit summary, and skips checkout plus
-`npm install -g` when already current.
+checkout files or the global installation. For the default managed source, the
+repository and ref default to the checkout's existing origin and symbolic
+branch, exact tag, or detached commit. A normal clean update proceeds directly,
+shows TTY-aware phase progress and a bounded commit summary, validates the
+target bundle before checkout, and skips checkout plus `npm install -g` when
+already current.
 
-The updater refuses dirty or diverged checkouts and never automatically
-stashes, resets, cleans, or rebases local work. Use output modes as needed:
+For `mode: local`, default update and check commands stop with development
+guidance and do not touch either the linked checkout or the default managed
+checkout. Update the linked repository with its normal Git workflow and refresh
+the committed bundle with `pnpm --filter @cthutool/cli dev`. Run
+`CHC_INSTALL_MODE=remote scripts/install-chc.sh` to switch back to managed mode.
+`--install-dir`, `--repo`, and `--ref` (or their environment equivalents) remain
+advanced explicit source overrides; a successful update relinks global `chc` to
+the selected install directory.
+
+The updater refuses dirty, diverged, or invalid-bundle targets and never
+automatically stashes, resets, cleans, or rebases local work. Use output modes
+as needed:
 
 ```bash
 chc update --quiet

--- a/apps/cli/dist/index.js
+++ b/apps/cli/dist/index.js
@@ -4145,7 +4145,7 @@ function sanitizeValue(key, value, depth) {
     return REDACTED;
   }
   if (typeof value === "string") {
-    return isPathKey(key) ? summarizePath(value) : truncate(value);
+    return isPathKey(key) ? summarizePath(value) : truncate(redactUrlUserinfo(value));
   }
   if (typeof value === "number" || typeof value === "boolean" || value === null || value === undefined) {
     return value;
@@ -4186,7 +4186,10 @@ function truncate(value) {
   return `${value.slice(0, MAX_STRING_LENGTH - 3)}...`;
 }
 function sanitizeDiagnosticMessage(value) {
-  return truncate(value.replace(/(token|secret|password|passwd|cookie|authorization|credential)=([^&\s]+)/gi, "$1=[redacted]"));
+  return truncate(redactUrlUserinfo(value).replace(/(token|secret|password|passwd|cookie|authorization|credential)=([^&\s]+)/gi, "$1=[redacted]"));
+}
+function redactUrlUserinfo(value) {
+  return value.replace(/:\/\/[^/\s]+@/g, "://***@");
 }
 function dropUndefined(value) {
   return Object.fromEntries(Object.entries(value).filter(([, item]) => item !== undefined));
@@ -6366,16 +6369,19 @@ class SelfUpdateError extends Error {
   hint;
   result;
   constructor(options) {
-    const cause = options.cause ? `
-Cause: ${options.cause}` : "";
-    super(`${options.summary}${cause}
-Next: ${options.hint}`);
+    const summary = redactSelfUpdateText(options.summary);
+    const causeText = options.cause ? redactSelfUpdateText(options.cause) : undefined;
+    const hint = redactSelfUpdateText(options.hint);
+    const cause = causeText ? `
+Cause: ${causeText}` : "";
+    super(`${summary}${cause}
+Next: ${hint}`);
     this.name = "SelfUpdateError";
     this.phase = options.phase;
-    this.summary = options.summary;
-    this.causeText = options.cause;
-    this.hint = options.hint;
-    this.result = options.result;
+    this.summary = summary;
+    this.causeText = causeText;
+    this.hint = hint;
+    this.result = options.result ? redactCommandResult(options.result) : undefined;
   }
 }
 function getDefaultSelfUpdateInstallDir(home = homedir3()) {
@@ -6390,19 +6396,53 @@ function createSelfUpdateDeps(onEvent) {
     run: runCommand2,
     env: process.env,
     home: homedir3,
+    runtimeRoot: findRepoRootFromModule,
     onEvent
   };
 }
 function getCliVersion() {
   return readPackageVersion(findRepoRootFromModule());
 }
-function resolveSelfUpdateOptions(options, deps) {
-  const home = deps.home();
+async function resolveSelfUpdateSource(options, deps) {
+  const runtimeRoot = deps.runtimeRoot();
+  const managedRoot = getDefaultSelfUpdateInstallDir(deps.home());
+  const envInstallDir = nonEmpty(deps.env.CHC_INSTALL_DIR);
+  const explicitInstallDir = options.installDir !== undefined || envInstallDir !== undefined;
+  const installDir = options.installDir ?? envInstallDir ?? runtimeRoot;
+  const mode = resolve4(runtimeRoot) === resolve4(managedRoot) ? "remote" : "local";
+  const gitRoot = join7(installDir, ".git");
+  const canInspectCheckout = deps.exists(gitRoot);
+  const repoOverride = options.repo ?? nonEmpty(deps.env.CHC_REPO_URL) ?? nonEmpty(deps.env.CHC_REPO);
+  const refOverride = options.ref ?? nonEmpty(deps.env.CHC_REF);
+  const installedRepo = canInspectCheckout && repoOverride === undefined ? await runOptional(deps, "git", ["remote", "get-url", "origin"], {
+    cwd: installDir
+  }) : undefined;
+  const installedRef = canInspectCheckout && refOverride === undefined ? await readInstalledRef(deps, installDir) : undefined;
   return {
-    repo: options.repo ?? deps.env.CHC_REPO_URL ?? deps.env.CHC_REPO ?? defaultSelfUpdateRepo,
-    ref: options.ref ?? deps.env.CHC_REF ?? defaultSelfUpdateRef,
-    installDir: options.installDir ?? deps.env.CHC_INSTALL_DIR ?? getDefaultSelfUpdateInstallDir(home)
+    repo: repoOverride ?? installedRepo ?? defaultSelfUpdateRepo,
+    ref: refOverride ?? installedRef ?? defaultSelfUpdateRef,
+    installDir,
+    runtimeRoot,
+    managedRoot,
+    mode,
+    explicitInstallDir
   };
+}
+async function readInstalledRef(deps, installDir) {
+  const branch = await runOptional(deps, "git", ["symbolic-ref", "--quiet", "--short", "HEAD"], { cwd: installDir });
+  if (branch)
+    return branch;
+  const tags = await runOptional(deps, "git", ["tag", "--points-at", "HEAD", "--sort=refname"], { cwd: installDir });
+  const exactTag = tags?.split(/\r?\n/).map((value) => value.trim()).filter(Boolean).sort((left, right) => left.localeCompare(right))[0];
+  if (exactTag)
+    return exactTag;
+  return runOptional(deps, "git", ["rev-parse", "--verify", "HEAD^{commit}"], {
+    cwd: installDir
+  });
+}
+function nonEmpty(value) {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : undefined;
 }
 function emit(deps, event) {
   deps.onEvent?.(event);
@@ -6450,7 +6490,7 @@ function toPhaseError(error, phase) {
   return new SelfUpdateError({
     phase,
     summary: `Update failed during ${formatPhase(phase)}.`,
-    cause: boundedText(error instanceof Error ? error.message : String(error)),
+    cause: boundedText(redactSelfUpdateText(error instanceof Error ? error.message : String(error))),
     hint: phaseHint(phase)
   });
 }
@@ -6482,8 +6522,8 @@ async function execute(deps, phase, command, args, options = {}) {
     args: redactArgs(args),
     cwd: options.cwd,
     code: result.code,
-    stdout: boundedText(result.stdout),
-    stderr: boundedText(result.stderr)
+    stdout: boundedText(redactSelfUpdateText(result.stdout)),
+    stderr: boundedText(redactSelfUpdateText(result.stderr))
   });
   if (result.code !== 0 && options.allowFailure !== true) {
     throw commandFailure(phase, result);
@@ -6516,13 +6556,27 @@ function finishPlan(deps, plan) {
   return plan;
 }
 async function planSelfUpdate(options = {}, deps = createSelfUpdateDeps()) {
-  const resolved = resolveSelfUpdateOptions(options, deps);
+  const resolved = await resolveSelfUpdateSource(options, deps);
   const publicResolved = {
-    ...resolved,
-    repo: redactValue(resolved.repo)
+    repo: redactSelfUpdateText(resolved.repo),
+    ref: resolved.ref,
+    installDir: resolved.installDir
   };
   const phases = [];
   const gitRoot = join7(resolved.installDir, ".git");
+  if (resolved.mode === "local" && !resolved.explicitInstallDir) {
+    phases.push("preflight");
+    return finishPlan(deps, {
+      status: "blocked",
+      ...publicResolved,
+      block: {
+        kind: "local_linked_source",
+        message: `The running chc command is linked to the local checkout at ${resolved.runtimeRoot}.`,
+        hint: "Update that checkout and rebuild apps/cli/dist/index.js, or run CHC_INSTALL_MODE=remote scripts/install-chc.sh to switch back to managed mode."
+      },
+      phases
+    });
+  }
   const initial = await runPhase(deps, "preflight", async () => {
     if (!deps.exists(gitRoot)) {
       return;
@@ -6563,12 +6617,29 @@ async function planSelfUpdate(options = {}, deps = createSelfUpdateDeps()) {
     };
   });
   phases.push("check_remote");
+  const targetBundle = await execute(deps, "check_remote", "git", ["cat-file", "-e", `${remote.target.commit}:${committedCliBundlePath}`], { cwd: resolved.installDir, allowFailure: true });
+  if (targetBundle.code !== 0) {
+    return finishPlan(deps, {
+      status: "blocked",
+      ...publicResolved,
+      before: initial,
+      target: remote.target,
+      block: {
+        kind: "missing_target_bundle",
+        message: `The selected target does not contain ${committedCliBundlePath}.`,
+        hint: `Select a ref containing ${committedCliBundlePath}.`
+      },
+      phases
+    });
+  }
   if (initial.commit === remote.target.commit) {
     return finishPlan(deps, {
       status: "up_to_date",
       ...publicResolved,
       before: initial,
       target: remote.target,
+      targetKind: remote.isBranch ? "branch" : "detached",
+      relinkRequired: resolve4(resolved.installDir) !== resolve4(resolved.runtimeRoot),
       phases
     });
   }
@@ -6580,6 +6651,7 @@ async function planSelfUpdate(options = {}, deps = createSelfUpdateDeps()) {
         ...publicResolved,
         before: initial,
         target: remote.target,
+        targetKind: "branch",
         block: {
           kind: "diverged_branch",
           message: "The selected checkout cannot fast-forward to the remote branch.",
@@ -6598,6 +6670,7 @@ async function planSelfUpdate(options = {}, deps = createSelfUpdateDeps()) {
     ...publicResolved,
     before: initial,
     target: remote.target,
+    targetKind: remote.isBranch ? "branch" : "detached",
     changes,
     phases
   });
@@ -6638,10 +6711,31 @@ function assertSelfUpdatePlanReady(plan) {
   }
 }
 async function runSelfUpdate(options = {}, deps = createSelfUpdateDeps()) {
-  const resolved = resolveSelfUpdateOptions(options, deps);
+  const resolved = await resolveSelfUpdateSource(options, deps);
   const plan = await planSelfUpdate(options, deps);
   assertSelfUpdatePlanReady(plan);
   if (plan.status === "up_to_date") {
+    if (plan.relinkRequired) {
+      await runPhase(deps, "install_global", async () => {
+        await execute(deps, "install_global", "npm", [
+          "install",
+          "-g",
+          "--ignore-scripts",
+          plan.installDir
+        ]);
+      });
+      return {
+        status: "installed",
+        repo: plan.repo,
+        ref: plan.ref,
+        installDir: plan.installDir,
+        before: plan.before,
+        target: plan.target,
+        after: plan.before,
+        phases: [...plan.phases, "install_global"],
+        steps: ["install-global"]
+      };
+    }
     return {
       status: "up_to_date",
       repo: plan.repo,
@@ -6691,6 +6785,20 @@ async function runSelfUpdate(options = {}, deps = createSelfUpdateDeps()) {
     steps.push("fetch");
   }
   await runPhase(deps, "checkout", async () => {
+    if (!isInstall && plan.target) {
+      if (plan.targetKind === "branch") {
+        await execute(deps, "checkout", "git", ["checkout", plan.ref], {
+          cwd: plan.installDir
+        });
+        steps.push("checkout");
+        await execute(deps, "checkout", "git", ["merge", "--ff-only", plan.target.commit], { cwd: plan.installDir });
+        steps.push("pull");
+      } else {
+        await execute(deps, "checkout", "git", ["checkout", "--detach", plan.target.commit], { cwd: plan.installDir });
+        steps.push("checkout");
+      }
+      return;
+    }
     await execute(deps, "checkout", "git", ["checkout", plan.ref], {
       cwd: plan.installDir
     });
@@ -6732,22 +6840,19 @@ async function runSelfUpdate(options = {}, deps = createSelfUpdateDeps()) {
   };
 }
 async function getCliInstallationStatus(options = {}, deps = createSelfUpdateDeps()) {
-  const installDir = options.installDir ?? deps.env.CHC_INSTALL_DIR ?? findRepoRootFromModule();
-  const resolved = resolveSelfUpdateOptions({ ...options, installDir }, deps);
+  const resolved = await resolveSelfUpdateSource(options, deps);
   const bundlePath = join7(resolved.installDir, committedCliBundlePath);
   const gitRoot = join7(resolved.installDir, ".git");
   const repo = deps.exists(gitRoot) ? await runOptional(deps, "git", ["remote", "get-url", "origin"], {
     cwd: resolved.installDir
   }) ?? resolved.repo : resolved.repo;
-  const ref = deps.exists(gitRoot) ? await runOptional(deps, "git", ["rev-parse", "--abbrev-ref", "HEAD"], {
-    cwd: resolved.installDir
-  }) ?? resolved.ref : resolved.ref;
+  const ref = deps.exists(gitRoot) ? await readInstalledRef(deps, resolved.installDir) ?? resolved.ref : resolved.ref;
   const commit = deps.exists(gitRoot) ? await runOptional(deps, "git", ["rev-parse", "--short", "HEAD"], {
     cwd: resolved.installDir
   }) : undefined;
   return {
     version: getCliVersion(),
-    mode: resolve4(resolved.installDir) === resolve4(getDefaultSelfUpdateInstallDir(deps.home())) ? "remote" : "local",
+    mode: resolve4(resolved.installDir) === resolve4(resolved.managedRoot) ? "remote" : "local",
     installDir: resolved.installDir,
     repo,
     ref,
@@ -6791,14 +6896,22 @@ function boundedText(value) {
 `) : undefined;
 }
 function boundedCommandOutput(result) {
-  return boundedText(`${result.stderr}
-${result.stdout}`);
+  return boundedText(redactSelfUpdateText(`${result.stderr}
+${result.stdout}`));
 }
 function redactArgs(args) {
-  return args.map(redactValue);
+  return args.map(redactSelfUpdateText);
 }
-function redactValue(value) {
-  return value.replace(/:\/\/[^/@\s]+@/g, "://***@");
+function redactSelfUpdateText(value) {
+  return value.replace(/:\/\/[^/\s]+@/g, "://***@");
+}
+function redactCommandResult(result) {
+  return {
+    ...result,
+    args: redactArgs(result.args),
+    stdout: redactSelfUpdateText(result.stdout),
+    stderr: redactSelfUpdateText(result.stderr)
+  };
 }
 function runCommand2(command, args, options = {}) {
   return new Promise((resolvePromise, reject) => {
@@ -6984,7 +7097,10 @@ function createSelfUpdateRenderer(context, options, deps = defaultDeps2) {
     renderCheckResult(plan) {
       if (!human)
         return;
-      if (plan.status === "up_to_date" && plan.target) {
+      if (plan.status === "up_to_date" && plan.relinkRequired && plan.target) {
+        deps.output.stdout.write(`${colors2.yellow("Global relink required")} · run chc update · ${identity(plan.target)}
+`);
+      } else if (plan.status === "up_to_date" && plan.target) {
         deps.output.stdout.write(`${colors2.green("✓")} chc is already up to date · ${identity(plan.target)}
 `);
       } else if (plan.status === "update_available" && plan.target) {
@@ -7120,7 +7236,7 @@ function createUpdateCommand() {
             details: {
               installDir,
               ref,
-              repo,
+              repo: repo ? redactSelfUpdateText(repo) : undefined,
               phase: error instanceof SelfUpdateError ? error.phase : undefined
             }
           });

--- a/apps/cli/src/command/self-update-output.ts
+++ b/apps/cli/src/command/self-update-output.ts
@@ -149,7 +149,11 @@ export function createSelfUpdateRenderer(
     },
     renderCheckResult(plan) {
       if (!human) return;
-      if (plan.status === 'up_to_date' && plan.target) {
+      if (plan.status === 'up_to_date' && plan.relinkRequired && plan.target) {
+        deps.output.stdout.write(
+          `${colors.yellow('Global relink required')} · run chc update · ${identity(plan.target)}\n`,
+        );
+      } else if (plan.status === 'up_to_date' && plan.target) {
         deps.output.stdout.write(
           `${colors.green('✓')} chc is already up to date · ${identity(plan.target)}\n`,
         );

--- a/apps/cli/src/command/self-update.command.ts
+++ b/apps/cli/src/command/self-update.command.ts
@@ -6,6 +6,7 @@ import {
   getCliInstallationStatus,
   getCliVersion,
   planSelfUpdate,
+  redactSelfUpdateText,
   runSelfUpdate,
   SelfUpdateError,
 } from '../domain/self-update-manager';
@@ -146,7 +147,7 @@ function createUpdateCommand() {
               details: {
                 installDir,
                 ref,
-                repo,
+                repo: repo ? redactSelfUpdateText(repo) : undefined,
                 phase:
                   error instanceof SelfUpdateError ? error.phase : undefined,
               },

--- a/apps/cli/src/domain/self-update-manager.ts
+++ b/apps/cli/src/domain/self-update-manager.ts
@@ -64,7 +64,11 @@ export type SelfUpdateChangeSummary = {
 };
 
 export type SelfUpdateBlock = {
-  readonly kind: 'dirty_checkout' | 'diverged_branch';
+  readonly kind:
+    | 'local_linked_source'
+    | 'dirty_checkout'
+    | 'diverged_branch'
+    | 'missing_target_bundle';
   readonly message: string;
   readonly hint: string;
 };
@@ -78,6 +82,8 @@ export type SelfUpdatePlan = {
   readonly target?: SelfUpdateIdentity;
   readonly changes?: SelfUpdateChangeSummary;
   readonly block?: SelfUpdateBlock;
+  readonly targetKind?: 'branch' | 'detached';
+  readonly relinkRequired?: boolean;
   readonly phases: readonly SelfUpdatePhase[];
 };
 
@@ -149,7 +155,15 @@ export type SelfUpdateDeps = {
   ) => Promise<SelfUpdateCommandResult>;
   readonly env: Record<string, string | undefined>;
   readonly home: () => string;
+  readonly runtimeRoot: () => string;
   readonly onEvent?: (event: SelfUpdateEvent) => void;
+};
+
+export type ResolvedSelfUpdateSource = Required<SelfUpdateOptions> & {
+  readonly runtimeRoot: string;
+  readonly managedRoot: string;
+  readonly mode: 'local' | 'remote';
+  readonly explicitInstallDir: boolean;
 };
 
 export class SelfUpdateError extends Error {
@@ -166,14 +180,21 @@ export class SelfUpdateError extends Error {
     readonly hint: string;
     readonly result?: SelfUpdateCommandResult;
   }) {
-    const cause = options.cause ? `\nCause: ${options.cause}` : '';
-    super(`${options.summary}${cause}\nNext: ${options.hint}`);
+    const summary = redactSelfUpdateText(options.summary);
+    const causeText = options.cause
+      ? redactSelfUpdateText(options.cause)
+      : undefined;
+    const hint = redactSelfUpdateText(options.hint);
+    const cause = causeText ? `\nCause: ${causeText}` : '';
+    super(`${summary}${cause}\nNext: ${hint}`);
     this.name = 'SelfUpdateError';
     this.phase = options.phase;
-    this.summary = options.summary;
-    this.causeText = options.cause;
-    this.hint = options.hint;
-    this.result = options.result;
+    this.summary = summary;
+    this.causeText = causeText;
+    this.hint = hint;
+    this.result = options.result
+      ? redactCommandResult(options.result)
+      : undefined;
   }
 }
 
@@ -192,6 +213,7 @@ export function createSelfUpdateDeps(
     run: runCommand,
     env: process.env,
     home: homedir,
+    runtimeRoot: findRepoRootFromModule,
     onEvent,
   };
 }
@@ -200,23 +222,80 @@ export function getCliVersion(): string {
   return readPackageVersion(findRepoRootFromModule());
 }
 
-export function resolveSelfUpdateOptions(
+export async function resolveSelfUpdateSource(
   options: SelfUpdateOptions,
   deps: SelfUpdateDeps,
-): Required<SelfUpdateOptions> {
-  const home = deps.home();
+): Promise<ResolvedSelfUpdateSource> {
+  const runtimeRoot = deps.runtimeRoot();
+  const managedRoot = getDefaultSelfUpdateInstallDir(deps.home());
+  const envInstallDir = nonEmpty(deps.env.CHC_INSTALL_DIR);
+  const explicitInstallDir =
+    options.installDir !== undefined || envInstallDir !== undefined;
+  const installDir = options.installDir ?? envInstallDir ?? runtimeRoot;
+  const mode =
+    resolve(runtimeRoot) === resolve(managedRoot) ? 'remote' : 'local';
+  const gitRoot = join(installDir, '.git');
+  const canInspectCheckout = deps.exists(gitRoot);
+  const repoOverride =
+    options.repo ??
+    nonEmpty(deps.env.CHC_REPO_URL) ??
+    nonEmpty(deps.env.CHC_REPO);
+  const refOverride = options.ref ?? nonEmpty(deps.env.CHC_REF);
+  const installedRepo =
+    canInspectCheckout && repoOverride === undefined
+      ? await runOptional(deps, 'git', ['remote', 'get-url', 'origin'], {
+          cwd: installDir,
+        })
+      : undefined;
+  const installedRef =
+    canInspectCheckout && refOverride === undefined
+      ? await readInstalledRef(deps, installDir)
+      : undefined;
+
   return {
-    repo:
-      options.repo ??
-      deps.env.CHC_REPO_URL ??
-      deps.env.CHC_REPO ??
-      defaultSelfUpdateRepo,
-    ref: options.ref ?? deps.env.CHC_REF ?? defaultSelfUpdateRef,
-    installDir:
-      options.installDir ??
-      deps.env.CHC_INSTALL_DIR ??
-      getDefaultSelfUpdateInstallDir(home),
+    repo: repoOverride ?? installedRepo ?? defaultSelfUpdateRepo,
+    ref: refOverride ?? installedRef ?? defaultSelfUpdateRef,
+    installDir,
+    runtimeRoot,
+    managedRoot,
+    mode,
+    explicitInstallDir,
   };
+}
+
+async function readInstalledRef(
+  deps: SelfUpdateDeps,
+  installDir: string,
+): Promise<string | undefined> {
+  const branch = await runOptional(
+    deps,
+    'git',
+    ['symbolic-ref', '--quiet', '--short', 'HEAD'],
+    { cwd: installDir },
+  );
+  if (branch) return branch;
+
+  const tags = await runOptional(
+    deps,
+    'git',
+    ['tag', '--points-at', 'HEAD', '--sort=refname'],
+    { cwd: installDir },
+  );
+  const exactTag = tags
+    ?.split(/\r?\n/)
+    .map((value) => value.trim())
+    .filter(Boolean)
+    .sort((left, right) => left.localeCompare(right))[0];
+  if (exactTag) return exactTag;
+
+  return runOptional(deps, 'git', ['rev-parse', '--verify', 'HEAD^{commit}'], {
+    cwd: installDir,
+  });
+}
+
+function nonEmpty(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : undefined;
 }
 
 function emit(deps: SelfUpdateDeps, event: SelfUpdateEvent): void {
@@ -272,7 +351,11 @@ function toPhaseError(error: unknown, phase: SelfUpdatePhase): SelfUpdateError {
   return new SelfUpdateError({
     phase,
     summary: `Update failed during ${formatPhase(phase)}.`,
-    cause: boundedText(error instanceof Error ? error.message : String(error)),
+    cause: boundedText(
+      redactSelfUpdateText(
+        error instanceof Error ? error.message : String(error),
+      ),
+    ),
     hint: phaseHint(phase),
   });
 }
@@ -319,8 +402,8 @@ async function execute(
     args: redactArgs(args),
     cwd: options.cwd,
     code: result.code,
-    stdout: boundedText(result.stdout),
-    stderr: boundedText(result.stderr),
+    stdout: boundedText(redactSelfUpdateText(result.stdout)),
+    stderr: boundedText(redactSelfUpdateText(result.stderr)),
   });
   if (result.code !== 0 && options.allowFailure !== true) {
     throw commandFailure(phase, result);
@@ -391,13 +474,28 @@ export async function planSelfUpdate(
   options: SelfUpdateOptions = {},
   deps = createSelfUpdateDeps(),
 ): Promise<SelfUpdatePlan> {
-  const resolved = resolveSelfUpdateOptions(options, deps);
+  const resolved = await resolveSelfUpdateSource(options, deps);
   const publicResolved = {
-    ...resolved,
-    repo: redactValue(resolved.repo),
+    repo: redactSelfUpdateText(resolved.repo),
+    ref: resolved.ref,
+    installDir: resolved.installDir,
   };
   const phases: SelfUpdatePhase[] = [];
   const gitRoot = join(resolved.installDir, '.git');
+
+  if (resolved.mode === 'local' && !resolved.explicitInstallDir) {
+    phases.push('preflight');
+    return finishPlan(deps, {
+      status: 'blocked',
+      ...publicResolved,
+      block: {
+        kind: 'local_linked_source',
+        message: `The running chc command is linked to the local checkout at ${resolved.runtimeRoot}.`,
+        hint: 'Update that checkout and rebuild apps/cli/dist/index.js, or run CHC_INSTALL_MODE=remote scripts/install-chc.sh to switch back to managed mode.',
+      },
+      phases,
+    });
+  }
 
   const initial = await runPhase(deps, 'preflight', async () => {
     if (!deps.exists(gitRoot)) {
@@ -466,12 +564,37 @@ export async function planSelfUpdate(
   });
   phases.push('check_remote');
 
+  const targetBundle = await execute(
+    deps,
+    'check_remote',
+    'git',
+    ['cat-file', '-e', `${remote.target.commit}:${committedCliBundlePath}`],
+    { cwd: resolved.installDir, allowFailure: true },
+  );
+  if (targetBundle.code !== 0) {
+    return finishPlan(deps, {
+      status: 'blocked',
+      ...publicResolved,
+      before: initial,
+      target: remote.target,
+      block: {
+        kind: 'missing_target_bundle',
+        message: `The selected target does not contain ${committedCliBundlePath}.`,
+        hint: `Select a ref containing ${committedCliBundlePath}.`,
+      },
+      phases,
+    });
+  }
+
   if (initial.commit === remote.target.commit) {
     return finishPlan(deps, {
       status: 'up_to_date',
       ...publicResolved,
       before: initial,
       target: remote.target,
+      targetKind: remote.isBranch ? 'branch' : 'detached',
+      relinkRequired:
+        resolve(resolved.installDir) !== resolve(resolved.runtimeRoot),
       phases,
     });
   }
@@ -490,6 +613,7 @@ export async function planSelfUpdate(
         ...publicResolved,
         before: initial,
         target: remote.target,
+        targetKind: 'branch',
         block: {
           kind: 'diverged_branch',
           message:
@@ -515,6 +639,7 @@ export async function planSelfUpdate(
     ...publicResolved,
     before: initial,
     target: remote.target,
+    targetKind: remote.isBranch ? 'branch' : 'detached',
     changes,
     phases,
   });
@@ -587,10 +712,31 @@ export async function runSelfUpdate(
   options: SelfUpdateOptions = {},
   deps = createSelfUpdateDeps(),
 ): Promise<SelfUpdateResult> {
-  const resolved = resolveSelfUpdateOptions(options, deps);
+  const resolved = await resolveSelfUpdateSource(options, deps);
   const plan = await planSelfUpdate(options, deps);
   assertSelfUpdatePlanReady(plan);
   if (plan.status === 'up_to_date') {
+    if (plan.relinkRequired) {
+      await runPhase(deps, 'install_global', async () => {
+        await execute(deps, 'install_global', 'npm', [
+          'install',
+          '-g',
+          '--ignore-scripts',
+          plan.installDir,
+        ]);
+      });
+      return {
+        status: 'installed',
+        repo: plan.repo,
+        ref: plan.ref,
+        installDir: plan.installDir,
+        before: plan.before,
+        target: plan.target,
+        after: plan.before,
+        phases: [...plan.phases, 'install_global'],
+        steps: ['install-global'],
+      };
+    }
     return {
       status: 'up_to_date',
       repo: plan.repo,
@@ -656,6 +802,33 @@ export async function runSelfUpdate(
   }
 
   await runPhase(deps, 'checkout', async () => {
+    if (!isInstall && plan.target) {
+      if (plan.targetKind === 'branch') {
+        await execute(deps, 'checkout', 'git', ['checkout', plan.ref], {
+          cwd: plan.installDir,
+        });
+        steps.push('checkout');
+        await execute(
+          deps,
+          'checkout',
+          'git',
+          ['merge', '--ff-only', plan.target.commit],
+          { cwd: plan.installDir },
+        );
+        steps.push('pull');
+      } else {
+        await execute(
+          deps,
+          'checkout',
+          'git',
+          ['checkout', '--detach', plan.target.commit],
+          { cwd: plan.installDir },
+        );
+        steps.push('checkout');
+      }
+      return;
+    }
+
     await execute(deps, 'checkout', 'git', ['checkout', plan.ref], {
       cwd: plan.installDir,
     });
@@ -716,9 +889,7 @@ export async function getCliInstallationStatus(
   options: SelfUpdateOptions = {},
   deps = createSelfUpdateDeps(),
 ): Promise<CliInstallationStatus> {
-  const installDir =
-    options.installDir ?? deps.env.CHC_INSTALL_DIR ?? findRepoRootFromModule();
-  const resolved = resolveSelfUpdateOptions({ ...options, installDir }, deps);
+  const resolved = await resolveSelfUpdateSource(options, deps);
   const bundlePath = join(resolved.installDir, committedCliBundlePath);
   const gitRoot = join(resolved.installDir, '.git');
   const repo = deps.exists(gitRoot)
@@ -727,9 +898,7 @@ export async function getCliInstallationStatus(
       })) ?? resolved.repo)
     : resolved.repo;
   const ref = deps.exists(gitRoot)
-    ? ((await runOptional(deps, 'git', ['rev-parse', '--abbrev-ref', 'HEAD'], {
-        cwd: resolved.installDir,
-      })) ?? resolved.ref)
+    ? ((await readInstalledRef(deps, resolved.installDir)) ?? resolved.ref)
     : resolved.ref;
   const commit = deps.exists(gitRoot)
     ? await runOptional(deps, 'git', ['rev-parse', '--short', 'HEAD'], {
@@ -740,8 +909,7 @@ export async function getCliInstallationStatus(
   return {
     version: getCliVersion(),
     mode:
-      resolve(resolved.installDir) ===
-      resolve(getDefaultSelfUpdateInstallDir(deps.home()))
+      resolve(resolved.installDir) === resolve(resolved.managedRoot)
         ? 'remote'
         : 'local',
     installDir: resolved.installDir,
@@ -805,15 +973,28 @@ function boundedText(value: string): string | undefined {
 function boundedCommandOutput(
   result: SelfUpdateCommandResult,
 ): string | undefined {
-  return boundedText(`${result.stderr}\n${result.stdout}`);
+  return boundedText(
+    redactSelfUpdateText(`${result.stderr}\n${result.stdout}`),
+  );
 }
 
 function redactArgs(args: readonly string[]): readonly string[] {
-  return args.map(redactValue);
+  return args.map(redactSelfUpdateText);
 }
 
-function redactValue(value: string): string {
-  return value.replace(/:\/\/[^/@\s]+@/g, '://***@');
+export function redactSelfUpdateText(value: string): string {
+  return value.replace(/:\/\/[^/\s]+@/g, '://***@');
+}
+
+function redactCommandResult(
+  result: SelfUpdateCommandResult,
+): SelfUpdateCommandResult {
+  return {
+    ...result,
+    args: redactArgs(result.args),
+    stdout: redactSelfUpdateText(result.stdout),
+    stderr: redactSelfUpdateText(result.stderr),
+  };
 }
 
 function runCommand(

--- a/apps/cli/src/runtime/observability.ts
+++ b/apps/cli/src/runtime/observability.ts
@@ -197,7 +197,9 @@ function sanitizeValue(key: string, value: unknown, depth: number): unknown {
     return REDACTED;
   }
   if (typeof value === 'string') {
-    return isPathKey(key) ? summarizePath(value) : truncate(value);
+    return isPathKey(key)
+      ? summarizePath(value)
+      : truncate(redactUrlUserinfo(value));
   }
   if (
     typeof value === 'number' ||
@@ -262,11 +264,15 @@ function truncate(value: string): string {
 
 function sanitizeDiagnosticMessage(value: string): string {
   return truncate(
-    value.replace(
+    redactUrlUserinfo(value).replace(
       /(token|secret|password|passwd|cookie|authorization|credential)=([^&\s]+)/gi,
       '$1=[redacted]',
     ),
   );
+}
+
+function redactUrlUserinfo(value: string): string {
+  return value.replace(/:\/\/[^/\s]+@/g, '://***@');
 }
 
 function dropUndefined(

--- a/apps/cli/tests/integration/self-update-command.test.ts
+++ b/apps/cli/tests/integration/self-update-command.test.ts
@@ -12,6 +12,7 @@ import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const cliRoot = join(dirname(fileURLToPath(import.meta.url)), '../..');
+const repoRoot = join(cliRoot, '../..');
 const scriptExecutable = Bun.which('script');
 
 async function runProcess(command: string, args: string[], cwd: string) {
@@ -146,6 +147,67 @@ function updateArgs(fixture: {
 }
 
 describe('self-update command', () => {
+  test('blocks default local-linked update and check without touching managed state', async () => {
+    const fixture = await createFixture();
+    const env = {
+      ...fixture.env,
+      CHC_INSTALL_DIR: undefined,
+      CHC_REPO_URL: undefined,
+      CHC_REPO: undefined,
+      CHC_REF: undefined,
+    };
+    try {
+      for (const args of [
+        ['update', '--json'],
+        ['update', '--check', '--json'],
+      ]) {
+        const result = await runCli(args, env);
+        expect(result.code).not.toBe(0);
+        expect(JSON.parse(result.out)).toMatchObject({
+          ok: false,
+          error: {
+            code: 'update_failed',
+            phase: 'preflight',
+            message: expect.stringContaining(repoRoot),
+            hint: expect.stringContaining('CHC_INSTALL_MODE=remote'),
+          },
+        });
+      }
+      expect(await fixture.npmInvocations()).toEqual([]);
+      expect(await Bun.file(join(fixture.installDir, '.git')).exists()).toBe(
+        false,
+      );
+    } finally {
+      await fixture.cleanup();
+    }
+  });
+
+  test('accepts environment source overrides as an explicit update target', async () => {
+    const fixture = await createFixture();
+    try {
+      await fixture.clone();
+      await fixture.advanceSource('Environment-selected update');
+
+      const result = await runCli(['update', '--json'], {
+        ...fixture.env,
+        CHC_INSTALL_DIR: fixture.installDir,
+        CHC_REPO_URL: fixture.source,
+        CHC_REF: 'main',
+      });
+
+      expect(result.code).toBe(0);
+      expect(JSON.parse(result.out)).toMatchObject({
+        result: {
+          status: 'updated',
+          installDir: fixture.installDir,
+        },
+      });
+      expect(await fixture.npmInvocations()).toHaveLength(1);
+    } finally {
+      await fixture.cleanup();
+    }
+  });
+
   test('checks a missing installation without cloning or invoking npm', async () => {
     const fixture = await createFixture();
     try {
@@ -202,7 +264,7 @@ describe('self-update command', () => {
     }
   });
 
-  test('applies an available update and skips a subsequent no-op reinstall', async () => {
+  test('applies an available update and relinks an explicitly selected current checkout', async () => {
     const fixture = await createFixture();
     try {
       await fixture.clone();
@@ -232,9 +294,9 @@ describe('self-update command', () => {
       );
       expect(current.code).toBe(0);
       expect(JSON.parse(current.out)).toMatchObject({
-        result: { status: 'up_to_date', steps: [] },
+        result: { status: 'installed', steps: ['install-global'] },
       });
-      expect(await fixture.npmInvocations()).toHaveLength(1);
+      expect(await fixture.npmInvocations()).toHaveLength(2);
     } finally {
       await fixture.cleanup();
     }
@@ -329,7 +391,7 @@ describe('self-update command', () => {
         fixture.env,
       );
       expect(human.code).toBe(0);
-      expect(human.out).toContain('chc is already up to date');
+      expect(human.out).toContain('Global relink required');
       expect(human.out).not.toContain('\u001b[');
 
       const quiet = await runCli(
@@ -383,7 +445,7 @@ describe('self-update command', () => {
         expect(await proc.exited).toBe(0);
         expect(err).toBe('');
         expect(out).toContain('Checking local update state complete');
-        expect(out).toContain('chc is already up to date');
+        expect(out).toContain('Global relink required');
         expect(out).toContain('\u001b[?25l');
       } finally {
         await fixture.cleanup();

--- a/apps/cli/tests/unit/runtime.test.ts
+++ b/apps/cli/tests/unit/runtime.test.ts
@@ -126,6 +126,7 @@ describe('CLI runtime contract', () => {
       details: {
         inputPath: '/tmp/private/sample.cbz',
         password: 'secret-value',
+        repo: 'https://user:repo@secret@example.invalid/private.git',
       },
     });
     writeJsonValue(output, { ok: true, command: 'test' });
@@ -144,6 +145,9 @@ describe('CLI runtime contract', () => {
     );
     expect(diagnostic.details.password).toBe('[redacted]');
     expect(diagnostic.details.inputPath).toBe('private/sample.cbz');
+    expect(diagnostic.details.repo).toBe(
+      'https://***@example.invalid/private.git',
+    );
   });
 
   test('quiet mode suppresses nonessential diagnostics but preserves errors', () => {

--- a/apps/cli/tests/unit/self-update-manager.test.ts
+++ b/apps/cli/tests/unit/self-update-manager.test.ts
@@ -5,6 +5,7 @@ import {
   defaultSelfUpdateRepo,
   getCliInstallationStatus,
   planSelfUpdate,
+  resolveSelfUpdateSource,
   runSelfUpdate,
   type SelfUpdateCommandResult,
   type SelfUpdateDeps,
@@ -16,6 +17,7 @@ const currentCommit = '1111111111111111111111111111111111111111';
 const targetCommit = '2222222222222222222222222222222222222222';
 
 type FakeOptions = {
+  readonly installDir?: string;
   readonly existingCheckout?: boolean;
   readonly currentCommit?: string;
   readonly targetCommit?: string;
@@ -27,6 +29,14 @@ type FakeOptions = {
   readonly failCommand?: string;
   readonly failOutput?: string;
   readonly changeCount?: number;
+  readonly runtimeRoot?: string;
+  readonly home?: string;
+  readonly repo?: string;
+  readonly ref?: string;
+  readonly exactTags?: readonly string[];
+  readonly targetBundlePresent?: boolean;
+  readonly env?: Record<string, string | undefined>;
+  readonly advanceTargetOnApply?: string;
 };
 
 function createDeps(options: FakeOptions = {}) {
@@ -37,12 +47,13 @@ function createDeps(options: FakeOptions = {}) {
   }> = [];
   const events: SelfUpdateEvent[] = [];
   const mkdirs: string[] = [];
-  const installDir = '/tmp/cthutool/source/CthuTool';
+  const installDir = options.installDir ?? '/tmp/cthutool/source/CthuTool';
+  const runtimeRoot = options.runtimeRoot ?? '/tmp/runtime/CthuTool';
   let checkoutExists = options.existingCheckout ?? true;
   let head = options.currentCommit ?? currentCommit;
   let ref = 'main';
   let statusCalls = 0;
-  const wantedTarget = options.targetCommit ?? targetCommit;
+  let remoteTarget = options.targetCommit ?? targetCommit;
   const targetKind = options.targetKind ?? 'branch';
   const changeCount = options.changeCount ?? 7;
 
@@ -83,6 +94,8 @@ function createDeps(options: FakeOptions = {}) {
           options.dirty === true ||
           (options.dirtyOnRecheck === true && statusCalls > 1);
         stdout = dirty ? '?? local-change\n' : '';
+      } else if (command === 'git' && args[0] === 'cat-file') {
+        code = options.targetBundlePresent === false ? 1 : 0;
       } else if (
         command === 'git' &&
         args[0] === 'rev-parse' &&
@@ -94,7 +107,7 @@ function createDeps(options: FakeOptions = {}) {
         args[0] === 'rev-parse' &&
         args[2] === 'FETCH_HEAD^{commit}'
       ) {
-        stdout = `${wantedTarget}\n`;
+        stdout = `${remoteTarget}\n`;
       } else if (
         command === 'git' &&
         args[0] === 'symbolic-ref' &&
@@ -105,7 +118,7 @@ function createDeps(options: FakeOptions = {}) {
         code = 1;
       } else if (command === 'git' && args[0] === 'ls-remote') {
         if (targetKind === 'branch') {
-          stdout = `${wantedTarget}\trefs/heads/main\n`;
+          stdout = `${remoteTarget}\trefs/heads/main\n`;
         } else {
           code = 2;
         }
@@ -120,10 +133,25 @@ function createDeps(options: FakeOptions = {}) {
         ).join('\n');
       } else if (command === 'git' && args[0] === 'clone') {
         checkoutExists = true;
-        head = wantedTarget;
+        head = remoteTarget;
+      } else if (
+        command === 'git' &&
+        args[0] === 'fetch' &&
+        args[1] === '--tags' &&
+        options.advanceTargetOnApply
+      ) {
+        remoteTarget = options.advanceTargetOnApply;
       } else if (command === 'git' && args[0] === 'checkout') {
-        ref = args[1] ?? ref;
-        head = wantedTarget;
+        if (args[1] === '--detach') {
+          ref = 'HEAD';
+          head = args[2] ?? head;
+        } else {
+          ref = args[1] ?? ref;
+        }
+      } else if (command === 'git' && args[0] === 'merge') {
+        head = args[2] ?? head;
+      } else if (command === 'git' && args[0] === 'pull') {
+        head = remoteTarget;
       } else if (
         command === 'git' &&
         args[0] === 'rev-parse' &&
@@ -131,13 +159,15 @@ function createDeps(options: FakeOptions = {}) {
         String(args[2]).startsWith('origin/')
       ) {
         code = targetKind === 'branch' ? 0 : 1;
-        stdout = code === 0 ? `${wantedTarget}\n` : '';
+        stdout = code === 0 ? `${remoteTarget}\n` : '';
       } else if (
         command === 'git' &&
         args[0] === 'remote' &&
         args[1] === 'get-url'
       ) {
-        stdout = 'git@github.com:me/CthuTool.git\n';
+        stdout = `${options.repo ?? defaultSelfUpdateRepo}\n`;
+      } else if (command === 'git' && args[0] === 'tag') {
+        stdout = `${(options.exactTags ?? []).join('\n')}\n`;
       } else if (
         command === 'git' &&
         args[0] === 'rev-parse' &&
@@ -160,12 +190,13 @@ function createDeps(options: FakeOptions = {}) {
         stderr: '',
       };
     },
-    env: {},
-    home: () => '/home/tester',
+    env: options.env ?? {},
+    home: () => options.home ?? '/home/tester',
+    runtimeRoot: () => runtimeRoot,
     onEvent: (event) => events.push(event),
   };
 
-  return { commands, deps, events, installDir, mkdirs };
+  return { commands, deps, events, installDir, mkdirs, runtimeRoot };
 }
 
 function signatures(
@@ -184,6 +215,82 @@ describe('self-update manager', () => {
     );
   });
 
+  test('resolves the running managed checkout and its installed origin and branch by default', async () => {
+    const installDir = '/home/tester/.cthutool/source/CthuTool';
+    const repo = 'https://example.invalid/fork/CthuTool.git';
+    const { deps } = createDeps({ installDir, runtimeRoot: installDir, repo });
+
+    await expect(resolveSelfUpdateSource({}, deps)).resolves.toMatchObject({
+      installDir,
+      runtimeRoot: installDir,
+      explicitInstallDir: false,
+      mode: 'remote',
+      repo,
+      ref: 'main',
+    });
+  });
+
+  test('preserves deterministic exact tags and detached commits', async () => {
+    const installDir = '/home/tester/.cthutool/source/CthuTool';
+    const tagged = createDeps({
+      installDir,
+      runtimeRoot: installDir,
+      targetKind: 'tag',
+      exactTags: ['v2.0.0', 'v1.0.0'],
+    });
+    await expect(
+      resolveSelfUpdateSource({}, tagged.deps),
+    ).resolves.toMatchObject({ ref: 'v1.0.0' });
+
+    const detached = createDeps({
+      installDir,
+      runtimeRoot: installDir,
+      targetKind: 'tag',
+    });
+    await expect(
+      resolveSelfUpdateSource({}, detached.deps),
+    ).resolves.toMatchObject({ ref: currentCommit });
+  });
+
+  test('applies explicit directory, repository, and ref precedence', async () => {
+    const { deps, installDir } = createDeps({
+      env: {
+        CHC_INSTALL_DIR: '/env/CthuTool',
+        CHC_REPO_URL: 'https://example.invalid/env.git',
+        CHC_REF: 'env-ref',
+      },
+    });
+
+    await expect(
+      resolveSelfUpdateSource(
+        {
+          installDir,
+          repo: 'https://example.invalid/cli.git',
+          ref: 'cli-ref',
+        },
+        deps,
+      ),
+    ).resolves.toMatchObject({
+      installDir,
+      repo: 'https://example.invalid/cli.git',
+      ref: 'cli-ref',
+      explicitInstallDir: true,
+    });
+  });
+
+  test('uses official defaults for an explicitly selected absent checkout', async () => {
+    const { deps, installDir } = createDeps({ existingCheckout: false });
+
+    await expect(
+      resolveSelfUpdateSource({ installDir }, deps),
+    ).resolves.toMatchObject({
+      installDir,
+      repo: defaultSelfUpdateRepo,
+      ref: 'main',
+      explicitInstallDir: true,
+    });
+  });
+
   test('classifies an absent managed checkout without running commands', async () => {
     const { commands, deps, installDir } = createDeps({
       existingCheckout: false,
@@ -195,6 +302,39 @@ describe('self-update manager', () => {
       phases: ['preflight'],
     });
     expect(commands).toEqual([]);
+  });
+
+  test('blocks a default local-linked source before remote or mutating commands', async () => {
+    const installDir = '/worktrees/local/CthuTool';
+    const { commands, deps } = createDeps({
+      installDir,
+      runtimeRoot: installDir,
+    });
+
+    const plan = await planSelfUpdate({}, deps);
+
+    expect(plan).toMatchObject({
+      status: 'blocked',
+      installDir,
+      block: {
+        kind: 'local_linked_source',
+        message: expect.stringContaining(installDir),
+        hint: expect.stringContaining('CHC_INSTALL_MODE=remote'),
+      },
+    });
+    expect(signatures(commands).join('\n')).not.toMatch(
+      /fetch|checkout|merge|pull|npm/,
+    );
+  });
+
+  test('allows an explicit local install directory to use the updater', async () => {
+    const installDir = '/worktrees/local/CthuTool';
+    const { deps } = createDeps({ installDir, runtimeRoot: installDir });
+
+    await expect(planSelfUpdate({ installDir }, deps)).resolves.toMatchObject({
+      status: 'update_available',
+      installDir,
+    });
   });
 
   test('classifies an equal branch target as already current', async () => {
@@ -223,14 +363,36 @@ describe('self-update manager', () => {
     await planSelfUpdate(
       {
         installDir,
-        repo: 'https://update-user:super-secret@example.invalid/repo.git',
+        repo: 'https://update-user:super@secret@example.invalid/repo.git',
       },
       deps,
     );
 
     const serialized = JSON.stringify(events);
-    expect(serialized).not.toContain('super-secret');
+    expect(serialized).not.toContain('super@secret');
     expect(serialized).toContain('https://***@example.invalid/repo.git');
+  });
+
+  test('redacts repository credentials from command failures and event output', async () => {
+    const secret = 'super-secret';
+    const repo = `https://update-user:${secret}@example.invalid/repo.git`;
+    const { deps, events, installDir } = createDeps({
+      failCommand: 'git fetch',
+      failOutput: `fatal: unable to access '${repo}'`,
+    });
+
+    let caught: unknown;
+    try {
+      await planSelfUpdate({ installDir, repo }, deps);
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(caught).toBeInstanceOf(SelfUpdateError);
+    expect(JSON.stringify(caught)).not.toContain(secret);
+    expect((caught as Error).message).not.toContain(secret);
+    expect(JSON.stringify(events)).not.toContain(secret);
+    expect((caught as Error).message).toContain('https://***@example.invalid');
   });
 
   test('classifies a branch update and bounds its change summary', async () => {
@@ -270,9 +432,9 @@ describe('self-update manager', () => {
       status: 'blocked',
       block: { kind: 'dirty_checkout' },
     });
-    expect(signatures(commands)).toEqual([
-      'git status --porcelain --untracked-files=normal',
-    ]);
+    const all = signatures(commands);
+    expect(all.at(-1)).toBe('git status --porcelain --untracked-files=normal');
+    expect(all.join('\n')).not.toMatch(/fetch|checkout|merge|pull|npm/);
   });
 
   test('blocks a diverged branch without resetting or rebasing it', async () => {
@@ -285,6 +447,22 @@ describe('self-update manager', () => {
     });
     expect(signatures(commands).join('\n')).not.toMatch(
       /reset|rebase|checkout|pull/,
+    );
+  });
+
+  test('blocks a target without the committed bundle before checkout', async () => {
+    const { commands, deps, installDir } = createDeps({
+      targetBundlePresent: false,
+    });
+
+    const plan = await planSelfUpdate({ installDir }, deps);
+
+    expect(plan).toMatchObject({
+      status: 'blocked',
+      block: { kind: 'missing_target_bundle' },
+    });
+    expect(signatures(commands).join('\n')).not.toMatch(
+      /remote set-url|checkout|merge|npm install/,
     );
   });
 
@@ -330,6 +508,8 @@ describe('self-update manager', () => {
     expect(
       all.indexOf(`git remote set-url origin ${defaultSelfUpdateRepo}`),
     ).toBeLessThan(all.indexOf('git checkout main'));
+    expect(all).toContain(`git merge --ff-only ${targetCommit}`);
+    expect(all).not.toContain('git pull --ff-only origin main');
     const npmInstall = all.indexOf(
       `npm install -g --ignore-scripts ${installDir}`,
     );
@@ -339,8 +519,32 @@ describe('self-update manager', () => {
     );
   });
 
-  test('skips checkout, bundle verification, and global install when current', async () => {
+  test('applies the planned commit when the remote advances during apply', async () => {
+    const laterCommit = '3333333333333333333333333333333333333333';
     const { commands, deps, installDir } = createDeps({
+      advanceTargetOnApply: laterCommit,
+    });
+
+    const result = await runSelfUpdate({ installDir }, deps);
+
+    expect(result).toMatchObject({
+      status: 'updated',
+      target: { commit: targetCommit },
+      after: { commit: targetCommit },
+    });
+    expect(signatures(commands)).toContain(
+      `git merge --ff-only ${targetCommit}`,
+    );
+    expect(signatures(commands)).not.toContain(
+      `git merge --ff-only ${laterCommit}`,
+    );
+  });
+
+  test('skips checkout, bundle verification, and global install when current', async () => {
+    const installDir = '/tmp/cthutool/source/CthuTool';
+    const { commands, deps } = createDeps({
+      installDir,
+      runtimeRoot: installDir,
       targetCommit: currentCommit,
     });
     const result = await runSelfUpdate({ installDir }, deps);
@@ -348,6 +552,25 @@ describe('self-update manager', () => {
 
     expect(result).toMatchObject({ status: 'up_to_date', steps: [] });
     expect(all).not.toMatch(/remote set-url|checkout|npm install/);
+  });
+
+  test('relinks an explicitly selected current checkout when it differs from the runtime source', async () => {
+    const { commands, deps, installDir } = createDeps({
+      targetCommit: currentCommit,
+    });
+
+    const result = await runSelfUpdate({ installDir }, deps);
+
+    expect(result).toMatchObject({
+      status: 'installed',
+      steps: ['install-global'],
+      before: { commit: currentCommit },
+      after: { commit: currentCommit },
+    });
+    expect(signatures(commands)).toContain(
+      `npm install -g --ignore-scripts ${installDir}`,
+    );
+    expect(signatures(commands).join('\n')).not.toMatch(/checkout|merge|pull/);
   });
 
   test('rechecks safety and stops before mutation when the checkout changes', async () => {
@@ -389,7 +612,8 @@ describe('self-update manager', () => {
   });
 
   test('reports installation status from an explicit checkout', async () => {
-    const { deps, installDir } = createDeps();
+    const repo = 'git@github.com:me/CthuTool.git';
+    const { deps, installDir } = createDeps({ repo });
 
     await expect(
       getCliInstallationStatus({ installDir }, deps),
@@ -397,7 +621,7 @@ describe('self-update manager', () => {
       version: '0.0.0',
       mode: 'local',
       installDir,
-      repo: 'git@github.com:me/CthuTool.git',
+      repo,
       ref: 'main',
       commit: currentCommit.slice(0, 7),
       bundlePath: join(installDir, committedCliBundlePath),

--- a/apps/cli/tests/unit/self-update-output.test.ts
+++ b/apps/cli/tests/unit/self-update-output.test.ts
@@ -128,6 +128,21 @@ describe('self-update output', () => {
     }
   });
 
+  test('reports when an already-current explicit source needs a global relink', () => {
+    const harness = createHarness();
+    const relinkPlan: SelfUpdatePlan = {
+      ...plan,
+      status: 'up_to_date',
+      relinkRequired: true,
+      changes: undefined,
+    };
+
+    harness.renderer.renderCheckResult(relinkPlan);
+
+    expect(harness.stdout()).toContain('Global relink required');
+    expect(harness.stdout()).toContain('run chc update');
+  });
+
   test('writes bounded verbose command details only to stderr', () => {
     const harness = createHarness({
       context: { json: true },

--- a/apps/docs/src/content/docs/client/cli.md
+++ b/apps/docs/src/content/docs/client/cli.md
@@ -69,7 +69,11 @@ chc update --ref v0.1.0
 
 Use `chc --version` for the lightweight version-only check. `chc status` includes that version and detects the source checkout used by the running global command. It reports `mode: local` for a linked development checkout and `mode: remote` for the default managed checkout, together with that checkout's Git and bundle state. Pass `--install-dir <path>` to inspect a different checkout explicitly.
 
-`chc update --check` reports whether installation or an update is required without changing checkout files or the global command. A clean managed `chc update` proceeds directly, shows current-to-target commit progress, and skips global reinstallation when already current. Dirty or diverged checkouts are blocked without automatic stash, reset, clean, or rebase.
+For the default managed source, `chc update --check` and `chc update` use the checkout's existing origin and preserve its symbolic branch, exact tag, or detached commit unless an override is supplied. Checks do not change checkout files or the global command. A clean managed update validates the target bundle before checkout, applies the exact planned commit, shows current-to-target progress, and skips global reinstallation when already current.
+
+When status reports `mode: local`, default update and check commands do not mutate the linked development checkout or `~/.cthutool/source/CthuTool`. Update the linked repository through its normal Git workflow and refresh the committed bundle with `pnpm --filter @cthutool/cli dev`. Run `CHC_INSTALL_MODE=remote scripts/install-chc.sh` to restore the global command to managed mode.
+
+Use `--install-dir <path>`, `--repo <url>`, and `--ref <ref>` (or `CHC_INSTALL_DIR`, `CHC_REPO_URL`, and `CHC_REF`) to explicitly select a custom update source. A successful explicit apply relinks global `chc` to the selected directory. Dirty, diverged, or invalid-bundle targets are blocked without automatic stash, reset, clean, or rebase.
 
 Use `--quiet` for errors-only human output, `--verbose` for bounded Git and npm details on stderr, or `--json` for one structured result. Checks only run when explicitly requested; there is no periodic or shell-startup background update checker.
 

--- a/openspec/changes/archive/2026-07-16-apps-cli-align-update-source-lifecycle/.openspec.yaml
+++ b/openspec/changes/archive/2026-07-16-apps-cli-align-update-source-lifecycle/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-16

--- a/openspec/changes/archive/2026-07-16-apps-cli-align-update-source-lifecycle/design.md
+++ b/openspec/changes/archive/2026-07-16-apps-cli-align-update-source-lifecycle/design.md
@@ -1,0 +1,103 @@
+## Context
+
+The root package is installed globally from a filesystem path, so npm links the global `chc` entrypoint back to the selected repository checkout. The running module can therefore recover its real package root. `chc status` already uses that fact, while the updater independently defaults to the official repository, `main`, and `~/.cthutool/source/CthuTool`.
+
+That split creates two different lifecycle identities. A local-linked command can update and globally install an unrelated managed checkout, while one-shot remote choices such as a fork or tag are lost unless the user repeats environment overrides forever. The managed checkout is also live: checkout mutations affect the next `chc` invocation before bundle verification and global reinstallation finish.
+
+The change must retain the lightweight target requirements of Git, Node.js 24, and npm; preserve the committed bundle model; avoid destructive Git recovery; and keep existing explicit source overrides available.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Give status, check, and update one shared understanding of the running installation source.
+- Prevent a default update from mutating or replacing an unrelated local-linked checkout.
+- Preserve the actual origin and checked-out branch, exact tag, or commit for managed updates unless the user explicitly overrides them.
+- Validate the planned target before worktree mutation and apply exactly the commit displayed by preflight.
+- Keep dirty and diverged work untouched in both CLI and remote-installer managed flows.
+- Prevent repository credentials from appearing in human, JSON, verbose, or diagnostic output.
+- Cover default entrypoints rather than testing only explicitly injected update directories.
+
+**Non-Goals:**
+
+- Automatically pull, merge, rebase, reset, stash, or clean a local development checkout.
+- Add a persistent installation registry or infer historical installer intent for every custom path.
+- Make managed checkout replacement fully transactional across process or filesystem failure.
+- Add a background update checker, publish to npm, or change the committed bundle model.
+- Change the existing `local` and `remote` status labels in this change.
+
+## Decisions
+
+### Resolve one installation source context
+
+Introduce a shared source-context resolver used by status and update. It identifies the runtime package root, the default managed root, whether the runtime root is the default managed checkout, Git origin and identity when available, and whether an install-directory selection was explicit.
+
+Update selection uses this precedence:
+
+1. Install directory: CLI `--install-dir`, then `CHC_INSTALL_DIR`, then the runtime package root.
+2. Repository: CLI `--repo`, then `CHC_REPO_URL` or `CHC_REPO`, then the selected checkout's `origin`, then the official default for an absent checkout.
+3. Ref: CLI `--ref`, then `CHC_REF`, then the selected checkout's symbolic branch, exact tag, or current commit, then `main` for an absent checkout.
+
+The runtime package root is preferred over the current working directory because the command can be invoked from anywhere. Reading the actual checkout is preferred over a state file because npm links can be replaced outside the installer and the linked module remains the source of truth.
+
+### Treat local-linked default update as blocked, not automatic Git management
+
+When the runtime source is outside the default managed root and no install-directory override is present, `chc update` and `chc update --check` produce the existing `blocked` plan status with a new `local_linked_source` block kind. They identify the local source, explain that it follows developer-managed files, and direct the user to update and rebuild that checkout or use the documented remote restore command.
+
+The command performs no remote fetch, managed-checkout mutation, checkout, or npm global install in this state. A CLI or environment install-directory override remains an explicit opt-in to the existing advanced update behavior, including relinking the global command to that selected directory after a successful apply.
+
+Automatically updating the local checkout was rejected because local sources can be dirty, detached, on feature branches, or attached to a multi-worktree repository. Silently retaining the managed default was rejected because it caused the reported bug and can change installation mode without consent.
+
+### Preserve installed managed source choices
+
+For the default managed runtime, repository and ref defaults come from the checkout itself. A symbolic branch tracks the matching remote branch; an exact tag remains pinned to that tag; a detached untagged commit remains pinned to that commit. Moving from a pinned ref to `main`, changing repository, or selecting another directory requires an explicit override.
+
+This avoids silently replacing forks and pins. Non-default remote installation directories continue to be reported as `local` under the existing path-based status contract; their users must keep using an explicit install-directory override. A registry that could distinguish those directories was rejected as outside this change.
+
+### Validate and freeze the planned target
+
+Preflight fetches the requested ref, resolves one full target commit, performs branch ancestry checks, and verifies `apps/cli/dist/index.js` exists in that target commit with Git object inspection before checkout. Apply rechecks worktree cleanliness and then advances or detaches the checkout to the recorded commit rather than running an unconstrained `git pull` that can install a newer commit than the plan displayed.
+
+Bundle presence is verified again after checkout as defense in depth. Full staging-directory replacement was rejected for now because it changes checkout ownership, cleanup, and npm-link mechanics substantially; exact-target application plus pre-mutation bundle validation addresses the known failure without introducing a second managed checkout lifecycle.
+
+### Redact at every output boundary
+
+Use one URL-userinfo redaction helper for plan/result repository fields, emitted command arguments, captured stdout and stderr, `SelfUpdateError` causes, verbose rendering, and command diagnostic details. Raw subprocess results may remain available only inside the updater long enough to classify success; they must not cross an output or diagnostics boundary unsanitized.
+
+Redacting only command arguments was rejected because Git commonly repeats a failing URL in stderr. Key-based diagnostics sanitization alone was also rejected because a field named `repo` is not currently considered sensitive.
+
+### Align remote installer safety with updater safety
+
+For an existing managed checkout, the shell installer checks dirty state before changing `origin`, resolves and validates the configured target before checkout, blocks non-fast-forward branch movement, and applies the resolved commit. It continues to clone a missing checkout and never auto-recovers by reset, rebase, stash, or clean.
+
+The shell flow remains separate from the TypeScript updater because the public raw installer must run before `chc` exists and cannot depend on workspace tooling. Contract tests keep the two implementations behaviorally aligned.
+
+### Preserve structured compatibility where possible
+
+The existing plan status union remains unchanged. Local-linked detection uses `status: "blocked"` plus `block.kind: "local_linked_source"`; applying or checking that plan continues through the existing `update_failed` error contract. Successful managed JSON result shapes remain unchanged, with source selection made accurate rather than adding another success state.
+
+This is intentionally breaking for scripts that ran a local-linked `chc update` expecting it to manage the default remote checkout. Those scripts can pass an explicit install directory or use the remote installer restore flow.
+
+## Risks / Trade-offs
+
+- [A local user expected `chc update` to switch back to remote mode] → Block with the exact source path and the existing remote restore command; keep explicit directory overrides.
+- [Exact tag detection can find multiple tags at one commit] → Choose a deterministic sorted exact tag for display while preserving the target commit identity.
+- [A remote branch advances after preflight] → Install the preflight commit and let the next check report the later commit instead of changing the approved target mid-apply.
+- [The managed checkout is still updated in place] → Validate the target bundle before checkout, recheck after checkout, and leave full staged replacement for a separately scoped change.
+- [Custom remote directories remain labeled local] → Preserve the documented current contract and require explicit `--install-dir` or `CHC_INSTALL_DIR`; do not introduce stale persistent state.
+- [Stronger installer preflight rejects a checkout previously carried through with local edits] → Report recovery guidance and never discard the edits automatically.
+- [Redaction can hide part of a legitimate URL] → Redact only URL userinfo and retain host, path, bounded Git context, and phase information.
+
+## Migration Plan
+
+1. Add the shared source context and update-selection tests before routing command behavior through it.
+2. Add local-linked blocking, installed repo/ref inference, exact-target planning, bundle object validation, and output redaction.
+3. Align the remote installer contract and update documentation for local and managed workflows.
+4. Refresh the committed CLI bundle and run focused lint, type, contract, unit, integration, bundle-freshness, and diff checks.
+5. Existing local-linked users continue running from their checkout; their next update command explains the manual development workflow instead of touching the managed directory.
+
+Rollback restores the prior bundle and source files. Users who need a managed command during rollback can run `CHC_INSTALL_MODE=remote scripts/install-chc.sh` from a checkout.
+
+## Open Questions
+
+None.

--- a/openspec/changes/archive/2026-07-16-apps-cli-align-update-source-lifecycle/proposal.md
+++ b/openspec/changes/archive/2026-07-16-apps-cli-align-update-source-lifecycle/proposal.md
@@ -1,0 +1,33 @@
+## Why
+
+`chc status` reports the checkout that actually provides the running command, but `chc update` always targets the default managed checkout. A locally linked installation can therefore inspect or replace an unrelated checkout, silently switch back to remote mode, or claim that `chc` is current by comparing the wrong source.
+
+## What Changes
+
+- Make update source selection aware of the checkout that provides the running `chc` command.
+- **BREAKING** Stop default `chc update` and `chc update --check` from operating on the managed checkout when the running command is linked to a local checkout; return a clear local-development outcome without mutating either checkout or the global npm link.
+- Keep automatic Git mutation for the default managed installation and keep `--install-dir` as the explicit advanced override for selecting another checkout.
+- Resolve managed update defaults from the selected checkout's actual origin and checked-out branch, exact tag, or commit so one-shot fork and ref selections are not silently replaced by the official `main` target.
+- Verify the target commit contains the committed CLI bundle before changing the live checkout, and apply the exact commit approved by preflight rather than a later moving branch head.
+- Apply credential redaction consistently to update plans, verbose command events, failures, JSON output, and command diagnostics.
+- Bring the remote installer and CLI updater safety contracts into alignment for dirty, diverged, and invalid target checkouts.
+- Update lifecycle documentation and focused tests for local, managed, custom-source, pinned-ref, detached-head, failure-redaction, and plan/apply race scenarios.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `apps-cli-self-installation`: Align default update behavior with the actual installed source, preserve explicit source selection, and prevent unsafe or implicit installation-mode switches.
+- `apps-cli-update-experience`: Extend preflight classification and apply guarantees for local-linked sources, target-bundle validation, exact-commit application, and redacted failures.
+- `apps-docs-site`: Document source-aware update behavior, local-development recovery, explicit managed switching, and custom or pinned update targets.
+
+## Impact
+
+- Affects `apps/cli/src/domain/self-update-manager.ts`, the lifecycle command and renderer, CLI diagnostics redaction, `scripts/install-chc.sh`, and the committed CLI bundle.
+- Changes default human and JSON outcomes for `chc update` when the running installation is local-linked.
+- Requires unit, integration, installer-contract, global-bin, output, and documentation coverage.
+- Does not add a background updater, publish an npm package, or automatically reset, rebase, stash, or clean user work.

--- a/openspec/changes/archive/2026-07-16-apps-cli-align-update-source-lifecycle/specs/apps-cli-self-installation/spec.md
+++ b/openspec/changes/archive/2026-07-16-apps-cli-align-update-source-lifecycle/specs/apps-cli-self-installation/spec.md
@@ -1,90 +1,4 @@
-# apps-cli-self-installation Specification
-
-## Purpose
-Define GitHub-based personal installation, lifecycle status, and update behavior for the `chc` CLI.
-## Requirements
-### Requirement: Public GitHub Installer
-The repository SHALL provide a shell installer that can be executed from the public GitHub raw URL or from a local checkout to install the `chc` CLI globally from committed prebuilt output.
-
-#### Scenario: Public raw installer command
-- **WHEN** a user runs the public raw GitHub installer with `curl -fsSL ... | bash`
-- **THEN** the installer runs in remote managed mode
-- **AND** it clones or updates the configured repository into a managed local checkout
-- **AND** it verifies the committed `apps/cli/dist/index.js` runtime bundle is present
-- **AND** it installs the root package globally so `chc` is available on `PATH`
-
-#### Scenario: Local checkout installer command
-- **WHEN** a user runs `scripts/install-chc.sh` from a repository checkout without forcing remote mode
-- **THEN** the installer runs in local checkout mode
-- **AND** it uses the repository containing the script as the install source
-- **AND** it does not clone, fetch, checkout, or pull the managed source checkout
-- **AND** it verifies the local `apps/cli/dist/index.js` runtime bundle is present
-- **AND** it installs the local root package globally so `chc` is available on `PATH`
-
-#### Scenario: Installer default repository
-- **WHEN** the installer runs in remote managed mode without repository override environment variables
-- **THEN** it uses `https://github.com/mickmetalholic/CthuTool.git` as the source repository
-
-#### Scenario: Installer configurable source
-- **WHEN** the user sets `CHC_REPO_URL`, `CHC_REPO`, `CHC_REF`, or `CHC_INSTALL_DIR`
-- **THEN** the installer uses those values for repository URL, Git ref, and local checkout directory in remote managed mode
-
-#### Scenario: Installer configurable mode
-- **WHEN** the user sets an installer mode override
-- **THEN** the installer uses the requested mode instead of auto-detecting from invocation style
-- **AND** remote managed mode uses the configured managed checkout source
-- **AND** local checkout mode uses the repository containing the local installer script
-
-#### Scenario: Installer prerequisites
-- **WHEN** a required command such as `git`, `node`, or `npm` is missing
-- **THEN** the installer fails with a clear missing-command message before attempting installation
-
-#### Scenario: Installer skips local build toolchain
-- **WHEN** the installer runs on a target machine
-- **THEN** it does not require `pnpm` or `bun`
-- **AND** it does not run workspace dependency installation or CLI build commands
-
-#### Scenario: Node runtime guard
-- **WHEN** the local Node major version is not 24
-- **THEN** the installer fails before global installation
-
-#### Scenario: Automatic zsh completion setup
-- **WHEN** the installer succeeds and the user's login shell is zsh
-- **AND** completion setup has not been disabled
-- **THEN** the installer enables persistent `chc` completion in the user's zsh profile
-
-#### Scenario: Automatic completion setup opt-out
-- **WHEN** the user sets `CHC_INSTALL_COMPLETION=none`
-- **THEN** the installer does not modify a shell profile
-
-### Requirement: Managed Source Checkout
-Remote managed install and update flows SHALL use a managed source checkout containing committed CLI build output as the source for the global `chc` installation.
-
-#### Scenario: First install clone
-- **WHEN** the remote managed checkout directory does not contain a Git checkout
-- **THEN** the remote managed install flow clones the configured repository into that directory
-
-#### Scenario: Existing checkout update
-- **WHEN** the remote managed checkout directory already contains a Git checkout
-- **THEN** the remote managed install flow updates the remote URL
-- **AND** it fetches tags from origin before checking out the requested ref
-
-#### Scenario: Branch fast-forward
-- **WHEN** the requested ref exists as `origin/<ref>`
-- **THEN** the remote managed install flow fast-forwards the checkout from origin for that ref
-
-#### Scenario: Tag or commit checkout
-- **WHEN** the requested ref does not exist as `origin/<ref>`
-- **THEN** the remote managed install flow does not attempt a branch pull after checkout
-
-#### Scenario: Local checkout mode bypasses managed checkout
-- **WHEN** the installer runs in local checkout mode
-- **THEN** the installer does not use the managed source checkout as the install source
-- **AND** it does not mutate the managed source checkout
-
-#### Scenario: Missing committed bundle
-- **WHEN** the selected install source does not contain `apps/cli/dist/index.js`
-- **THEN** the install flow fails before global installation with a clear missing-bundle message
+## MODIFIED Requirements
 
 ### Requirement: CLI Lifecycle Commands
 The CLI SHALL provide top-level lifecycle entry points for viewing the installed CLI version, inspecting installation state, and safely updating the global `chc` installation from committed prebuilt output according to its actual source checkout. The discoverable interface SHALL use `chc --version` for version-only output and `chc status` for installation diagnostics, while retaining `chc version` as an undiscoverable compatibility alias.
@@ -181,41 +95,6 @@ The CLI SHALL provide top-level lifecycle entry points for viewing the installed
 - **THEN** the command exits non-zero
 - **AND** reports an `update_failed` command error with the failed phase and bounded redacted recovery context
 
-### Requirement: Installation Documentation
-The repository SHALL document the public and local CLI install flows, lightweight target prerequisites, committed runtime bundle, canonical lifecycle commands, and update path.
-
-#### Scenario: Public install documented
-- **WHEN** a user reads the root README
-- **THEN** it shows a `curl -fsSL https://raw.githubusercontent.com/mickmetalholic/CthuTool/main/scripts/install-chc.sh | bash` installation command
-- **AND** it explains that public raw installation uses the managed checkout
-- **AND** it explains automatic zsh completion setup and its opt-out
-
-#### Scenario: Local checkout install documented
-- **WHEN** a developer reads the CLI installation documentation
-- **THEN** it explains that running `scripts/install-chc.sh` from a local checkout installs global `chc` from that checkout
-- **AND** it shows the CLI watch build command needed for source-editing development
-
-#### Scenario: Remote restore documented
-- **WHEN** a developer reads the CLI installation documentation
-- **THEN** it shows how to force remote managed installation after a local checkout install
-
-#### Scenario: Lighter target prerequisites documented
-- **WHEN** a user reads the CLI installation documentation
-- **THEN** it explains that target machines need `git`, Node 24, and `npm`, but do not need `pnpm` or `bun` for install/update
-
-#### Scenario: Committed bundle documented
-- **WHEN** a developer reads the CLI installation documentation
-- **THEN** it explains that CLI source changes must refresh the committed `apps/cli/dist/index.js` bundle
-
-#### Scenario: Lifecycle commands documented
-- **WHEN** a user reads the CLI installation documentation
-- **THEN** it shows `chc --version`, `chc status`, and `chc update` as the canonical lifecycle entry points
-- **AND** it does not present `chc version` as a canonical command
-
-#### Scenario: Update documented
-- **WHEN** a user reads the CLI installation documentation
-- **THEN** it shows `chc update` as the update path after the first install
-
 ### Requirement: Managed Update Safety
 Managed checkout install and update flows SHALL preserve local work, validate the selected target, and complete safety checks before mutating checkout files or reinstalling the global command.
 
@@ -243,6 +122,8 @@ Managed checkout install and update flows SHALL preserve local work, validate th
 - **WHEN** the running global command is linked to a local checkout and no install-directory override is provided
 - **THEN** update does not mutate that checkout or the default managed checkout
 - **AND** it does not relink the global command
+
+## ADDED Requirements
 
 ### Requirement: Local Update Documentation
 The repository SHALL distinguish managed self-update from the manual local-development update workflow.

--- a/openspec/changes/archive/2026-07-16-apps-cli-align-update-source-lifecycle/specs/apps-cli-update-experience/spec.md
+++ b/openspec/changes/archive/2026-07-16-apps-cli-align-update-source-lifecycle/specs/apps-cli-update-experience/spec.md
@@ -1,0 +1,113 @@
+## ADDED Requirements
+
+### Requirement: Update Source Resolution
+The CLI SHALL resolve update defaults from the checkout that provides the running command and SHALL require explicit authorization before selecting a different checkout.
+
+#### Scenario: Managed runtime source selection
+- **WHEN** the running package root is the default managed source directory
+- **AND** no install-directory override is present
+- **THEN** update selects that package root as its source checkout
+
+#### Scenario: Local runtime source selection
+- **WHEN** the running package root is outside the default managed source directory
+- **AND** no install-directory override is present
+- **THEN** update classifies the source as local-linked before any remote operation
+- **AND** does not fall back to the default managed checkout
+
+#### Scenario: Explicit directory selection
+- **WHEN** `--install-dir` or `CHC_INSTALL_DIR` selects a checkout
+- **THEN** update uses that directory instead of the runtime package root
+- **AND** treats the selection as explicit authorization to update and globally install from that directory
+
+#### Scenario: Installed repository selection
+- **WHEN** an existing selected checkout has an `origin` remote and no repository override is present
+- **THEN** update uses the existing origin URL instead of replacing it with the official default
+
+#### Scenario: Installed ref selection
+- **WHEN** an existing selected checkout has no ref override
+- **THEN** update preserves its symbolic branch, deterministic exact tag, or detached commit
+- **AND** does not silently switch a pinned installation to `main`
+
+#### Scenario: Missing checkout defaults
+- **WHEN** an explicitly selected checkout is absent
+- **AND** repository or ref overrides are absent
+- **THEN** update uses the official repository and `main` defaults for the initial managed clone
+
+### Requirement: Update Output Credential Safety
+The CLI SHALL redact repository URL userinfo from every update output and diagnostic boundary.
+
+#### Scenario: Failed authenticated repository command
+- **WHEN** a Git command fails for a repository URL containing userinfo credentials
+- **THEN** human errors, JSON errors, verbose command details, phase events, and command diagnostics omit those credentials
+- **AND** retain bounded host, repository path, phase, and recovery context
+
+#### Scenario: Successful authenticated repository plan
+- **WHEN** a plan or result contains a repository URL with userinfo credentials
+- **THEN** human and JSON source fields contain a redacted URL
+
+## MODIFIED Requirements
+
+### Requirement: Update Preflight Classification
+The CLI SHALL inspect the resolved installed source and selected target before changing the checkout worktree or global installation.
+
+#### Scenario: Managed install required
+- **WHEN** an explicitly selected managed install directory has no Git checkout
+- **THEN** preflight classifies the operation as `install_required`
+- **AND** identifies the selected repository, ref, and install directory
+
+#### Scenario: Update available
+- **WHEN** the selected checkout is safe to update, contains a valid target bundle, and its current commit differs from the resolved target commit
+- **THEN** preflight classifies the operation as `update_available`
+- **AND** reports the current and exact target commit identities and bounded change count when available
+
+#### Scenario: Already current
+- **WHEN** the selected checkout already resolves to the target commit
+- **THEN** preflight classifies the operation as `up_to_date`
+- **AND** the update command exits successfully without checking out files or reinstalling the global command
+
+#### Scenario: Local-linked default source is blocked
+- **WHEN** the runtime source is outside the default managed directory
+- **AND** no install-directory override is present
+- **THEN** preflight classifies the operation as `blocked` with block kind `local_linked_source`
+- **AND** performs no remote fetch or checkout mutation
+
+#### Scenario: Dirty checkout is blocked
+- **WHEN** an existing selected checkout has tracked or untracked worktree changes
+- **THEN** preflight classifies the operation as `blocked`
+- **AND** reports that the user must preserve or remove the local changes before retrying
+- **AND** does not change the remote URL, checkout, or global installation
+
+#### Scenario: Non-fast-forward branch is blocked
+- **WHEN** the current branch cannot safely fast-forward to the resolved remote branch target
+- **THEN** preflight classifies the operation as `blocked`
+- **AND** does not rewrite, reset, or automatically stash the checkout
+
+#### Scenario: Missing target bundle is blocked before checkout
+- **WHEN** the resolved target commit lacks the committed CLI bundle
+- **THEN** preflight blocks the operation before checkout mutation or global installation
+- **AND** reports the target and missing bundle path
+
+### Requirement: Actionable Update Failures
+The CLI SHALL report update failures by stable phase with a concise summary, bounded redacted cause, and recovery hint while retaining the `update_failed` command error code.
+
+#### Scenario: Local-linked source failure
+- **WHEN** default update or check is invoked from a local-linked installation
+- **THEN** the command identifies the local source directory
+- **AND** explains the manual checkout update workflow and remote restore path
+- **AND** attempts no managed update
+
+#### Scenario: Preflight failure
+- **WHEN** update prerequisites, target validation, or checkout safety checks fail
+- **THEN** the command identifies the preflight phase and the blocked resource or condition
+- **AND** no global installation is attempted
+
+#### Scenario: Apply phase failure
+- **WHEN** clone, fetch, checkout, bundle verification, or global installation fails
+- **THEN** the command identifies the failed phase
+- **AND** provides a recovery hint appropriate to that phase
+- **AND** exits non-zero with error code `update_failed`
+
+#### Scenario: Default failure detail is bounded and redacted
+- **WHEN** a subprocess produces lengthy output or repeats an authenticated repository URL during a failed update
+- **THEN** default human and JSON errors include only bounded safe context without repository credentials
+- **AND** verbose output and diagnostics remain bounded and apply the same credential redaction

--- a/openspec/changes/archive/2026-07-16-apps-cli-align-update-source-lifecycle/specs/apps-docs-site/spec.md
+++ b/openspec/changes/archive/2026-07-16-apps-cli-align-update-source-lifecycle/specs/apps-docs-site/spec.md
@@ -1,0 +1,44 @@
+## MODIFIED Requirements
+
+### Requirement: Client installation documentation
+The docs site SHALL document how users install, inspect, safely update, switch, and remove CthuTool client tools on client computers using the canonical CLI lifecycle interface.
+
+#### Scenario: Reader installs CLI tooling
+- **WHEN** a reader opens CLI installation documentation
+- **THEN** the documentation explains target-machine prerequisites, public raw installer usage, committed bundle runtime behavior, remote install mode, local checkout install mode, automatic zsh completion behavior, and supported override environment variables
+
+#### Scenario: Reader checks the installed CLI version
+- **WHEN** a reader needs only the installed CLI version
+- **THEN** the documentation presents `chc --version` as the canonical version-only entry point
+- **AND** it does not present the legacy `chc version` compatibility alias as a canonical command
+
+#### Scenario: Reader inspects installed CLI tooling
+- **WHEN** a reader needs to inspect CLI installation state
+- **THEN** the documentation explains that `chc status` includes the installed version and reports the detected local or remote source checkout
+- **AND** it documents the explicit install-directory override
+
+#### Scenario: Reader updates managed CLI tooling
+- **WHEN** a reader needs to update a default remote managed installation
+- **THEN** the documentation presents `chc update --check` and `chc update` as source-aware managed update commands
+- **AND** explains that repository and ref defaults follow the installed managed checkout
+
+#### Scenario: Reader updates local-linked CLI tooling
+- **WHEN** a reader uses a local-linked installation
+- **THEN** the documentation explains that default `chc update` does not mutate the local or managed checkout
+- **AND** shows the manual Git and committed-bundle development workflow
+- **AND** shows how to restore the global command to remote managed mode explicitly
+
+#### Scenario: Reader updates an explicit custom checkout
+- **WHEN** a reader intentionally manages a non-default update checkout
+- **THEN** the documentation explains the `--install-dir`, `--repo`, and `--ref` overrides and their environment equivalents
+- **AND** warns that a successful explicit apply can relink the global command to that selected checkout
+
+### Requirement: CLI installer mode documentation
+The docs site SHALL document CLI installer mode selection and its relationship to subsequent status and update behavior.
+
+#### Scenario: Reader compares remote and local mode
+- **WHEN** a reader reviews CLI installation docs
+- **THEN** the documentation explains that raw/stdin installer usage selects remote mode and checkout script execution selects local mode by default
+- **AND** explains that `chc status` derives mode from the checkout providing the running module
+- **AND** explains that default automatic update is available only for the default managed source
+- **AND** documents `CHC_INSTALL_MODE=remote` as the way to restore the global command to the managed checkout after local development

--- a/openspec/changes/archive/2026-07-16-apps-cli-align-update-source-lifecycle/tasks.md
+++ b/openspec/changes/archive/2026-07-16-apps-cli-align-update-source-lifecycle/tasks.md
@@ -1,0 +1,45 @@
+## 1. Source Context and Selection
+
+- [x] 1.1 Extract an injectable runtime package-root resolver and a shared installation source context used by both `status` and `update`.
+- [x] 1.2 Implement install-directory, repository, and ref precedence across CLI overrides, environment overrides, actual checkout origin and identity, and absent-checkout defaults.
+- [x] 1.3 Detect symbolic branches, deterministic exact tags, and detached commits without silently falling back to `main`.
+- [x] 1.4 Add unit coverage for default managed, local-linked, fork origin, pinned tag, detached commit, absent checkout, and explicit directory selection.
+
+## 2. Source-Aware Update Behavior
+
+- [x] 2.1 Add the `local_linked_source` blocked plan kind before any remote command when no install-directory override authorizes another checkout.
+- [x] 2.2 Render actionable human and JSON local-development guidance with the actual source path and remote restore command.
+- [x] 2.3 Preserve explicit `--install-dir` and `CHC_INSTALL_DIR` update and relink behavior outside the default managed checkout.
+- [x] 2.4 Add command-level tests proving default local `update` and `update --check` do not fetch, mutate either checkout, invoke npm, or change the global source link.
+- [x] 2.5 Add default-entrypoint tests that exercise runtime source detection without injecting all three source overrides.
+
+## 3. Deterministic and Safe Managed Apply
+
+- [x] 3.1 Verify the fetched target commit contains `apps/cli/dist/index.js` through Git object inspection before checkout mutation.
+- [x] 3.2 Record one full target commit in the plan and apply that exact commit for branch, tag, and raw commit targets instead of an unconstrained later pull.
+- [x] 3.3 Recheck worktree cleanliness and post-checkout bundle presence while preserving existing dirty and diverged checkout protections.
+- [x] 3.4 Add unit and integration coverage for missing target bundles, remote advancement between plan and apply, exact-target results, and no-op updates.
+
+## 4. Output and Diagnostic Credential Safety
+
+- [x] 4.1 Centralize repository URL userinfo redaction for plan and result fields, command arguments, captured stdout and stderr, and update error causes.
+- [x] 4.2 Sanitize update failure diagnostic details and verbose output without removing bounded host, repository path, phase, and recovery context.
+- [x] 4.3 Add success and failure tests proving authenticated repository credentials never appear in human output, JSON output, verbose events, or diagnostics.
+
+## 5. Remote Installer Safety Alignment
+
+- [x] 5.1 Update the remote installer to reject tracked or untracked changes before changing `origin` or checkout state.
+- [x] 5.2 Resolve the configured remote target, block non-fast-forward branch movement, validate its committed bundle, and apply the resolved commit without reset, rebase, stash, or clean.
+- [x] 5.3 Extend installer contract fixtures and tests for clean updates, dirty and diverged blocks, invalid bundles, exact target application, and unchanged local mode.
+
+## 6. Documentation and Release Artifact
+
+- [x] 6.1 Update the root README, CLI README, and docs-site CLI guide to distinguish managed self-update, manual local development updates, explicit custom targets, and remote restore behavior.
+- [x] 6.2 Refresh `apps/cli/dist/index.js` from the updated CLI source and verify the committed bundle matches source.
+
+## 7. Verification
+
+- [x] 7.1 Run targeted ESLint for changed CLI TypeScript files, the CLI TypeScript type check, and `git diff --check`.
+- [x] 7.2 Run focused self-update unit, output, integration, global-bin, diagnostics, and installer contract tests.
+- [x] 7.3 Run the repository's CLI bundle freshness verification and confirm generated `.claude/`, `.codex/`, and `.cursor/` adapter files remain unchanged.
+- [x] 7.4 Run OpenSpec validation for `apps-cli-align-update-source-lifecycle` and review the final diff for scope and requirement coverage.

--- a/openspec/specs/apps-cli-update-experience/spec.md
+++ b/openspec/specs/apps-cli-update-experience/spec.md
@@ -4,22 +4,28 @@
 TBD - created by archiving change apps-cli-update-experience. Update Purpose after archive.
 ## Requirements
 ### Requirement: Update Preflight Classification
-The CLI SHALL inspect the selected update source and classify the intended operation before changing the checkout worktree or global installation.
+The CLI SHALL inspect the resolved installed source and selected target before changing the checkout worktree or global installation.
 
 #### Scenario: Managed install required
-- **WHEN** the selected managed install directory has no Git checkout
+- **WHEN** an explicitly selected managed install directory has no Git checkout
 - **THEN** preflight classifies the operation as `install_required`
 - **AND** identifies the selected repository, ref, and install directory
 
 #### Scenario: Update available
-- **WHEN** the selected checkout is safe to update and its current commit differs from the resolved target commit
+- **WHEN** the selected checkout is safe to update, contains a valid target bundle, and its current commit differs from the resolved target commit
 - **THEN** preflight classifies the operation as `update_available`
-- **AND** reports the current and target commit identities and bounded change count when available
+- **AND** reports the current and exact target commit identities and bounded change count when available
 
 #### Scenario: Already current
 - **WHEN** the selected checkout already resolves to the target commit
 - **THEN** preflight classifies the operation as `up_to_date`
 - **AND** the update command exits successfully without checking out files or reinstalling the global command
+
+#### Scenario: Local-linked default source is blocked
+- **WHEN** the runtime source is outside the default managed directory
+- **AND** no install-directory override is present
+- **THEN** preflight classifies the operation as `blocked` with block kind `local_linked_source`
+- **AND** performs no remote fetch or checkout mutation
 
 #### Scenario: Dirty checkout is blocked
 - **WHEN** an existing selected checkout has tracked or untracked worktree changes
@@ -31,6 +37,11 @@ The CLI SHALL inspect the selected update source and classify the intended opera
 - **WHEN** the current branch cannot safely fast-forward to the resolved remote branch target
 - **THEN** preflight classifies the operation as `blocked`
 - **AND** does not rewrite, reset, or automatically stash the checkout
+
+#### Scenario: Missing target bundle is blocked before checkout
+- **WHEN** the resolved target commit lacks the committed CLI bundle
+- **THEN** preflight blocks the operation before checkout mutation or global installation
+- **AND** reports the target and missing bundle path
 
 ### Requirement: Read-only Update Availability Check
 The CLI SHALL provide `chc update --check` to report update availability without changing checkout files or the global installation.
@@ -106,10 +117,16 @@ The CLI SHALL expose stable machine-readable update states and identities while 
 - **AND** no apply-only phase is reported as completed
 
 ### Requirement: Actionable Update Failures
-The CLI SHALL report update failures by stable phase with a concise summary, bounded cause, and recovery hint while retaining the `update_failed` command error code.
+The CLI SHALL report update failures by stable phase with a concise summary, bounded redacted cause, and recovery hint while retaining the `update_failed` command error code.
+
+#### Scenario: Local-linked source failure
+- **WHEN** default update or check is invoked from a local-linked installation
+- **THEN** the command identifies the local source directory
+- **AND** explains the manual checkout update workflow and remote restore path
+- **AND** attempts no managed update
 
 #### Scenario: Preflight failure
-- **WHEN** update prerequisites or checkout safety checks fail
+- **WHEN** update prerequisites, target validation, or checkout safety checks fail
 - **THEN** the command identifies the preflight phase and the blocked resource or condition
 - **AND** no global installation is attempted
 
@@ -119,7 +136,52 @@ The CLI SHALL report update failures by stable phase with a concise summary, bou
 - **AND** provides a recovery hint appropriate to that phase
 - **AND** exits non-zero with error code `update_failed`
 
-#### Scenario: Default failure detail is bounded
-- **WHEN** a subprocess produces lengthy output during a failed update
-- **THEN** default human and JSON errors include only bounded safe context
-- **AND** direct command, cwd, and expanded output details are reserved for verbose output or diagnostics
+#### Scenario: Default failure detail is bounded and redacted
+- **WHEN** a subprocess produces lengthy output or repeats an authenticated repository URL during a failed update
+- **THEN** default human and JSON errors include only bounded safe context without repository credentials
+- **AND** verbose output and diagnostics remain bounded and apply the same credential redaction
+
+### Requirement: Update Source Resolution
+The CLI SHALL resolve update defaults from the checkout that provides the running command and SHALL require explicit authorization before selecting a different checkout.
+
+#### Scenario: Managed runtime source selection
+- **WHEN** the running package root is the default managed source directory
+- **AND** no install-directory override is present
+- **THEN** update selects that package root as its source checkout
+
+#### Scenario: Local runtime source selection
+- **WHEN** the running package root is outside the default managed source directory
+- **AND** no install-directory override is present
+- **THEN** update classifies the source as local-linked before any remote operation
+- **AND** does not fall back to the default managed checkout
+
+#### Scenario: Explicit directory selection
+- **WHEN** `--install-dir` or `CHC_INSTALL_DIR` selects a checkout
+- **THEN** update uses that directory instead of the runtime package root
+- **AND** treats the selection as explicit authorization to update and globally install from that directory
+
+#### Scenario: Installed repository selection
+- **WHEN** an existing selected checkout has an `origin` remote and no repository override is present
+- **THEN** update uses the existing origin URL instead of replacing it with the official default
+
+#### Scenario: Installed ref selection
+- **WHEN** an existing selected checkout has no ref override
+- **THEN** update preserves its symbolic branch, deterministic exact tag, or detached commit
+- **AND** does not silently switch a pinned installation to `main`
+
+#### Scenario: Missing checkout defaults
+- **WHEN** an explicitly selected checkout is absent
+- **AND** repository or ref overrides are absent
+- **THEN** update uses the official repository and `main` defaults for the initial managed clone
+
+### Requirement: Update Output Credential Safety
+The CLI SHALL redact repository URL userinfo from every update output and diagnostic boundary.
+
+#### Scenario: Failed authenticated repository command
+- **WHEN** a Git command fails for a repository URL containing userinfo credentials
+- **THEN** human errors, JSON errors, verbose command details, phase events, and command diagnostics omit those credentials
+- **AND** retain bounded host, repository path, phase, and recovery context
+
+#### Scenario: Successful authenticated repository plan
+- **WHEN** a plan or result contains a repository URL with userinfo credentials
+- **THEN** human and JSON source fields contain a redacted URL

--- a/openspec/specs/apps-docs-site/spec.md
+++ b/openspec/specs/apps-docs-site/spec.md
@@ -84,7 +84,7 @@ The docs site SHALL document Kubernetes/GitOps as the official user-facing deplo
 - **THEN** the documentation identifies the GitOps-managed observability namespace, ArgoCD Applications, Prometheus metrics scrape path, Loki log collection path, Tempo trace storage path, and OpenTelemetry Collector ingestion path
 
 ### Requirement: Client installation documentation
-The docs site SHALL document how users install, inspect, update, and remove CthuTool client tools on client computers using the canonical CLI lifecycle interface.
+The docs site SHALL document how users install, inspect, safely update, switch, and remove CthuTool client tools on client computers using the canonical CLI lifecycle interface.
 
 #### Scenario: Reader installs CLI tooling
 - **WHEN** a reader opens CLI installation documentation
@@ -100,9 +100,21 @@ The docs site SHALL document how users install, inspect, update, and remove Cthu
 - **THEN** the documentation explains that `chc status` includes the installed version and reports the detected local or remote source checkout
 - **AND** it documents the explicit install-directory override
 
-#### Scenario: Reader manages installed CLI tooling
-- **WHEN** a reader needs to update CLI tooling
-- **THEN** the documentation presents `chc update` as the update command
+#### Scenario: Reader updates managed CLI tooling
+- **WHEN** a reader needs to update a default remote managed installation
+- **THEN** the documentation presents `chc update --check` and `chc update` as source-aware managed update commands
+- **AND** explains that repository and ref defaults follow the installed managed checkout
+
+#### Scenario: Reader updates local-linked CLI tooling
+- **WHEN** a reader uses a local-linked installation
+- **THEN** the documentation explains that default `chc update` does not mutate the local or managed checkout
+- **AND** shows the manual Git and committed-bundle development workflow
+- **AND** shows how to restore the global command to remote managed mode explicitly
+
+#### Scenario: Reader updates an explicit custom checkout
+- **WHEN** a reader intentionally manages a non-default update checkout
+- **THEN** the documentation explains the `--install-dir`, `--repo`, and `--ref` overrides and their environment equivalents
+- **AND** warns that a successful explicit apply can relink the global command to that selected checkout
 
 ### Requirement: Module usage documentation
 The docs site SHALL provide module-oriented usage documentation for major CthuTool product areas.
@@ -203,9 +215,11 @@ The docs site SHALL document `@cthutool/browser-client` for third-party applicat
 - **THEN** the docs include install/build context, a minimal `CthuBrowserClient` example, session lifecycle, supported page methods, and limitations
 
 ### Requirement: CLI installer mode documentation
-The docs site SHALL document CLI installer mode selection for user and development install paths.
+The docs site SHALL document CLI installer mode selection and its relationship to subsequent status and update behavior.
 
 #### Scenario: Reader compares remote and local mode
 - **WHEN** a reader reviews CLI installation docs
 - **THEN** the documentation explains that raw/stdin installer usage selects remote mode and checkout script execution selects local mode by default
-- **AND** it documents `CHC_INSTALL_MODE=remote` as the way to restore the global command to the managed checkout after local development
+- **AND** explains that `chc status` derives mode from the checkout providing the running module
+- **AND** explains that default automatic update is available only for the default managed source
+- **AND** documents `CHC_INSTALL_MODE=remote` as the way to restore the global command to the managed checkout after local development

--- a/scripts/install-chc.sh
+++ b/scripts/install-chc.sh
@@ -79,22 +79,52 @@ if [ "$selected_mode" = "remote" ]; then
   printf 'ref:  %s\n' "$ref"
   printf 'dir:  %s\n' "$install_dir"
 
-  if [ -d "$install_dir/.git" ]; then
+  if git -C "$install_dir" rev-parse --git-dir >/dev/null 2>&1; then
+    existing_checkout=true
+    if [ -n "$(git -C "$install_dir" status --porcelain --untracked-files=normal)" ]; then
+      printf 'Update blocked: the managed checkout has uncommitted or untracked changes.\n' >&2
+      printf 'Preserve those changes, then retry.\n' >&2
+      exit 1
+    fi
     printf '%s\n' '- fetching repository'
-    git -C "$install_dir" remote set-url origin "$repo_url"
-    git -C "$install_dir" fetch --tags origin
+    git -C "$install_dir" fetch --no-tags "$repo_url" "$ref"
   else
+    existing_checkout=false
     printf '%s\n' '- cloning repository'
     mkdir -p "$(dirname "$install_dir")"
     git clone "$repo_url" "$install_dir"
+    git -C "$install_dir" fetch --no-tags "$repo_url" "$ref"
+  fi
+
+  target_commit="$(git -C "$install_dir" rev-parse --verify 'FETCH_HEAD^{commit}')"
+  if ! git -C "$install_dir" cat-file -e "$target_commit:apps/cli/dist/index.js"; then
+    printf 'Missing committed CLI bundle in target %s: apps/cli/dist/index.js\n' "$target_commit" >&2
+    exit 1
+  fi
+
+  if git ls-remote --exit-code --heads "$repo_url" "$ref" >/dev/null 2>&1; then
+    target_kind="branch"
+    if [ "$existing_checkout" = true ] && ! git -C "$install_dir" merge-base --is-ancestor HEAD "$target_commit"; then
+      printf 'Update blocked: the managed checkout cannot fast-forward to %s.\n' "$ref" >&2
+      printf 'Reconcile the local branch manually, then retry.\n' >&2
+      exit 1
+    fi
+  else
+    target_kind="detached"
+  fi
+
+  if [ "$existing_checkout" = true ]; then
+    git -C "$install_dir" remote set-url origin "$repo_url"
+    git -C "$install_dir" fetch --tags origin
   fi
 
   printf '%s\n' '- checking out ref'
-  git -C "$install_dir" checkout "$ref"
-
-  if git -C "$install_dir" rev-parse --verify "origin/$ref" >/dev/null 2>&1; then
+  if [ "$target_kind" = "branch" ]; then
+    git -C "$install_dir" checkout "$ref"
     printf '%s\n' '- fast-forwarding branch'
-    git -C "$install_dir" pull --ff-only origin "$ref"
+    git -C "$install_dir" merge --ff-only "$target_commit"
+  else
+    git -C "$install_dir" checkout --detach "$target_commit"
   fi
 
   install_source="$install_dir"

--- a/tests/contract/install-chc-script.test.ts
+++ b/tests/contract/install-chc-script.test.ts
@@ -69,6 +69,7 @@ done
 printf '\\n' >> "${logPath}"
 
 if [ "$1" = "clone" ]; then
+  mkdir -p "$3/.git"
   mkdir -p "$3/apps/cli/dist"
   printf '{"name":"cthutool","bin":{"chc":"apps/cli/bin/chc.mjs"}}\\n' > "$3/package.json"
   if [ "\${MOCK_GIT_CREATE_BUNDLE:-1}" = "1" ]; then
@@ -77,8 +78,46 @@ if [ "$1" = "clone" ]; then
   exit 0
 fi
 
-if [ "$1" = "-C" ] && [ "$3" = "rev-parse" ]; then
+if [ "$1" = "-C" ] && [ "$3" = "rev-parse" ] && [ "$4" = "--git-dir" ]; then
+  if [ -d "$2/.git" ]; then
+    printf '.git\n'
+    exit 0
+  fi
   exit 1
+fi
+
+if [ "$1" = "-C" ] && [ "$3" = "status" ]; then
+  if [ -n "\${MOCK_GIT_STATUS:-}" ]; then
+    printf '%s\n' "$MOCK_GIT_STATUS"
+  fi
+  exit 0
+fi
+
+if [ "$1" = "-C" ] && [ "$3" = "rev-parse" ] && [ "$4" = "--verify" ]; then
+  printf '%s\n' "\${MOCK_GIT_TARGET:-2222222222222222222222222222222222222222}"
+  exit 0
+fi
+
+if [ "$1" = "-C" ] && [ "$3" = "cat-file" ]; then
+  if [ "\${MOCK_GIT_TARGET_BUNDLE:-1}" = "1" ]; then
+    exit 0
+  fi
+  exit 1
+fi
+
+if [ "$1" = "ls-remote" ]; then
+  if [ "\${MOCK_GIT_TARGET_KIND:-branch}" = "branch" ]; then
+    printf '%s\trefs/heads/%s\n' "\${MOCK_GIT_TARGET:-2222222222222222222222222222222222222222}" "\${!#}"
+    exit 0
+  fi
+  exit 2
+fi
+
+if [ "$1" = "-C" ] && [ "$3" = "merge-base" ]; then
+  if [ "\${MOCK_GIT_DIVERGED:-0}" = "1" ]; then
+    exit 1
+  fi
+  exit 0
 fi
 
 exit 0
@@ -104,6 +143,21 @@ exit 0
       }
     },
     cleanup: () => rmSync(dir, { recursive: true, force: true }),
+    prepareManagedCheckout: () => {
+      const installDir = env.CHC_INSTALL_DIR;
+      mkdirSync(join(installDir, ".git"), { recursive: true });
+      mkdirSync(join(installDir, "apps", "cli", "dist"), {
+        recursive: true,
+      });
+      writeFileSync(
+        join(installDir, "package.json"),
+        '{"name":"cthutool","bin":{"chc":"apps/cli/bin/chc.mjs"}}\n',
+      );
+      writeFileSync(
+        join(installDir, "apps", "cli", "dist", "index.js"),
+        'console.log("existing bundle");\n',
+      );
+    },
   };
 }
 
@@ -201,6 +255,88 @@ describe("install-chc.sh", () => {
       );
     } finally {
       remoteFixture.cleanup();
+    }
+  });
+
+  it("updates an existing managed checkout to the resolved commit", () => {
+    const fixture = createFixture();
+    const target = "3333333333333333333333333333333333333333";
+    try {
+      fixture.prepareManagedCheckout();
+      const result = runInstaller({
+        env: {
+          ...fixture.env,
+          CHC_INSTALL_MODE: "remote",
+          MOCK_GIT_TARGET: target,
+        },
+      });
+
+      expect(result.status).toBe(0);
+      const log = fixture.readLog();
+      const status = `git\t-C\t${fixture.env.CHC_INSTALL_DIR}\tstatus`;
+      const setUrl = `git\t-C\t${fixture.env.CHC_INSTALL_DIR}\tremote\tset-url`;
+      expect(log).toContain(status);
+      expect(log).toContain(
+        `git\t-C\t${fixture.env.CHC_INSTALL_DIR}\tmerge\t--ff-only\t${target}`,
+      );
+      expect(log).not.toContain("\tpull\t");
+      expect(log.indexOf(status)).toBeLessThan(log.indexOf(setUrl));
+      expect(log).toContain(
+        `npm\tinstall\t-g\t--ignore-scripts\t${fixture.env.CHC_INSTALL_DIR}`,
+      );
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  it("blocks dirty and diverged managed checkouts before mutation", () => {
+    for (const state of ["dirty", "diverged"] as const) {
+      const fixture = createFixture();
+      try {
+        fixture.prepareManagedCheckout();
+        const result = runInstaller({
+          env: {
+            ...fixture.env,
+            CHC_INSTALL_MODE: "remote",
+            ...(state === "dirty"
+              ? { MOCK_GIT_STATUS: "?? local-change" }
+              : { MOCK_GIT_DIVERGED: "1" }),
+          },
+        });
+
+        expect(result.status).not.toBe(0);
+        expect(result.stderr).toContain("Update blocked");
+        const log = fixture.readLog();
+        expect(log).not.toContain("\tremote\tset-url\t");
+        expect(log).not.toContain("\tcheckout\t");
+        expect(log).not.toContain("npm\tinstall");
+        expect(log).not.toMatch(/\t(reset|rebase|stash|clean)\t/);
+      } finally {
+        fixture.cleanup();
+      }
+    }
+  });
+
+  it("blocks an invalid managed target bundle before checkout mutation", () => {
+    const fixture = createFixture();
+    try {
+      fixture.prepareManagedCheckout();
+      const result = runInstaller({
+        env: {
+          ...fixture.env,
+          CHC_INSTALL_MODE: "remote",
+          MOCK_GIT_TARGET_BUNDLE: "0",
+        },
+      });
+
+      expect(result.status).not.toBe(0);
+      expect(result.stderr).toContain("Missing committed CLI bundle in target");
+      const log = fixture.readLog();
+      expect(log).not.toContain("\tremote\tset-url\t");
+      expect(log).not.toContain("\tcheckout\t");
+      expect(log).not.toContain("npm\tinstall");
+    } finally {
+      fixture.cleanup();
     }
   });
 


### PR DESCRIPTION
## What changed

- resolve `chc status`, `chc update --check`, and `chc update` from the checkout that provides the running CLI
- block implicit self-update for local-linked development installs without touching the local or managed checkout
- preserve managed checkout origin and branch/tag/commit identity, validate the target bundle, and apply the exact planned commit
- redact authenticated repository credentials from update output and diagnostics
- align the remote installer with dirty/diverged checkout and exact-target safety
- update lifecycle documentation, synchronize the main OpenSpec capabilities, and archive `apps-cli-align-update-source-lifecycle`

## Why

The updater previously defaulted independently to `~/.cthutool/source/CthuTool`, the official repository, and `main`. A globally linked local checkout could therefore update and relink an unrelated managed checkout, while forks and pinned refs were not preserved.

## Impact

Local-linked users now receive actionable manual-update guidance. Default managed installs continue to self-update, but follow their actual source and apply the exact validated target. Explicit source overrides remain supported and relink the global command when applied.

## Validation

- 60 focused CLI unit and integration tests
- 10 installer contract tests
- CLI TypeScript typecheck
- targeted Biome checks
- CLI bundle build and freshness check
- `git diff --check`
- OpenSpec validation: 47 specs passed