### PR TITLE
feat(codex): add batch Notion channel workflow

### DIFF
--- a/apps/docs/src/content/docs/modules/codex-plugin.md
+++ b/apps/docs/src/content/docs/modules/codex-plugin.md
@@ -107,9 +107,34 @@ The `Sentence` field uses Anki cloze syntax with a short synonym or paraphrase h
 
 ## Notion Channel Library
 
-Use `$notion-add-channel` to add a YouTube or Bilibili channel to the personal Notion Channel Library. The explicit-only skill checks for duplicates, resolves an existing category, selects the platform-specific template, verifies the created entry, and returns its Notion URL.
+Use `$notion-add-channel` to add one or more YouTube or Bilibili channels to the personal Notion Channel Library. The explicit-only skill validates current tags, checks for input and database duplicates, selects each platform-specific template, verifies created entries, and returns per-channel Notion URLs.
+
+An exact tag supplied by the user is used without inspecting the channel description or recent content and without a second confirmation. The skill still reads the minimum channel metadata required for its name and duplicate identity.
+
+Apply the same tags to a batch with a standalone `tags:` line:
+
+```text
+$notion-add-channel
+tags: Technology, AI
+
+https://www.youtube.com/@channel-a
+https://space.bilibili.com/123456
+```
+
+Put `tags:` on a channel line to replace the batch default for that item:
+
+```text
+$notion-add-channel
+tags: Technology
+
+https://www.youtube.com/@channel-a | tags: AI
+https://space.bilibili.com/123456 | tags: Japanese, Education
+https://www.youtube.com/@channel-c
+```
+
+Only channels without effective user-supplied tags require content inspection and inferred-tag confirmation. In a mixed batch, the skill consolidates those decisions before it creates any new entries.
 
 ## Authoritative Sources
 
 - Plugin README: `codex/plugins/cthu-codex/README.md`
-- Requirements: `openspec/specs/codex-plugins-cthu-codex-anki-mcp/spec.md`, `openspec/specs/codex-plugins-cthu-codex-language-coach/spec.md`, `openspec/specs/codex-plugins-cthu-codex-japanese-sentence-skill/spec.md`, `openspec/specs/codex-plugins-cthu-codex-japanese-vocabulary-skill/spec.md`, `openspec/specs/codex-plugins-cthu-codex-english-expression-skill/spec.md`
+- Requirements: `openspec/specs/codex-plugins-cthu-codex-anki-mcp/spec.md`, `openspec/specs/codex-plugins-cthu-codex-language-coach/spec.md`, `openspec/specs/codex-plugins-cthu-codex-japanese-sentence-skill/spec.md`, `openspec/specs/codex-plugins-cthu-codex-japanese-vocabulary-skill/spec.md`, `openspec/specs/codex-plugins-cthu-codex-english-expression-skill/spec.md`, `openspec/specs/codex-plugins-cthu-codex-notion-channel-skill/spec.md`

--- a/codex/plugins/cthu-codex/.codex-plugin/plugin.json
+++ b/codex/plugins/cthu-codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cthu-codex",
-  "version": "0.1.5+codex.20260715115305",
+  "version": "0.1.5+codex.20260716064835",
   "description": "Provides a personal Codex toolkit for CthuTool workflows and reusable assistant utilities.",
   "author": {
     "name": "mickmetalholic"

--- a/codex/plugins/cthu-codex/skills/notion-add-channel/SKILL.md
+++ b/codex/plugins/cthu-codex/skills/notion-add-channel/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: notion-add-channel
-description: Add a YouTube or Bilibili channel to the personal Notion Channel Library after checking for duplicates, resolving an existing category, selecting the platform template, and returning the entry URL. Use only when the user explicitly invokes `$notion-add-channel`.
+description: Add one or more YouTube or Bilibili channels to the personal Notion Channel Library with live tag validation, duplicate prevention, platform templates, and per-channel results. Use only when the user explicitly invokes `$notion-add-channel`.
 ---
 
 # Notion · Add Channel
 
-Add one YouTube or Bilibili channel to the configured Notion database. Treat the database as live state: fetch its schema, category options, and templates on every run instead of relying on cached IDs.
+Add one or more YouTube or Bilibili channels to the configured Notion database. Treat one invocation as one batch and the database as live state. Fetch its schema, tag options, and templates once per invocation instead of relying on cached IDs.
 
 ## Constants
 
@@ -13,48 +13,130 @@ Add one YouTube or Bilibili channel to the configured Notion database. Treat the
 - Required properties: `Name`, `Link`, `Source`, `Tags`
 - Supported `Source` values: `YouTube`, `Bilibili`
 
+## Input Forms
+
+Keep the single-channel form compatible:
+
+```text
+$notion-add-channel https://www.youtube.com/@example tags: Technology
+```
+
+For a batch, a standalone `tags:` line is the default for every channel without an item-specific override:
+
+```text
+$notion-add-channel
+tags: Technology, AI
+
+https://www.youtube.com/@channel-a
+https://space.bilibili.com/123456
+```
+
+Associate an override with one channel by putting it on the same line. The override replaces the batch default; it does not merge with it:
+
+```text
+$notion-add-channel
+tags: Technology
+
+https://www.youtube.com/@channel-a | tags: AI
+https://space.bilibili.com/123456 | tags: Japanese, Education
+https://www.youtube.com/@channel-c
+```
+
+Treat tags as comma-separated values only when that interpretation is unambiguous. If a natural-language invocation leaves a URL-to-tag association ambiguous, ask the user to restate it in one of the canonical forms before reading or writing Notion.
+
 ## Workflow
 
-1. Parse the explicit invocation for a channel URL and an optional category.
-2. If the channel URL is missing, ask for it and stop without reading or writing Notion.
-3. Fetch the configured database through the Notion connector. Extract the current data-source ID, property schema, `Tags` options, and template IDs. Stop with a clear connection error if the Notion connector is unavailable.
-4. Confirm that the required properties exist and that the platform has a matching `Source` option.
-5. Identify and inspect the channel:
-   - Accept YouTube channel URLs using `/channel/`, `/@handle`, `/c/`, or `/user/`.
-   - Accept Bilibili channel URLs using `space.bilibili.com/<uid>`.
-   - Reject video, playlist, search, and unsupported-site URLs; ask for the channel homepage URL.
-   - Normalize the URL to HTTPS, remove query strings, fragments, and trailing slashes, and preserve the channel identifier or handle.
-   - Read the channel page or current web metadata to determine its display name, canonical identity when available, description, and representative recent content.
-6. Check for an existing entry before creating anything:
-   - Query the fetched data source with parameterized SQL.
-   - Compare normalized `Link` values first.
-   - Also compare the canonical YouTube channel ID or handle, or the numeric Bilibili UID, when available.
-   - Treat a same-name entry as a candidate only; verify its link or platform identity before declaring it a duplicate.
-   - If a duplicate exists, do not create or update anything. Return the existing Notion page URL.
-7. Resolve the category from the data source's current `Tags` options:
-   - If the user supplied a category, require an exact existing option. For a close or invalid value, show the nearest existing options and ask the user to choose; do not create yet.
-   - If the user omitted the category, infer the strongest existing option from the channel description and representative recent content. Present the proposed category with a short reason and ask for explicit confirmation before creating.
-   - If no category is sufficiently supported, present the most plausible two or three existing options, or the full option list when necessary, and ask the user to choose.
-   - Treat a category supplied in the original invocation or explicitly confirmed in a follow-up as authorization for that category only.
-8. Select the correct template dynamically:
-   - Fetch every current database template page.
-   - Select the template whose default `Source` property exactly equals the detected platform.
-   - Prefer the matching platform icon only as a secondary check.
-   - If no template matches, or more than one matching template remains ambiguous, stop and ask the user instead of creating a blank page or guessing.
-9. Create the database page with the selected `template_id` and no explicit page content. Set:
-   - `Name` to the channel display name.
-   - `Link` to the normalized channel URL.
-   - `Source` to the detected platform.
-   - `Tags` to a JSON array containing the confirmed category value or values.
-10. Fetch the created page after template application. Verify its name, link, source, tags, and platform template icon. Retry the fetch briefly if template application is still pending; never apply a second template to compensate for normal asynchronous delay.
-11. Report the channel name, source, confirmed category, and clickable Notion entry URL. If verification is incomplete, say exactly which field or template signal could not be verified.
+### 1. Parse the batch
+
+1. Parse every channel URL, the optional batch-level default tags, and any per-channel tag overrides.
+2. Resolve each channel's effective tags: use its override when present; otherwise use the batch default. An override replaces the default completely.
+3. If no channel URL is present, ask for one or more URLs and stop without reading or writing Notion.
+
+### 2. Load live Notion state once
+
+1. Fetch the configured database through the Notion connector once for this invocation. Stop with a clear connection error if the connector is unavailable.
+2. Extract and reuse the current data-source ID, property schema, `Tags` options, and template IDs for the whole batch.
+3. Confirm that `Name`, `Link`, `Source`, and `Tags` exist and that the supported platform values exist in `Source`.
+4. Fetch every current database template page once. Map a template to a platform only when its default `Source` exactly matches that platform; use the platform icon only as a secondary check.
+
+### 3. Validate URLs and explicit tags
+
+For every input item:
+
+- Accept YouTube channel URLs using `/channel/`, `/@handle`, `/c/`, or `/user/`.
+- Accept Bilibili channel URLs using `space.bilibili.com/<uid>`.
+- Reject video, playlist, search, and unsupported-site URLs when the channel homepage cannot be resolved reliably.
+- Normalize accepted URLs to HTTPS, remove query strings, fragments, and trailing slashes, and preserve the channel identifier or handle.
+- Require every effective user-supplied tag to exactly match a current `Tags` option.
+
+Collect all invalid URLs and invalid tags into one response. For invalid tags, show the nearest current options but do not inspect channel content to reinterpret the user's choice. Do not create any new batch entry while an invalid value remains unresolved.
+
+### 4. Resolve minimal channel identities
+
+Read only the current metadata required to determine each valid channel's display name, source, and canonical identity when available:
+
+- YouTube channel ID or handle.
+- Numeric Bilibili UID.
+
+When effective user-supplied tags are valid, do not read the channel description or representative recent content and do not request a second tag confirmation. The supplied tags authorize only those exact values. Minimal identity lookup remains required for `Name` and duplicate prevention.
+
+### 5. Remove duplicates before content inspection
+
+1. Compare normalized links and canonical platform identities across the input batch. Process the first occurrence at most once and mark later occurrences as `repeated in input`.
+2. Query the fetched Notion data source for the remaining identities with parameterized, set-based SQL where supported.
+3. Compare normalized `Link` values first, then canonical YouTube identities or numeric Bilibili UIDs when available.
+4. Treat a same-name entry as a candidate only; verify its link or platform identity before declaring it a duplicate.
+5. Mark a database match as `already present`, do not create or edit it, and retain its Notion page URL. Resolved duplicates do not block other new entries.
+
+### 6. Resolve only missing tags
+
+For each new, non-duplicate channel without effective tags:
+
+1. Read its description and representative recent content.
+2. Infer the strongest current `Tags` option and record a short reason.
+3. If no option is sufficiently supported, record the most plausible two or three current options, or the full option list when necessary.
+
+Present all inferred and ambiguous tag decisions in one consolidated response and wait for explicit confirmation or selection. Do not ask the user to reconfirm tags they supplied. Do not invent a tag or add a new `Tags` option.
+
+### 7. Complete a read-only preflight
+
+Before creating anything, require every new entry to have:
+
+- a supported normalized URL and resolved platform;
+- a display name and sufficient identity for the existing duplicate safeguards;
+- exact user-supplied tags or explicitly confirmed inferred tags; and
+- exactly one template whose default `Source` matches its platform.
+
+If any new item remains invalid, unconfirmed, or has a missing or ambiguous template, consolidate the issues and stop without creating any new batch entry. Do not fall back to a blank page or guess a template.
+
+### 8. Create the ready entries
+
+Create all ready entries through one Notion multi-page creation operation when supported, using the discovered data-source ID as the common parent. For every page:
+
+- Set `template_id` to that item's platform template and provide no explicit page content.
+- Set `Name` to the channel display name.
+- Set `Link` to the normalized channel URL.
+- Set `Source` to the detected platform.
+- Set `Tags` to a JSON array containing its authorized tag values.
+
+If an exposed connector limit requires splitting a large batch, preserve the original item-to-result mapping and apply the same completed preflight to every chunk.
+
+### 9. Verify and report per channel
+
+1. Fetch every created page after template application. Verify its name, link, source, tags, and platform template icon.
+2. Retry the fetch briefly if template application is pending; never apply a second template to compensate for normal asynchronous delay.
+3. If creation is uncertain or partially fails, verify every returned or discoverable page and query the Channel Library again before retrying any uncertain item.
+4. Never roll back successful pages or blindly retry the whole batch.
+5. Report every input item as `created`, `already present`, `repeated in input`, or `failed`. Include a clickable Notion URL for every created or existing entry and identify any field or template signal that could not be verified.
 
 ## Safety Rules
 
-- Never create an entry without a channel URL.
+- Never create an entry without a supported channel URL.
 - Never create an entry from a video URL when the channel homepage cannot be resolved reliably.
-- Never create a duplicate or silently edit an existing entry.
-- Never invent a category or add a new `Tags` option.
-- Never infer a missing category and write it without explicit user confirmation.
+- Never create a duplicate, silently edit an existing entry, or blindly retry an uncertain batch.
+- Never invent a tag or add a new `Tags` option.
+- Never inspect channel content to infer or reconfirm tags when valid effective tags were supplied by the user.
+- Never infer missing tags and write them without explicit user confirmation.
+- Never write part of a batch while a new item still has an unresolved preflight issue.
 - Never hard-code the data-source ID or template IDs; discover them from the database each run.
 - Never fall back to a blank page when the platform template cannot be identified.

--- a/codex/plugins/cthu-codex/skills/notion-add-channel/agents/openai.yaml
+++ b/codex/plugins/cthu-codex/skills/notion-add-channel/agents/openai.yaml
@@ -1,6 +1,6 @@
 interface:
   display_name: "Notion · Add Channel"
   short_description: "Add YouTube or Bilibili channels to Notion."
-  default_prompt: "Use $notion-add-channel to add this channel URL to my Notion Channel Library with an optional category."
+  default_prompt: "Use $notion-add-channel to add one or more channel URLs to my Notion Channel Library with optional shared or per-channel tags."
 policy:
   allow_implicit_invocation: false

--- a/openspec/changes/improve-notion-channel-batch-add/.openspec.yaml
+++ b/openspec/changes/improve-notion-channel-batch-add/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-16

--- a/openspec/changes/improve-notion-channel-batch-add/design.md
+++ b/openspec/changes/improve-notion-channel-batch-add/design.md
@@ -1,0 +1,76 @@
+## Context
+
+`notion-add-channel` is an instruction-only, explicit-invocation skill that coordinates the Notion connector with public YouTube or Bilibili metadata. The current workflow accepts one channel and combines two different concerns in one mandatory inspection step: resolving the channel's display identity and examining its content to infer a category. Consequently, even a user-provided exact tag still causes content inspection.
+
+The Notion connector can discover the live data source and templates, query stored rows, and create multiple pages under one data source while assigning a template per page. Template application remains asynchronous, and a multi-page create operation is not guaranteed to provide transaction semantics. The design must therefore optimize the read path while preserving duplicate protection, explicit authorization for inferred tags, and per-entry verification.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Preserve the existing single-channel invocation while accepting batches of mixed YouTube and Bilibili channels.
+- Skip channel description and recent-content inspection whenever effective tags were supplied by the user and match current Notion options.
+- Fetch live Notion schema, tag options, and templates once per invocation and reuse them across the batch.
+- Detect duplicate identities within the input and against the database before content inference or creation.
+- Resolve all user decisions in one preflight phase, then create and verify ready entries with per-channel results.
+
+**Non-Goals:**
+
+- Add new Notion tag options, templates, databases, or MCP tools.
+- Make multi-page Notion creation transactional or automatically roll back successful entries after a partial runtime failure.
+- Infer tags without explicit confirmation or change an existing duplicate entry.
+- Add support for platforms other than YouTube and Bilibili.
+- Change the skill's explicit-only invocation policy.
+
+## Decisions
+
+### Split identity lookup from content inspection
+
+Every accepted URL still receives a minimal identity lookup for `Name`, normalized `Link`, `Source`, and a canonical YouTube channel identity or Bilibili UID when available. Description and representative recent content are fetched only when the effective tag list is missing and category inference is required.
+
+This preserves reliable naming and duplicate detection without treating content analysis as mandatory. Completely skipping channel access for tagged entries was rejected because the database still needs a display name and platform identity.
+
+### Use a shared-default and per-channel-override input model
+
+The invocation may contain a batch-level `tags:` value that applies to every URL without item-specific tags. An item-specific tag list replaces, rather than merges with, the shared default for that channel. A URL with neither source receives the existing inference flow. One URL with an optional tag remains valid for backward compatibility.
+
+Replacement semantics are preferred over implicit merging because the user can see the complete effective tag list for each channel and avoid accidentally inheriting an unwanted batch tag.
+
+### Treat tag validation as authorization and perform it before content analysis
+
+Fetch the live `Tags` options once and require every user-supplied value to match an existing option exactly. Collect invalid values and nearby valid options into one response; do not inspect content to reinterpret an invalid explicit value. Once the effective tag list is valid, it authorizes those tags without a second confirmation.
+
+For new, non-duplicate channels still lacking tags, inspect content and present all inferred or ambiguous tag decisions together. Tagged channels may appear as ready context, but their tags are not included in the confirmation request.
+
+### Use a two-phase batch workflow
+
+The read-only preflight phase normalizes inputs, resolves minimal identities, removes repeated input identities, checks database duplicates, validates effective tags, resolves platform templates, and collects missing-tag decisions. Existing database duplicates and repeated input entries are terminal per-item outcomes rather than blocking errors.
+
+No new page is created while any new entry has an invalid URL, invalid tag, unresolved tag, or ambiguous template. After all new entries are ready, create them through the connector's multi-page operation with the appropriate platform template on each page. This favors predictable user-visible behavior over best-effort writes during validation.
+
+### Preserve per-item state across creation and verification
+
+Maintain the input-to-result mapping throughout the workflow so mixed-platform batches can use different templates and report each channel as created, already present, repeated in input, or failed. Fetch each created page after template application to verify its properties and platform template signal. If a runtime create result is uncertain, query the database again before retrying so a retry cannot silently introduce duplicates.
+
+Using only one aggregate success message was rejected because asynchronous templates and non-transactional failures require item-level evidence.
+
+## Risks / Trade-offs
+
+- [A single invalid new item delays otherwise ready entries] → Present all preflight issues together and require an explicit request before ever adopting partial-write behavior.
+- [Large batches can encounter connector limits or rate limiting] → Use the connector's multi-page operation where supported, preserve stable item mapping, and split execution only when an exposed connector constraint requires it.
+- [A multi-page operation can partially succeed] → Verify every returned or discoverable page, report per-item outcomes, and re-query before retrying uncertain items.
+- [Minimal metadata cannot resolve a canonical identity] → Fall back to normalized-link comparison and treat same-name matches as candidates requiring clarification, preserving current safety behavior.
+- [Input syntax could become ambiguous] → Document a canonical shared `tags:` form and a canonical per-channel override form while retaining natural-language parsing only when the association is unambiguous.
+
+## Migration Plan
+
+1. Update the skill instructions and prompt metadata while preserving the `$notion-add-channel` name and explicit-only policy.
+2. Update the user documentation, main capability spec through this delta, and plugin cachebuster.
+3. Validate the OpenSpec change, skill metadata, plugin manifest, relevant documentation, and repository diff.
+4. Merge the worktree change, reinstall `cthu-codex@personal`, and test single-channel, fully tagged batch, mixed-tag batch, duplicate, and partial-runtime-failure scenarios in a fresh Codex task.
+
+Rollback by reverting the skill, documentation, spec, and cachebuster changes, then reinstalling the previous plugin version. Already-created Notion pages remain unchanged.
+
+## Open Questions
+
+None. The default behavior is full preflight before writes, shared tags with per-item replacement overrides, and one consolidated confirmation for only the entries that require inferred tags.

--- a/openspec/changes/improve-notion-channel-batch-add/proposal.md
+++ b/openspec/changes/improve-notion-channel-batch-add/proposal.md
@@ -1,0 +1,29 @@
+## Why
+
+The Notion channel skill still inspects channel descriptions and recent content even when the user has already supplied an exact tag, adding unnecessary work and latency. It also accepts only one channel per invocation, making larger Channel Library updates repetitive and inconsistent to review.
+
+## What Changes
+
+- Separate minimal channel identity lookup from content inspection so an exact user-supplied existing tag skips category inference and any second confirmation.
+- Extend `$notion-add-channel` to accept one or more YouTube or Bilibili channel URLs in the same invocation.
+- Support batch-level default tags with optional per-channel overrides, while continuing to use only current Notion `Tags` options.
+- Load the live Notion schema and templates once per invocation, detect duplicates both within the input batch and in the database, and inspect content only for non-duplicate channels that still lack tags.
+- Consolidate unresolved or inferred tag decisions before writing, preflight the batch, create the ready entries together, and report verification results per channel.
+- Preserve the existing explicit-only invocation policy and single-channel compatibility.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `codex-plugins-cthu-codex-notion-channel-skill`: Add the explicit-tag fast path and define multi-channel parsing, validation, duplicate prevention, confirmation, creation, and reporting behavior.
+
+## Impact
+
+- Affected plugin source: `codex/plugins/cthu-codex/skills/notion-add-channel/` and the CthuCodex plugin cachebuster metadata.
+- Affected documentation: `apps/docs/src/content/docs/modules/codex-plugin.md`.
+- Affected specification: `openspec/specs/codex-plugins-cthu-codex-notion-channel-skill/spec.md` through this change's delta spec.
+- External systems remain the Notion connector plus YouTube and Bilibili metadata; no new runtime dependency or MCP server is introduced.

--- a/openspec/changes/improve-notion-channel-batch-add/specs/codex-plugins-cthu-codex-notion-channel-skill/spec.md
+++ b/openspec/changes/improve-notion-channel-batch-add/specs/codex-plugins-cthu-codex-notion-channel-skill/spec.md
@@ -1,0 +1,113 @@
+## MODIFIED Requirements
+
+### Requirement: Channel input and platform resolution
+The skill SHALL require at least one supported channel homepage URL, SHALL accept one or more channels in one invocation, and SHALL derive a normalized channel identity for each channel before modifying the Channel Library.
+
+#### Scenario: Channel URL is missing
+- **WHEN** the user invokes the skill without any channel URL
+- **THEN** the skill asks for one or more channel URLs
+- **AND** it does not read or write the Notion database
+
+#### Scenario: One supported channel URL is provided
+- **WHEN** the user provides one YouTube channel URL or one Bilibili `space.bilibili.com/<uid>` URL
+- **THEN** the skill preserves the existing single-channel workflow
+- **AND** it accepts an optional tag list for that channel
+
+#### Scenario: Multiple supported channel URLs are provided
+- **WHEN** the user provides multiple supported YouTube or Bilibili channel URLs
+- **THEN** the skill treats them as one batch
+- **AND** it accepts batch-level default tags and optional per-channel tag overrides
+- **AND** a per-channel tag list replaces the batch-level default for that channel
+
+#### Scenario: Supported channel URLs are resolved
+- **WHEN** one or more supported channel URLs are provided
+- **THEN** the skill normalizes each URL to HTTPS without query, fragment, or trailing slash
+- **AND** it resolves each source as `YouTube` or `Bilibili`
+- **AND** it reads the minimum current channel metadata needed to determine the display name and canonical identity when available
+
+#### Scenario: Unsupported content URL is provided
+- **WHEN** any provided URL identifies a video, playlist, search result, or unsupported site and the channel homepage cannot be resolved reliably
+- **THEN** the skill identifies the invalid batch item and asks for its channel homepage URL
+- **AND** it does not create any new entry from the batch while that item remains unresolved
+
+### Requirement: Live database discovery and duplicate prevention
+The skill SHALL fetch the configured Channel Library schema, category options, and templates once per invocation and SHALL NOT create a duplicate channel entry within the input batch or the database.
+
+#### Scenario: Database state is loaded for a batch
+- **WHEN** at least one supported channel URL is available
+- **THEN** the skill fetches the configured database URL through the Notion connector once for the invocation
+- **AND** it discovers and reuses the current data-source ID, required properties, category options, and templates for the batch
+- **AND** it does not rely on hard-coded data-source or template IDs
+
+#### Scenario: Channel is repeated within the input batch
+- **WHEN** multiple input items resolve to the same normalized URL or canonical platform identity
+- **THEN** the skill processes that identity at most once
+- **AND** it reports the remaining occurrences as repeated input items
+
+#### Scenario: Existing channel is found
+- **WHEN** a stored entry matches an input item's normalized URL or canonical platform identity
+- **THEN** the skill does not create or update that entry
+- **AND** it returns the existing Notion page URL for that item
+- **AND** the resolved duplicate does not block other valid new items from completing preflight
+
+#### Scenario: Same display name has a different identity
+- **WHEN** an entry has the same display name but a different or unverifiable platform identity
+- **THEN** the skill does not treat the name alone as proof of a duplicate
+- **AND** it verifies the link or asks for clarification before creating any affected new entry
+
+### Requirement: Existing category resolution
+The skill SHALL use only tag values currently defined by the Channel Library, SHALL skip content-based category inference for channels with valid user-supplied tags, and SHALL require explicit confirmation before writing inferred tags.
+
+#### Scenario: Valid tags are supplied
+- **WHEN** a new channel receives one or more exact existing tag values from its per-channel override or the batch-level default
+- **THEN** the skill uses those tags without requesting a second confirmation
+- **AND** it does not read the channel description or representative recent content for category inference
+- **AND** it still reads the minimum channel identity metadata required for naming and duplicate detection
+
+#### Scenario: Invalid tags are supplied
+- **WHEN** any user-supplied tag is not an exact current `Tags` option
+- **THEN** the skill collects the invalid values and nearest existing options into one response
+- **AND** it waits for the user to choose valid values
+- **AND** it does not inspect channel content to reinterpret the invalid values
+- **AND** it does not create new batch entries while the values remain unresolved
+
+#### Scenario: Tags are missing for part of a batch
+- **WHEN** one or more new, non-duplicate channels have no effective user-supplied tags
+- **THEN** the skill reads descriptions and representative recent content only for those channels
+- **AND** it proposes the strongest existing option for each sufficiently supported channel with a short reason
+- **AND** it presents the inferred tag decisions in one consolidated confirmation
+- **AND** it waits for explicit user confirmation before creating the new entries
+
+#### Scenario: Tags cannot be inferred reliably
+- **WHEN** no existing tag is sufficiently supported for one or more untagged channels
+- **THEN** the skill presents plausible existing options or the full current option list for each affected channel
+- **AND** it waits for the user to choose
+- **AND** it does not invent or add a tag
+
+### Requirement: Platform-template creation and verification
+The skill SHALL preflight all new batch entries, create each ready non-duplicate channel with the template whose default source matches its platform, and return a per-channel result.
+
+#### Scenario: Batch preflight succeeds
+- **WHEN** every new batch item has a supported normalized identity, valid or confirmed tags, and exactly one matching platform template
+- **THEN** the skill creates the ready pages through a multi-page connector operation when supported
+- **AND** it sets each page's `Name`, normalized `Link`, `Source`, `Tags`, and platform-specific `template_id`
+- **AND** it provides no explicit page content when applying a template
+
+#### Scenario: Batch preflight has an unresolved item
+- **WHEN** any new batch item has an invalid URL, invalid or unconfirmed tags, or a missing or ambiguous platform template
+- **THEN** the skill consolidates the unresolved items for the user
+- **AND** it does not create any new batch entry until the preflight issues are resolved
+
+#### Scenario: Batch entries are created
+- **WHEN** Notion returns one or more created pages
+- **THEN** the skill fetches each created page to verify its name, link, source, tags, and platform template signal
+- **AND** it retries verification briefly when template application is pending without applying a second template
+- **AND** it reports each input item as created, already present, repeated in the input, or failed
+- **AND** it returns a clickable Notion URL for every created or existing entry
+- **AND** it identifies every verification field or template signal that remains incomplete
+
+#### Scenario: Batch creation result is uncertain or partially fails
+- **WHEN** a multi-page creation operation has an uncertain or partial result
+- **THEN** the skill verifies all returned or discoverable entries individually
+- **AND** it queries the Channel Library again before retrying any uncertain item
+- **AND** it does not roll back or silently duplicate entries that were created successfully

--- a/openspec/changes/improve-notion-channel-batch-add/tasks.md
+++ b/openspec/changes/improve-notion-channel-batch-add/tasks.md
@@ -1,0 +1,31 @@
+## 1. Input and Tag Resolution
+
+- [x] 1.1 Update `notion-add-channel` to accept one or more channel URLs, a batch-level `tags:` default, and per-channel replacement overrides while preserving the existing single-channel form.
+- [x] 1.2 Split minimal channel identity lookup from category content inspection so valid explicit tags skip descriptions, recent content, and second confirmation.
+- [x] 1.3 Validate all supplied tags against the live Notion `Tags` options and consolidate invalid values and suggested existing options without reinterpreting them from channel content.
+
+## 2. Batch Preflight and Duplicate Handling
+
+- [x] 2.1 Fetch and reuse the live Channel Library data source, schema, tag options, and templates once per invocation.
+- [x] 2.2 Add input-batch identity deduplication and set-based database duplicate checks while preserving same-name identity safeguards and existing-entry links.
+- [x] 2.3 Inspect content only for new channels without effective tags, then consolidate inferred and ambiguous tag decisions into one confirmation step.
+- [x] 2.4 Block new writes until every new item passes URL, tag, identity, and platform-template preflight, while treating resolved duplicates as non-blocking item outcomes.
+
+## 3. Batch Creation and Reporting
+
+- [x] 3.1 Create ready entries through the Notion connector's multi-page operation with the correct per-item platform template and no explicit page content.
+- [x] 3.2 Verify every created page after asynchronous template application and re-query the database before retrying any uncertain or partially failed item.
+- [x] 3.3 Report each input item as created, already present, repeated in the input, or failed, including Notion links and incomplete verification details where applicable.
+
+## 4. Plugin Metadata and Documentation
+
+- [x] 4.1 Update the skill description and `agents/openai.yaml` prompt for single or batch input while preserving `policy.allow_implicit_invocation: false`.
+- [x] 4.2 Document canonical shared-tag and per-channel-override examples plus explicit-tag fast-path behavior in the Codex plugin module documentation.
+- [x] 4.3 Refresh the CthuCodex plugin cachebuster metadata so the updated skill can be reinstalled after merge.
+
+## 5. Verification
+
+- [x] 5.1 Validate the OpenSpec change and confirm the delta covers single-channel compatibility, fully tagged batches, mixed tagged and untagged batches, duplicate handling, preflight blocking, and partial creation outcomes.
+- [x] 5.2 Validate the modified skill and plugin metadata, including exact skill name-directory-prompt consistency and the explicit-only policy.
+- [x] 5.3 Run `git diff --check`, review the scoped diff, and confirm generated `.claude/`, `.codex/`, and `.cursor/` adapter files remain unchanged.
+- [ ] 5.4 After merge, reinstall `cthu-codex@personal` and exercise the documented single-channel and batch examples in a fresh Codex task.


### PR DESCRIPTION
## Summary

- extend `$notion-add-channel` from one channel to single or batch YouTube/Bilibili input
- support shared batch tags and per-channel replacement overrides
- skip channel content inspection and second confirmation when exact existing tags are supplied
- add batch preflight, input/database deduplication, multi-page creation, and per-channel verification results
- document the workflow and include the complete OpenSpec proposal, design, delta spec, and tasks
- refresh the CthuCodex plugin cachebuster for post-merge reinstall

## Why

The previous skill always inspected channel descriptions and recent content even when the user had already supplied an exact tag. It also required one invocation per channel. This change removes that unnecessary content-analysis path and makes larger Channel Library updates predictable and efficient.

## Impact

Single-channel invocations remain compatible. Batch writes now complete a read-only preflight before creating any entries, and only untagged channels require content-based tag inference and confirmation. The skill remains explicit-only and does not add new Notion tags, templates, databases, or dependencies.

## Validation

- `openspec validate improve-notion-channel-batch-add --type change --strict`
- skill-creator `quick_validate.py`
- plugin-creator `validate_plugin.py`
- `git diff --check origin/main...HEAD`
- confirmed generated `.claude/`, `.codex/`, and `.cursor/` adapter files are unchanged

## Post-merge

- reinstall `cthu-codex@personal`
- exercise the documented single-channel and batch examples in a fresh Codex task
